### PR TITLE
feat: add --paths flag for file-scoped scanning

### DIFF
--- a/cmd/stringer/report.go
+++ b/cmd/stringer/report.go
@@ -31,6 +31,7 @@ var (
 	reportAnonymize         string
 	reportExcludeCollectors string
 	reportCollectorTimeout  string
+	reportPaths             []string
 )
 
 // reportCmd is the subcommand for generating a repository health report.
@@ -52,6 +53,7 @@ func init() {
 	reportCmd.Flags().StringVar(&reportAnonymize, "anonymize", "auto", "anonymize author names: auto, always, or never")
 	reportCmd.Flags().StringVarP(&reportExcludeCollectors, "exclude-collectors", "x", "", "comma-separated list of collectors to skip")
 	reportCmd.Flags().StringVar(&reportCollectorTimeout, "collector-timeout", "", "per-collector timeout (e.g. 60s, 2m); 0 or empty = no timeout")
+	reportCmd.Flags().StringSliceVar(&reportPaths, "paths", nil, "restrict scanning to specific files or directories (comma-separated)")
 }
 
 func runReport(cmd *cobra.Command, args []string) error {
@@ -185,6 +187,18 @@ func runReport(cmd *cobra.Command, args []string) error {
 				}
 				scanCfg.CollectorOpts[name] = co
 			}
+		}
+	}
+
+	// Apply --paths as IncludePatterns for file-scoped scanning.
+	if len(reportPaths) > 0 {
+		if scanCfg.CollectorOpts == nil {
+			scanCfg.CollectorOpts = make(map[string]signal.CollectorOpts)
+		}
+		for _, name := range collector.List() {
+			co := scanCfg.CollectorOpts[name]
+			co.IncludePatterns = append(co.IncludePatterns, reportPaths...)
+			scanCfg.CollectorOpts[name] = co
 		}
 	}
 

--- a/cmd/stringer/report_test.go
+++ b/cmd/stringer/report_test.go
@@ -35,6 +35,10 @@ func resetReportFlags() {
 	if h := reportCmd.Flags().Lookup("help"); h != nil {
 		_ = h.Value.Set("false")
 	}
+
+	// Reset slices AFTER VisitAll — pflag's StringSlice.Set("[]") appends a
+	// literal "[]" entry rather than clearing.
+	reportPaths = nil
 }
 
 func TestReportCmd_Exists(t *testing.T) {
@@ -132,6 +136,7 @@ func TestReportCmd_FlagsRegistered(t *testing.T) {
 		{"git-depth", ""},
 		{"git-since", ""},
 		{"anonymize", ""},
+		{"paths", ""},
 	}
 
 	for _, ff := range flags {


### PR DESCRIPTION
## Summary
- Adds `--paths` flag to both `stringer scan` and `stringer report` commands for restricting scanning to specific files or directories
- Wires path values as `IncludePatterns` on all collectors via `CollectorOpts`
- Fixes pflag `StringSlice` reset ordering bug in `resetScanFlags()`

## Beads
Completes stringer-8jd.5

## Test plan
- [x] 4 new unit tests in `scan_unit_test.go` covering single path, multiple paths, flag registration, and report paths flag
- [x] Updated `report_test.go` flags table to verify `--paths` registration
- [x] `go test -race ./...` passes
- [x] `golangci-lint run ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)