### PR TITLE
feat: enhance tasks formatter with IDs, status, and enriched context

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ But most real work happens on **existing codebases**. When an agent boots up on 
 
 Stringer solves the cold-start problem. It mines signals already present in your repo and produces structured Beads issues that agents can immediately orient around.
 
+## Why Stringer?
+
+**Static analysis on your laptop, not your token budget.** Stringer runs locally — no API keys, no network calls, no per-request costs. It extracts signals that are already sitting in your codebase using deterministic static analysis.
+
+**Pre-process the easy stuff so agents start informed.** Without Stringer, an AI agent boots up on a new codebase and has to discover TODOs, stale branches, risky bus-factor modules, and open GitHub issues on its own — burning inference tokens on mechanical work. Stringer does that extraction up front on local CPU, so agents begin with structured context instead of a blank slate.
+
+**LLM-optional by design.** Core scanning needs zero API keys. The planned LLM pass (signal clustering, dependency inference) adds intelligence on top but is never required. You control where the money goes.
+
 ## What It Does Today
 
 ### Collectors
@@ -84,12 +92,12 @@ Stringer solves the cold-start problem. It mines signals already present in your
                     │ Validation │
                     └──────┬─────┘
                            │
-              ┌────────────┼────────────┐
-              ▼            ▼            ▼
-         ┌─────────┐ ┌─────────┐ ┌─────────┐
-         │  Beads  │ │  JSON   │ │Markdown │
-         │  JSONL  │ │         │ │         │
-         └─────────┘ └─────────┘ └─────────┘
+         ┌────────────┼────────────┬────────────┐
+         ▼            ▼            ▼            ▼
+    ┌─────────┐ ┌─────────┐ ┌─────────┐ ┌─────────┐
+    │  Beads  │ │  JSON   │ │Markdown │ │  Tasks  │
+    │  JSONL  │ │         │ │         │ │         │
+    └─────────┘ └─────────┘ └─────────┘ └─────────┘
 ```
 
 ## What to Expect

--- a/docs/decisions/010-shared-signal-id.md
+++ b/docs/decisions/010-shared-signal-id.md
@@ -1,0 +1,22 @@
+# 010: Shared Signal ID Generation
+
+**Status:** Accepted
+**Date:** 2026-02-08
+**Context:** O4: Claude Code Tasks Formatter (stringer-cqo) — tasks formatter needs deterministic IDs, same algorithm as beads formatter
+
+## Problem
+
+The beads formatter generates deterministic content-based IDs via `BeadsFormatter.generateID()`. The tasks formatter now also needs deterministic IDs for Claude Code TaskCreate compatibility. Duplicating the hashing logic would violate DRY and risk the two formatters diverging.
+
+## Decision
+
+Extract the ID generation logic into a package-level `signalID(sig, prefix)` function in `internal/output/signalid.go`. Both formatters delegate to this shared function:
+
+- **BeadsFormatter.generateID** applies convention prefix overrides, then calls `signalID`
+- **TasksFormatter.signalToTask** calls `signalID` directly with the `"str-"` prefix
+
+## Consequences
+
+- **Positive:** Single source of truth for ID generation; adding new formatters that need IDs is trivial
+- **Positive:** All existing beads tests pass unchanged — `generateID` behavior is identical
+- **Negative:** None significant — this is a pure DRY extraction with no behavioral change

--- a/internal/output/beads.go
+++ b/internal/output/beads.go
@@ -1,7 +1,6 @@
 package output
 
 import (
-	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -123,21 +122,13 @@ func deriveCloseReason(kind string) string {
 }
 
 // generateID produces a deterministic ID from signal content.
-// It hashes Source + Kind + FilePath + Line + Title using SHA-256,
-// truncates to 8 hex characters, and prefixes with "str-" (or the
-// convention prefix if set).
+// It delegates to the shared signalID helper and applies convention overrides.
 func (b *BeadsFormatter) generateID(sig signal.RawSignal) string {
-	h := sha256.New()
-	// Write each field separated by null bytes to avoid collisions
-	// from field concatenation (e.g., "ab"+"c" vs "a"+"bc").
-	// sha256.Hash.Write never returns an error per the hash.Hash contract.
-	_, _ = fmt.Fprintf(h, "%s\x00%s\x00%s\x00%d\x00%s", sig.Source, sig.Kind, sig.FilePath, sig.Line, sig.Title)
-	sum := h.Sum(nil)
 	prefix := "str-"
 	if b.conventions != nil && b.conventions.IDPrefix != "" {
 		prefix = b.conventions.IDPrefix
 	}
-	return fmt.Sprintf("%s%x", prefix, sum[:4])
+	return signalID(sig, prefix)
 }
 
 // mapKindToType maps a signal Kind to a bead type.

--- a/internal/output/signalid.go
+++ b/internal/output/signalid.go
@@ -1,0 +1,21 @@
+package output
+
+import (
+	"crypto/sha256"
+	"fmt"
+
+	"github.com/davetashner/stringer/internal/signal"
+)
+
+// signalID produces a deterministic ID from signal content.
+// It hashes Source + Kind + FilePath + Line + Title using SHA-256,
+// truncates to 8 hex characters, and prepends the given prefix.
+func signalID(sig signal.RawSignal, prefix string) string {
+	h := sha256.New()
+	// Write each field separated by null bytes to avoid collisions
+	// from field concatenation (e.g., "ab"+"c" vs "a"+"bc").
+	// sha256.Hash.Write never returns an error per the hash.Hash contract.
+	_, _ = fmt.Fprintf(h, "%s\x00%s\x00%s\x00%d\x00%s", sig.Source, sig.Kind, sig.FilePath, sig.Line, sig.Title)
+	sum := h.Sum(nil)
+	return fmt.Sprintf("%s%x", prefix, sum[:4])
+}

--- a/internal/output/signalid_test.go
+++ b/internal/output/signalid_test.go
@@ -1,0 +1,86 @@
+package output
+
+import (
+	"testing"
+
+	"github.com/davetashner/stringer/internal/signal"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSignalID_Deterministic(t *testing.T) {
+	sig := signal.RawSignal{
+		Source:   "todos",
+		Kind:     "todo",
+		FilePath: "main.go",
+		Line:     42,
+		Title:    "Add tests",
+	}
+
+	id1 := signalID(sig, "str-")
+	id2 := signalID(sig, "str-")
+	assert.Equal(t, id1, id2, "same signal should produce the same ID")
+}
+
+func TestSignalID_Format(t *testing.T) {
+	sig := signal.RawSignal{
+		Source:   "todos",
+		Kind:     "todo",
+		FilePath: "main.go",
+		Line:     1,
+		Title:    "Test",
+	}
+
+	id := signalID(sig, "str-")
+	assert.Regexp(t, `^str-[0-9a-f]{8}$`, id, "ID should be str- prefix + 8 hex chars")
+}
+
+func TestSignalID_CustomPrefix(t *testing.T) {
+	sig := signal.RawSignal{
+		Source:   "todos",
+		Kind:     "todo",
+		FilePath: "main.go",
+		Line:     1,
+		Title:    "Test",
+	}
+
+	id := signalID(sig, "proj-")
+	assert.Regexp(t, `^proj-[0-9a-f]{8}$`, id, "ID should use the given prefix")
+}
+
+func TestSignalID_FieldSensitivity(t *testing.T) {
+	base := signal.RawSignal{
+		Source:   "todos",
+		Kind:     "todo",
+		FilePath: "main.go",
+		Line:     42,
+		Title:    "Add tests",
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(s signal.RawSignal) signal.RawSignal
+	}{
+		{"different_source", func(s signal.RawSignal) signal.RawSignal { s.Source = "gitlog"; return s }},
+		{"different_kind", func(s signal.RawSignal) signal.RawSignal { s.Kind = "fixme"; return s }},
+		{"different_filepath", func(s signal.RawSignal) signal.RawSignal { s.FilePath = "other.go"; return s }},
+		{"different_line", func(s signal.RawSignal) signal.RawSignal { s.Line = 99; return s }},
+		{"different_title", func(s signal.RawSignal) signal.RawSignal { s.Title = "Different title"; return s }},
+	}
+
+	baseID := signalID(base, "str-")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mutated := tt.mutate(base)
+			mutatedID := signalID(mutated, "str-")
+			assert.NotEqual(t, baseID, mutatedID, "changing %s should produce a different ID", tt.name)
+		})
+	}
+}
+
+func TestSignalID_MatchesBeadsFormatter(t *testing.T) {
+	sig := testSignal()
+
+	sharedID := signalID(sig, "str-")
+	beadsID := NewBeadsFormatter().generateID(sig)
+	assert.Equal(t, beadsID, sharedID, "signalID and BeadsFormatter.generateID should produce identical IDs")
+}


### PR DESCRIPTION
## Summary

Closes O4: Claude Code Tasks Formatter (`stringer-cqo`).

- **Extract shared `signalID` helper** from `BeadsFormatter.generateID` into `internal/output/signalid.go` (DR-010) — both formatters now delegate to the same function
- **Fix `activeForm` JSON tag** from snake_case (`active_form`) to camelCase (`activeForm`) to match Claude Code's TaskCreate API
- **Add deterministic task IDs** via `signalID(sig, "str-")` — same algorithm as beads
- **Add `status` field**: `"pending"` when open, `"completed"` when `ClosedAt` is set
- **Enrich description** with author, priority (from confidence via `mapConfidenceToPriority`), and tags
- **Enrich metadata** with `author`, `timestamp`, and `closed_at` fields
- **README**: Add "Why Stringer?" value prop section; add Tasks to the ASCII pipeline diagram

### Beads issues
- Closes `stringer-cqo.1` (research)
- Closes `stringer-cqo.2` (field mapping)
- Closes `stringer-cqo.3` (file paths/context)
- `stringer-cqo.4` (dependencies) deferred — no signal-level dependency fields yet

## Test plan

- [ ] `go test -race ./internal/output/...` passes (new + updated tests for signalid, tasks, beads)
- [ ] `golangci-lint run ./...` clean
- [ ] `go build -o stringer ./cmd/stringer` succeeds
- [ ] `./stringer scan . -f tasks | head -20` shows `id`, `status`, `activeForm` (camelCase), author/priority/tags in output
- [ ] Beads formatter behavior unchanged (signalID extraction is pure refactor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)