### PR TITLE
feat: cobra CLI framework with root, scan, and version commands

### DIFF
--- a/cmd/stringer/main.go
+++ b/cmd/stringer/main.go
@@ -9,12 +9,8 @@ import (
 var Version = "dev"
 
 func main() {
-	if len(os.Args) > 1 && os.Args[1] == "version" {
-		fmt.Printf("stringer %s\n", Version)
-		return
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
 	}
-
-	fmt.Fprintln(os.Stderr, "usage: stringer <command>")
-	fmt.Fprintln(os.Stderr, "  version    Print version information")
-	os.Exit(1)
 }

--- a/cmd/stringer/root.go
+++ b/cmd/stringer/root.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// Global flag values.
+var (
+	verbose bool
+	quiet   bool
+	noColor bool
+)
+
+// rootCmd is the base command for stringer.
+var rootCmd = &cobra.Command{
+	Use:   "stringer",
+	Short: "Mine your codebase for actionable work items",
+	Long: `Stringer is a codebase archaeology tool that mines existing repositories
+to produce Beads-formatted issues. It extracts actionable work items from
+signals already present in the repo — TODOs, FIXMEs, git history patterns,
+and more — giving agents instant situational awareness.`,
+	SilenceUsage:  true,
+	SilenceErrors: true,
+}
+
+func init() {
+	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "enable verbose output")
+	rootCmd.PersistentFlags().BoolVarP(&quiet, "quiet", "q", false, "suppress non-essential output")
+	rootCmd.PersistentFlags().BoolVar(&noColor, "no-color", false, "disable colored output")
+
+	rootCmd.AddCommand(scanCmd)
+	rootCmd.AddCommand(versionCmd)
+}

--- a/cmd/stringer/root_test.go
+++ b/cmd/stringer/root_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestRootHelp(t *testing.T) {
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"--help"})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("root --help failed: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "codebase archaeology tool") {
+		t.Errorf("root help missing description, got:\n%s", out)
+	}
+	if !strings.Contains(out, "scan") {
+		t.Errorf("root help missing scan subcommand, got:\n%s", out)
+	}
+	if !strings.Contains(out, "version") {
+		t.Errorf("root help missing version subcommand, got:\n%s", out)
+	}
+}
+
+func TestGlobalFlags(t *testing.T) {
+	tests := []struct {
+		name string
+		flag string
+	}{
+		{"verbose", "--verbose"},
+		{"quiet", "--quiet"},
+		{"no-color", "--no-color"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := rootCmd.PersistentFlags().Lookup(strings.TrimPrefix(tt.flag, "--"))
+			if f == nil {
+				t.Errorf("global flag %s not registered", tt.flag)
+			}
+		})
+	}
+
+	// Verify shorthand aliases.
+	v := rootCmd.PersistentFlags().ShorthandLookup("v")
+	if v == nil || v.Name != "verbose" {
+		t.Error("-v shorthand not registered for --verbose")
+	}
+	q := rootCmd.PersistentFlags().ShorthandLookup("q")
+	if q == nil || q.Name != "quiet" {
+		t.Error("-q shorthand not registered for --quiet")
+	}
+}
+
+func TestScanNotImplemented(t *testing.T) {
+	// Build the binary so we can test the actual command output.
+	binary := t.TempDir() + "/stringer-test"
+	build := exec.Command("go", "build", //nolint:gosec // test helper with fixed args
+		"-o", binary,
+		".",
+	)
+	build.Dir, _ = os.Getwd()
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("go build failed: %v\n%s", err, out)
+	}
+
+	cmd := exec.Command(binary, "scan") //nolint:gosec // test helper with fixed args
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("stringer scan failed: %v", err)
+	}
+
+	got := strings.TrimSpace(string(out))
+	if !strings.Contains(got, "not implemented yet") {
+		t.Errorf("stringer scan = %q, want 'not implemented yet'", got)
+	}
+}

--- a/cmd/stringer/scan.go
+++ b/cmd/stringer/scan.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// scanCmd is the subcommand for scanning a repository.
+var scanCmd = &cobra.Command{
+	Use:   "scan [path]",
+	Short: "Scan a repository for actionable work items",
+	Long: `Scan a repository for actionable work items such as TODOs, FIXMEs,
+git history patterns, and other signals. Outputs Beads-formatted JSONL
+suitable for import with 'bd import'.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(_ *cobra.Command, _ []string) error {
+		fmt.Println("stringer scan: not implemented yet")
+		return nil
+	},
+}

--- a/cmd/stringer/version.go
+++ b/cmd/stringer/version.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// versionCmd prints the stringer version.
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print version information",
+	Long:  "Print the version of the stringer binary.",
+	Args:  cobra.NoArgs,
+	Run: func(_ *cobra.Command, _ []string) {
+		fmt.Printf("stringer %s\n", Version)
+	},
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,10 @@
 module github.com/davetashner/stringer
 
 go 1.24
+
+require github.com/spf13/cobra v1.10.2
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.9 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
+github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
+github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
## Summary
- Add `github.com/spf13/cobra` dependency and refactor `cmd/stringer/main.go` to use cobra's command execution
- Create root command with project description ("Mine your codebase for actionable work items") and global flags: `--verbose`/`-v`, `--quiet`/`-q`, `--no-color`
- Add `scan` subcommand skeleton (prints "not implemented yet" — real implementation comes in CLI1)
- Add `version` subcommand preserving the existing `-ldflags -X main.Version=...` injection pattern
- Add tests for help output, global flag registration, shorthand aliases, and scan placeholder behavior

### File structure
- `cmd/stringer/main.go` — minimal entrypoint, calls `rootCmd.Execute()`
- `cmd/stringer/root.go` — root command definition + global flags
- `cmd/stringer/scan.go` — scan subcommand skeleton
- `cmd/stringer/version.go` — version subcommand
- `cmd/stringer/root_test.go` — tests for root help, flags, and scan output

### Beads issues
Closes stringer-pte.1 (cobra setup), stringer-pte.2 (subcommand skeletons), stringer-pte.3 (global flags), stringer-pte.5 (version subcommand)

## Test plan
- [x] go test -race ./cmd/stringer/ -- all 6 tests pass
- [x] golangci-lint run ./cmd/stringer/ -- 0 issues
- [x] go vet ./cmd/stringer/ -- clean
- [x] gofmt -l cmd/stringer/ -- no formatting issues
- [x] Manual testing: stringer, stringer --help, stringer version, stringer scan, stringer -v version
- [ ] CI pipeline passes

Generated with Claude Code