### PR TITLE
docs: add Homebrew install option to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,10 @@
 **Codebase archaeology for [Beads](https://github.com/steveyegge/beads).** Mine your repo for actionable work items, output them as Beads-formatted issues, and give your AI agents instant situational awareness.
 
 ```bash
-# Install
+# Install via Homebrew
+brew install davetashner/tap/stringer
+
+# Or install via Go
 go install github.com/davetashner/stringer/cmd/stringer@latest
 
 # Scan a repo and seed beads


### PR DESCRIPTION
## Summary
- Adds `brew install davetashner/tap/stringer` as the primary install method in the README quickstart

🤖 Generated with [Claude Code](https://claude.com/claude-code)