### PR TITLE
fix: add error context to bare returns in state and report

### DIFF
--- a/internal/report/table.go
+++ b/internal/report/table.go
@@ -81,7 +81,7 @@ func (t *Table) Render(w io.Writer) error {
 		parts[i] = strings.Repeat("-", width)
 	}
 	if _, err := fmt.Fprintf(w, "  %s\n", strings.Join(parts, "  ")); err != nil {
-		return err
+		return fmt.Errorf("render table: %w", err)
 	}
 
 	// Render data rows.
@@ -104,8 +104,10 @@ func (t *Table) renderHeader(w io.Writer, widths []int) error {
 			parts[i] = bold.Sprintf("%-*s", widths[i], col.Header)
 		}
 	}
-	_, err := fmt.Fprintf(w, "  %s\n", strings.Join(parts, "  "))
-	return err
+	if _, err := fmt.Fprintf(w, "  %s\n", strings.Join(parts, "  ")); err != nil {
+		return fmt.Errorf("render table: %w", err)
+	}
+	return nil
 }
 
 func (t *Table) renderRow(w io.Writer, values []string, widths []int) error {
@@ -131,6 +133,8 @@ func (t *Table) renderRow(w io.Writer, values []string, widths []int) error {
 			parts[i] = display + strings.Repeat(" ", pad)
 		}
 	}
-	_, err := fmt.Fprintf(w, "  %s\n", strings.Join(parts, "  "))
-	return err
+	if _, err := fmt.Fprintf(w, "  %s\n", strings.Join(parts, "  ")); err != nil {
+		return fmt.Errorf("render table: %w", err)
+	}
+	return nil
 }

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -98,7 +98,7 @@ func Load(repoPath string) (*ScanState, error) {
 func Save(repoPath string, s *ScanState) error {
 	dir := filepath.Join(repoPath, stateDir)
 	if err := FS.MkdirAll(dir, 0o750); err != nil {
-		return err
+		return fmt.Errorf("create state directory: %w", err)
 	}
 
 	data, err := json.MarshalIndent(s, "", "  ")
@@ -106,7 +106,10 @@ func Save(repoPath string, s *ScanState) error {
 		return err
 	}
 
-	return FS.WriteFile(filepath.Join(dir, stateFile), data, 0o644)
+	if err := FS.WriteFile(filepath.Join(dir, stateFile), data, 0o644); err != nil {
+		return fmt.Errorf("write state file: %w", err)
+	}
+	return nil
 }
 
 // FilterNew returns only the signals whose hashes are not present in prev.


### PR DESCRIPTION
## Summary
- Wrap bare `return err` with `fmt.Errorf` context in `internal/state/state.go` Save() method (2 fixes: MkdirAll, WriteFile)
- Wrap bare `return err` with `fmt.Errorf("render table: %w", err)` in `internal/report/table.go` (3 fixes: Render, renderHeader, renderRow)
- Aligns with the codebase's otherwise thorough error wrapping discipline (115+ correct `%w` uses elsewhere)

Resolves [stringer-1gs.7]

## Test plan
- [x] `go build ./internal/state/... ./internal/report/...` passes
- [x] `go test ./internal/state/... ./internal/report/...` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)