### PR TITLE
ci: integrate OpenSSF Scorecard

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,34 @@
+name: OpenSSF Scorecard
+
+on:
+  push:
+    branches: [main]
+  branch_protection_rule:
+  schedule:
+    - cron: '30 1 * * 1'
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard Analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+      - name: Run Scorecard
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@b5ebac6f4c00c8ccddb7cdcd45fdb248329f808a # v3
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/davetashner/stringer)](https://goreportcard.com/report/github.com/davetashner/stringer)
 [![Release](https://img.shields.io/github/v/release/davetashner/stringer)](https://github.com/davetashner/stringer/releases/latest)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/davetashner/stringer/badge)](https://securityscorecards.dev/viewer/?uri=github.com/davetashner/stringer)
 
 > **Status: v0.5.0.** Five collectors, four output formats, report command with health analysis, parallel pipeline with signal deduplication, delta scanning, per-collector timeouts, and beads-aware dedup. See [Current Limitations](#current-limitations) for what's not here yet.
 


### PR DESCRIPTION
## Summary
- Add `.github/workflows/scorecard.yml` — runs OpenSSF Scorecard weekly, on push to main, and on branch protection changes
- Upload SARIF results to GitHub Security tab for visibility
- Publish results to the public OpenSSF dashboard
- Add scorecard badge to README

Closes stringer-2dh.8

## Test plan
- [ ] Workflow YAML validates (actionlint or manual review)
- [ ] After merge, first scorecard run on main completes successfully
- [ ] Badge renders at https://securityscorecards.dev/viewer/?uri=github.com/davetashner/stringer

🤖 Generated with [Claude Code](https://claude.com/claude-code)