### PR TITLE
feat: add per-collector timeout with graceful degradation

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,6 +39,9 @@ type CollectorConfig struct {
 
 	// Anonymization settings.
 	Anonymize string `yaml:"anonymize,omitempty"`
+
+	// Timeout is the per-collector timeout (e.g. "60s", "2m").
+	Timeout string `yaml:"timeout,omitempty"`
 }
 
 // FileName is the expected config file name in a repository root.

--- a/internal/config/merge.go
+++ b/internal/config/merge.go
@@ -1,6 +1,10 @@
 package config
 
-import "github.com/davetashner/stringer/internal/signal"
+import (
+	"time"
+
+	"github.com/davetashner/stringer/internal/signal"
+)
 
 // Merge combines file-based config with CLI-provided ScanConfig.
 // CLI values take precedence; zero-value CLI fields fall through to file config.
@@ -58,6 +62,11 @@ func Merge(fileCfg *Config, cliCfg signal.ScanConfig) signal.ScanConfig {
 			}
 			if co.HistoryDepth == "" && fc.HistoryDepth != "" {
 				co.HistoryDepth = fc.HistoryDepth
+			}
+			if co.Timeout == 0 && fc.Timeout != "" {
+				if d, err := time.ParseDuration(fc.Timeout); err == nil {
+					co.Timeout = d
+				}
 			}
 			result.CollectorOpts[name] = co
 		}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -169,6 +169,13 @@ func (p *Pipeline) runCollector(ctx context.Context, c collector.Collector) sign
 		opts.ExcludePatterns = append(p.config.ExcludePatterns, opts.ExcludePatterns...)
 	}
 
+	// Apply per-collector timeout if configured.
+	if opts.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, opts.Timeout)
+		defer cancel()
+	}
+
 	start := time.Now()
 
 	signals, err := c.Collect(ctx, p.config.RepoPath, opts)

--- a/internal/signal/signal.go
+++ b/internal/signal/signal.go
@@ -72,6 +72,9 @@ type CollectorOpts struct {
 
 	// Anonymize controls author name anonymization: "auto", "always", or "never".
 	Anonymize string
+
+	// Timeout is the per-collector timeout. 0 means no timeout.
+	Timeout time.Duration
 }
 
 // ScanConfig holds the overall configuration for a scan operation.


### PR DESCRIPTION
## Summary
- Adds per-collector timeout support so a hanging collector can't kill the entire scan
- New `Timeout` field on `CollectorOpts` (duration), `timeout` key in `.stringer.yaml` per-collector config, and `--collector-timeout` CLI flag as global default
- Pipeline wraps each `Collect` call with `context.WithTimeout` when configured; existing error mode handling (skip/warn/fail) handles `DeadlineExceeded` naturally

Closes [stringer-r0r]

## Test plan
- [x] `TestRunCollector_Timeout` — slow collector (500ms sleep) with 50ms timeout returns `context.DeadlineExceeded`
- [x] `TestRunCollector_NoTimeout` — `Timeout: 0` does not apply any deadline (regression guard)
- [x] `TestRunCollector_TimeoutDoesNotAffectFastCollector` — fast collector with generous timeout succeeds
- [x] `TestMerge_TimeoutFromFile` — timeout merges from YAML config to CollectorOpts
- [x] `TestMerge_TimeoutCLIOverridesFile` — CLI-set timeout takes precedence over file config
- [x] `TestMerge_TimeoutInvalidDurationIgnored` — malformed duration string is silently ignored
- [x] Full test suite passes (`go test -race ./...`)
- [x] Lint clean (`golangci-lint run ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)