### PR TITLE
chore: replace custom sortStrings with slices.Sort

### DIFF
--- a/internal/context/generator.go
+++ b/internal/context/generator.go
@@ -3,6 +3,7 @@ package context
 import (
 	"fmt"
 	"io"
+	"slices"
 	"strings"
 
 	"github.com/davetashner/stringer/internal/docs"
@@ -118,7 +119,7 @@ func Generate(analysis *docs.RepoAnalysis, history *GitHistory, scanState *state
 		for k := range byKind {
 			kinds = append(kinds, k)
 		}
-		sortStrings(kinds)
+		slices.Sort(kinds)
 
 		g.printf("Found %d signals from last scan:\n\n", scanState.SignalCount)
 		for _, kind := range kinds {
@@ -209,15 +210,6 @@ func formatKindLabel(kind string) string {
 		return "Lottery Risk"
 	default:
 		return strings.ToUpper(kind[:1]) + kind[1:]
-	}
-}
-
-// sortStrings sorts a string slice in place.
-func sortStrings(s []string) {
-	for i := 1; i < len(s); i++ {
-		for j := i; j > 0 && s[j] < s[j-1]; j-- {
-			s[j], s[j-1] = s[j-1], s[j]
-		}
 	}
 }
 

--- a/internal/context/generator_test.go
+++ b/internal/context/generator_test.go
@@ -231,12 +231,6 @@ func TestLastPathElement(t *testing.T) {
 	assert.Equal(t, "dir", lastPathElement("a/b/dir"))
 }
 
-func TestSortStrings(t *testing.T) {
-	s := []string{"c", "a", "b"}
-	sortStrings(s)
-	assert.Equal(t, []string{"a", "b", "c"}, s)
-}
-
 func TestGenerate_WithMilestones(t *testing.T) {
 	analysis := &docs.RepoAnalysis{
 		Name:     "myproject",

--- a/internal/output/json.go
+++ b/internal/output/json.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"time"
 
 	"github.com/davetashner/stringer/internal/signal"
@@ -139,16 +140,7 @@ func extractCollectors(signals []signal.RawSignal) []string {
 	}
 	// Sort for deterministic output.
 	if len(names) > 1 {
-		sortStrings(names)
+		slices.Sort(names)
 	}
 	return names
-}
-
-// sortStrings sorts a string slice in place.
-func sortStrings(s []string) {
-	for i := 1; i < len(s); i++ {
-		for j := i; j > 0 && s[j] < s[j-1]; j-- {
-			s[j], s[j-1] = s[j-1], s[j]
-		}
-	}
 }

--- a/internal/output/json_test.go
+++ b/internal/output/json_test.go
@@ -443,32 +443,6 @@ func TestExtractCollectors(t *testing.T) {
 	})
 }
 
-func TestSortStrings(t *testing.T) {
-	t.Run("already_sorted", func(t *testing.T) {
-		s := []string{"a", "b", "c"}
-		sortStrings(s)
-		assert.Equal(t, []string{"a", "b", "c"}, s)
-	})
-
-	t.Run("reverse", func(t *testing.T) {
-		s := []string{"c", "b", "a"}
-		sortStrings(s)
-		assert.Equal(t, []string{"a", "b", "c"}, s)
-	})
-
-	t.Run("single", func(t *testing.T) {
-		s := []string{"only"}
-		sortStrings(s)
-		assert.Equal(t, []string{"only"}, s)
-	})
-
-	t.Run("empty", func(t *testing.T) {
-		var s []string
-		sortStrings(s)
-		assert.Empty(t, s)
-	})
-}
-
 // --- Helpers ---
 
 // fixedNow returns a deterministic time for testing.


### PR DESCRIPTION
## Summary
- Replace hand-rolled insertion sort (`sortStrings()`) with `slices.Sort()` from Go 1.21+ stdlib
- Remove duplicate implementations in `internal/output/json.go` and `internal/context/generator.go`
- Remove corresponding `TestSortStrings` tests (stdlib doesn't need testing)
- Net: 4 insertions, 52 deletions

Resolves [stringer-1gs.5]

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/output/... ./internal/context/...` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)