### PR TITLE
chore: add SBOM generation and cosign signing to releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write  # Required for cosign keyless signing via Sigstore/Fulcio OIDC
 
 jobs:
   release:
@@ -19,6 +20,8 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: "1.25"
+      - uses: sigstore/cosign-installer@v3
+      - uses: anchore/sbom-action/download-syft@v0
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -62,6 +62,19 @@ brews:
     install: |
       bin.install "stringer"
 
+sboms:
+  - artifacts: archive
+
+signs:
+  - cmd: cosign
+    artifacts: checksum
+    output: true
+    args:
+      - sign-blob
+      - --yes
+      - --output-signature=${signature}
+      - ${artifact}
+
 release:
   github:
     owner: davetashner
@@ -69,3 +82,5 @@ release:
   draft: false
   prerelease: auto
   name_template: "{{.Tag}}"
+  extra_files:
+    - glob: "*.sbom.json"


### PR DESCRIPTION
## Summary
- Adds SBOM (Software Bill of Materials) generation via syft — CycloneDX JSON per archive, attached to GitHub Releases
- Adds cosign keyless signing of `checksums.txt` via Sigstore/Fulcio OIDC — no secrets needed, uses GitHub's OIDC identity

## Changes

### `.goreleaser.yml`
- `sboms:` section — generates CycloneDX JSON SBOMs for each archive
- `signs:` section — signs `checksums.txt` with cosign keyless (Fulcio OIDC)
- `extra_files:` — attaches SBOM files to the GitHub Release

### `.github/workflows/release.yml`
- Installs `cosign` via `sigstore/cosign-installer@v3`
- Installs `syft` via `anchore/sbom-action/download-syft@v0`
- Adds `id-token: write` permission for OIDC keyless signing

## Verification
After a release, consumers can verify:
```bash
cosign verify-blob --signature checksums.txt.sig checksums.txt
```

Closes stringer-2dh.5, stringer-2dh.6

## Test plan
- [x] CI passes (no release-path changes affect CI)
- [ ] Next tagged release will exercise the full signing + SBOM pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)