### PR TITLE
feat: add --include-demo-paths CLI flag and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ stringer scan [path] [flags]
 | `--history-depth`       |       |         | Filter closed items older than this duration (e.g., 90d)  |
 | `--anonymize`           |       | `auto`  | Anonymize author names: auto, always, or never            |
 | `--collector-timeout`   |       |         | Per-collector timeout (e.g. 60s, 2m); 0 = no timeout      |
+| `--include-demo-paths`  |       |         | Include demo/example/tutorial paths in noise-prone signals |
 | `--no-llm`              |       |         | Skip LLM clustering pass (noop — reserved for future use) |
 
 **Global flags:** `--quiet` (`-q`), `--verbose` (`-v`), `--no-color`, `--help` (`-h`)
@@ -225,6 +226,10 @@ collectors:
   gitlog:
     git_depth: 500
     git_since: 6m
+  patterns:
+    include_demo_paths: true  # report missing-tests / low-test-ratio in example dirs
+  lotteryrisk:
+    include_demo_paths: true  # report lottery-risk in example dirs
   github:
     include_closed: true
     history_depth: 90d
@@ -233,6 +238,8 @@ collectors:
 **Precedence:** CLI flags > `.stringer.yaml` > defaults
 
 If no config file exists, stringer uses its built-in defaults (all collectors enabled, beads format, no issue cap).
+
+By default, stringer suppresses noise-prone signals (`missing-tests`, `low-test-ratio`, `low-lottery-risk`) in demo/example/tutorial directories (`examples/`, `tutorials/`, `demos/`, `samples/`, and variants). Use `--include-demo-paths` or set `include_demo_paths: true` per collector to scan these paths.
 
 ## Other Commands
 

--- a/cmd/stringer/scan.go
+++ b/cmd/stringer/scan.go
@@ -43,6 +43,7 @@ var (
 	scanHistoryDepth      string
 	scanCollectorTimeout  string
 	scanExcludeCollectors string
+	scanIncludeDemoPaths  bool
 )
 
 // scanCmd is the subcommand for scanning a repository.
@@ -76,6 +77,7 @@ func init() {
 	scanCmd.Flags().StringVar(&scanAnonymize, "anonymize", "auto", "anonymize author names: auto, always, or never")
 	scanCmd.Flags().StringVar(&scanCollectorTimeout, "collector-timeout", "", "per-collector timeout (e.g. 60s, 2m); 0 or empty = no timeout")
 	scanCmd.Flags().StringVarP(&scanExcludeCollectors, "exclude-collectors", "x", "", "comma-separated list of collectors to skip")
+	scanCmd.Flags().BoolVar(&scanIncludeDemoPaths, "include-demo-paths", false, "include demo/example/tutorial paths in noise-prone signals")
 }
 
 func runScan(cmd *cobra.Command, args []string) error {
@@ -242,6 +244,18 @@ func runScan(cmd *cobra.Command, args []string) error {
 		co := scanCfg.CollectorOpts["lotteryrisk"]
 		co.Anonymize = scanAnonymize
 		scanCfg.CollectorOpts["lotteryrisk"] = co
+	}
+
+	// Apply --include-demo-paths to noise-prone collectors.
+	if scanIncludeDemoPaths {
+		if scanCfg.CollectorOpts == nil {
+			scanCfg.CollectorOpts = make(map[string]signal.CollectorOpts)
+		}
+		for _, name := range []string{"patterns", "lotteryrisk"} {
+			co := scanCfg.CollectorOpts[name]
+			co.IncludeDemoPaths = true
+			scanCfg.CollectorOpts[name] = co
+		}
 	}
 
 	// Wire progress callback for long-running collectors.


### PR DESCRIPTION
## Summary

- Add `--include-demo-paths` CLI flag to `stringer scan`, wiring it to the `patterns` and `lotteryrisk` collectors
- Add flag to README Usage Reference table
- Add `include_demo_paths` examples to README config section
- Add explanation paragraph about default demo-path filtering behavior

This was part of PR #82 but got dropped during squash-merge (late push after CI passed).

## Test plan

- [x] `./stringer scan --help` shows `--include-demo-paths` flag
- [x] `go build`, `go test -race ./cmd/stringer/...`, `golangci-lint` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)