### PR TITLE
feat: add git depth/since limits and progress output

### DIFF
--- a/internal/collectors/patterns.go
+++ b/internal/collectors/patterns.go
@@ -103,6 +103,7 @@ func (c *PatternsCollector) Collect(ctx context.Context, repoPath string, opts s
 	}
 
 	var signals []signal.RawSignal
+	var fileCount int
 
 	// Track per-directory file counts for test-ratio analysis.
 	type dirStats struct {
@@ -211,6 +212,11 @@ func (c *PatternsCollector) Collect(ctx context.Context, repoPath string, opts s
 					})
 				}
 			}
+		}
+
+		fileCount++
+		if opts.ProgressFunc != nil && fileCount%500 == 0 {
+			opts.ProgressFunc(fmt.Sprintf("patterns: scanned %d files", fileCount))
 		}
 
 		return nil

--- a/internal/collectors/todos.go
+++ b/internal/collectors/todos.go
@@ -86,6 +86,7 @@ func (c *TodoCollector) Collect(ctx context.Context, repoPath string, opts signa
 	}
 
 	var signals []signal.RawSignal
+	var fileCount int
 
 	err = filepath.WalkDir(repoPath, func(path string, d os.DirEntry, walkErr error) error {
 		if walkErr != nil {
@@ -151,6 +152,12 @@ func (c *TodoCollector) Collect(ctx context.Context, repoPath string, opts signa
 		}
 
 		signals = append(signals, found...)
+
+		fileCount++
+		if opts.ProgressFunc != nil && fileCount%500 == 0 {
+			opts.ProgressFunc(fmt.Sprintf("todos: scanned %d files", fileCount))
+		}
+
 		return nil
 	})
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,6 +26,10 @@ type CollectorConfig struct {
 	// Patterns collector settings.
 	LargeFileThreshold int `yaml:"large_file_threshold,omitempty"`
 
+	// Git collector settings.
+	GitDepth int    `yaml:"git_depth,omitempty"`
+	GitSince string `yaml:"git_since,omitempty"`
+
 	// GitHub collector settings.
 	IncludePRs            *bool `yaml:"include_prs,omitempty"`
 	CommentDepth          int   `yaml:"comment_depth,omitempty"`

--- a/internal/config/merge.go
+++ b/internal/config/merge.go
@@ -44,6 +44,12 @@ func Merge(fileCfg *Config, cliCfg signal.ScanConfig) signal.ScanConfig {
 			if co.LargeFileThreshold == 0 && fc.LargeFileThreshold > 0 {
 				co.LargeFileThreshold = fc.LargeFileThreshold
 			}
+			if co.GitDepth == 0 && fc.GitDepth > 0 {
+				co.GitDepth = fc.GitDepth
+			}
+			if co.GitSince == "" && fc.GitSince != "" {
+				co.GitSince = fc.GitSince
+			}
 			result.CollectorOpts[name] = co
 		}
 	}

--- a/internal/config/merge_test.go
+++ b/internal/config/merge_test.go
@@ -178,3 +178,84 @@ func TestMerge_LargeFileThresholdCLIOverride(t *testing.T) {
 	// CLI value should win.
 	assert.Equal(t, 750, result.CollectorOpts["patterns"].LargeFileThreshold)
 }
+
+func TestMerge_GitDepthFromFile(t *testing.T) {
+	fileCfg := &Config{
+		Collectors: map[string]CollectorConfig{
+			"gitlog": {
+				GitDepth: 500,
+			},
+		},
+	}
+	cliCfg := signal.ScanConfig{}
+
+	result := Merge(fileCfg, cliCfg)
+	assert.Equal(t, 500, result.CollectorOpts["gitlog"].GitDepth)
+}
+
+func TestMerge_GitDepthCLIOverridesFile(t *testing.T) {
+	fileCfg := &Config{
+		Collectors: map[string]CollectorConfig{
+			"gitlog": {
+				GitDepth: 500,
+			},
+		},
+	}
+	cliCfg := signal.ScanConfig{
+		CollectorOpts: map[string]signal.CollectorOpts{
+			"gitlog": {GitDepth: 200},
+		},
+	}
+
+	result := Merge(fileCfg, cliCfg)
+	assert.Equal(t, 200, result.CollectorOpts["gitlog"].GitDepth)
+}
+
+func TestMerge_GitSinceFromFile(t *testing.T) {
+	fileCfg := &Config{
+		Collectors: map[string]CollectorConfig{
+			"gitlog": {
+				GitSince: "90d",
+			},
+		},
+	}
+	cliCfg := signal.ScanConfig{}
+
+	result := Merge(fileCfg, cliCfg)
+	assert.Equal(t, "90d", result.CollectorOpts["gitlog"].GitSince)
+}
+
+func TestMerge_GitSinceCLIOverridesFile(t *testing.T) {
+	fileCfg := &Config{
+		Collectors: map[string]CollectorConfig{
+			"gitlog": {
+				GitSince: "90d",
+			},
+		},
+	}
+	cliCfg := signal.ScanConfig{
+		CollectorOpts: map[string]signal.CollectorOpts{
+			"gitlog": {GitSince: "30d"},
+		},
+	}
+
+	result := Merge(fileCfg, cliCfg)
+	assert.Equal(t, "30d", result.CollectorOpts["gitlog"].GitSince)
+}
+
+func TestMerge_GitDepthAndSinceBothFromFile(t *testing.T) {
+	fileCfg := &Config{
+		Collectors: map[string]CollectorConfig{
+			"lotteryrisk": {
+				GitDepth: 300,
+				GitSince: "6m",
+			},
+		},
+	}
+	cliCfg := signal.ScanConfig{}
+
+	result := Merge(fileCfg, cliCfg)
+	opts := result.CollectorOpts["lotteryrisk"]
+	assert.Equal(t, 300, opts.GitDepth)
+	assert.Equal(t, "6m", opts.GitSince)
+}

--- a/internal/signal/signal.go
+++ b/internal/signal/signal.go
@@ -53,6 +53,15 @@ type CollectorOpts struct {
 	// GitRoot is the path to the .git directory root, which may differ
 	// from RepoPath when scanning a subdirectory.
 	GitRoot string
+
+	// GitDepth caps the number of commits walked. 0 uses default (1000).
+	GitDepth int
+
+	// GitSince limits commit walking to commits after this duration (e.g., "90d", "6m", "1y").
+	GitSince string
+
+	// ProgressFunc is called periodically with status messages during long operations.
+	ProgressFunc func(msg string)
 }
 
 // ScanConfig holds the overall configuration for a scan operation.


### PR DESCRIPTION
## Summary
- Add `--git-depth` and `--git-since` CLI flags to bound commit walking in gitlog and lotteryrisk collectors [stringer-ais]
- Add `ProgressFunc` callback on `CollectorOpts` for periodic progress output during long-running scans [stringer-6zs]
- Progress reports: every 100 commits (git walkers), every 50 files (blame), every 500 files (file walkers)
- All progress output uses `slog.Info`, automatically suppressed by `--quiet`
- New config file fields: `git_depth` and `git_since` in collector config

Example: `stringer scan . --git-depth 500 --git-since 90d` completes in bounded time on repos with 180k+ commits.

## Test plan
- [ ] `stringer scan . --git-depth 100` limits commit examination to 100
- [ ] `stringer scan . --git-since 90d` skips commits older than 90 days
- [ ] Progress output appears during long scans (visible with `--verbose`)
- [ ] `--quiet` suppresses progress output
- [ ] `parseDuration` correctly handles "90d", "6m", "1y", "2w"
- [ ] All existing tests pass with race detector

🤖 Generated with [Claude Code](https://claude.com/claude-code)