### PR TITLE
feat: resolved TODO detection [stringer-6kq.3]

### DIFF
--- a/cmd/stringer/scan.go
+++ b/cmd/stringer/scan.go
@@ -296,6 +296,13 @@ func runScan(cmd *cobra.Command, args []string) error {
 			if err := state.FormatDiff(diff, absPath, cmd.ErrOrStderr()); err != nil {
 				slog.Warn("failed to write diff summary", "error", err)
 			}
+
+			// Emit resolved TODOs as pre-closed signals.
+			resolvedTodos := state.BuildResolvedTodoSignals(absPath, diff.Removed)
+			if len(resolvedTodos) > 0 {
+				slog.Info("resolved TODOs detected", "count", len(resolvedTodos))
+				result.Signals = append(result.Signals, resolvedTodos...)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Add `BuildResolvedTodoSignals()` to `internal/state/state.go` that converts removed TODO signals into pre-closed `RawSignal`s
- Wire into the delta scan flow in `cmd/stringer/scan.go` — when a TODO disappears between scans, it's emitted as a closed bead
- Signals include `pre-closed`, `resolved`, `stringer-generated` tags, 0.3 confidence, and file-deleted annotation

## Test plan
- [x] `TestBuildResolvedTodoSignals_FiltersToTodosOnly` — only TODO-sourced signals are converted
- [x] `TestBuildResolvedTodoSignals_SignalFields` — all fields set correctly (tags, confidence, ClosedAt, etc.)
- [x] `TestBuildResolvedTodoSignals_FileDeleted` — annotation flows into description
- [x] `TestBuildResolvedTodoSignals_FileExists` — no false file-deleted annotation
- [x] `TestBuildResolvedTodoSignals_Empty` — empty/no-todos input returns nil
- [x] Full test suite passes with `go test -race ./...`
- [x] `golangci-lint run ./...` clean

Part of epic A5: Pre-closed Beads (`stringer-6kq`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)