### PR TITLE
fix: handle json.Marshal error in mcpjson.go

### DIFF
--- a/internal/bootstrap/mcpjson.go
+++ b/internal/bootstrap/mcpjson.go
@@ -62,7 +62,10 @@ func GenerateMCPConfig(repoPath string) (Action, error) {
 			Command: "stringer",
 			Args:    []string{"mcp", "serve"},
 		}
-		entryJSON, _ := json.Marshal(entry)
+		entryJSON, entryErr := json.Marshal(entry)
+		if entryErr != nil {
+			return Action{}, fmt.Errorf("marshaling MCP server entry: %w", entryErr)
+		}
 		cfg.MCPServers["stringer"] = entryJSON
 
 		data, marshalErr := json.MarshalIndent(cfg, "", "  ")
@@ -90,7 +93,10 @@ func GenerateMCPConfig(repoPath string) (Action, error) {
 		Command: "stringer",
 		Args:    []string{"mcp", "serve"},
 	}
-	entryJSON, _ := json.Marshal(entry)
+	entryJSON, entryErr := json.Marshal(entry)
+	if entryErr != nil {
+		return Action{}, fmt.Errorf("marshaling MCP server entry: %w", entryErr)
+	}
 	cfg.MCPServers["stringer"] = entryJSON
 
 	data, marshalErr := json.MarshalIndent(cfg, "", "  ")


### PR DESCRIPTION
## Summary
- Check `json.Marshal` error instead of discarding it with `_` in `internal/bootstrap/mcpjson.go`
- Fix applied to both code paths: existing `.mcp.json` update (line 65) and new file creation (line 93)
- Uses `entryErr` variable name to avoid shadowing the outer `err`

Resolves [stringer-1gs.6]

## Test plan
- [x] `go build ./internal/bootstrap/...` passes
- [x] `go test ./internal/bootstrap/...` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)