### PR TITLE
refactor: replace govulncheck with OSV.dev client in vuln collector

### DIFF
--- a/internal/collectors/vuln_test.go
+++ b/internal/collectors/vuln_test.go
@@ -14,17 +14,30 @@ import (
 	"github.com/davetashner/stringer/internal/testable"
 )
 
-// mockVulnScanner implements vulnScanner for testing.
-type mockVulnScanner struct {
-	results []vulnResult
+// mockOSVClient implements osvClient for testing.
+type mockOSVClient struct {
+	results []VulnDetail
 	err     error
 }
 
-func (m *mockVulnScanner) Scan(_ context.Context, _ string) ([]vulnResult, error) {
+func (m *mockOSVClient) QueryBatch(_ context.Context, _ []PackageQuery) ([]VulnDetail, error) {
 	if m.err != nil {
 		return nil, m.err
 	}
 	return m.results, nil
+}
+
+// validGoMod returns a go.mod with require directives for testing.
+func validGoMod() []byte {
+	return []byte(`module example.com/test
+
+go 1.22
+
+require (
+	github.com/foo/bar v1.0.0
+	github.com/baz/qux v0.2.0
+)
+`)
 }
 
 func TestVulnCollector_Name(t *testing.T) {
@@ -34,7 +47,7 @@ func TestVulnCollector_Name(t *testing.T) {
 
 func TestVulnCollector_NoGoMod(t *testing.T) {
 	dir := t.TempDir()
-	c := &VulnCollector{scanner: &mockVulnScanner{}}
+	c := &VulnCollector{osv: &mockOSVClient{}}
 	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{})
 	assert.NoError(t, err)
 	assert.Nil(t, signals)
@@ -42,16 +55,18 @@ func TestVulnCollector_NoGoMod(t *testing.T) {
 
 func TestVulnCollector_SingleVuln(t *testing.T) {
 	dir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/test\n\ngo 1.22\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), validGoMod(), 0o600))
 
-	c := &VulnCollector{scanner: &mockVulnScanner{
-		results: []vulnResult{{
-			OSVID:        "GO-2024-2687",
+	c := &VulnCollector{osv: &mockOSVClient{
+		results: []VulnDetail{{
+			ID:           "GO-2024-2687",
 			Aliases:      []string{"CVE-2024-24790"},
 			Summary:      "Mishandling of DNS in net/netip",
-			Module:       "stdlib",
-			Version:      "v1.22.3",
-			FixedVersion: "v1.22.4",
+			Ecosystem:    "Go",
+			PackageName:  "github.com/foo/bar",
+			Version:      "v1.0.0",
+			FixedVersion: "v1.0.1",
+			Severity:     "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
 		}},
 	}}
 
@@ -64,9 +79,9 @@ func TestVulnCollector_SingleVuln(t *testing.T) {
 	assert.Equal(t, "vulnerable-dependency", sig.Kind)
 	assert.Equal(t, "go.mod", sig.FilePath)
 	assert.Contains(t, sig.Title, "CVE-2024-24790")
-	assert.Contains(t, sig.Title, "stdlib")
-	assert.Contains(t, sig.Description, "Upgrade stdlib from v1.22.3 to v1.22.4")
-	assert.Equal(t, 0.9, sig.Confidence)
+	assert.Contains(t, sig.Title, "github.com/foo/bar")
+	assert.Contains(t, sig.Description, "Upgrade github.com/foo/bar from v1.0.0 to v1.0.1")
+	assert.Equal(t, 0.95, sig.Confidence) // high severity
 	assert.Contains(t, sig.Tags, "security")
 	assert.Contains(t, sig.Tags, "vulnerable-dependency")
 	assert.Contains(t, sig.Tags, "CVE-2024-24790")
@@ -75,16 +90,18 @@ func TestVulnCollector_SingleVuln(t *testing.T) {
 
 func TestVulnCollector_NoFixAvailable(t *testing.T) {
 	dir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/test\n\ngo 1.22\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), validGoMod(), 0o600))
 
-	c := &VulnCollector{scanner: &mockVulnScanner{
-		results: []vulnResult{{
-			OSVID:        "GO-2024-9999",
+	c := &VulnCollector{osv: &mockOSVClient{
+		results: []VulnDetail{{
+			ID:           "GO-2024-9999",
 			Aliases:      []string{"CVE-2024-99999"},
 			Summary:      "Unpatched vulnerability",
-			Module:       "github.com/foo/bar",
+			Ecosystem:    "Go",
+			PackageName:  "github.com/foo/bar",
 			Version:      "v1.0.0",
 			FixedVersion: "",
+			Severity:     "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
 		}},
 	}}
 
@@ -92,39 +109,45 @@ func TestVulnCollector_NoFixAvailable(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, signals, 1)
 
-	assert.Equal(t, 0.85, signals[0].Confidence)
+	assert.Equal(t, 0.80, signals[0].Confidence) // medium severity (C:L)
 	assert.Contains(t, signals[0].Description, "No fix available")
 }
 
 func TestVulnCollector_MultipleVulns(t *testing.T) {
 	dir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/test\n\ngo 1.22\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), validGoMod(), 0o600))
 
-	c := &VulnCollector{scanner: &mockVulnScanner{
-		results: []vulnResult{
+	c := &VulnCollector{osv: &mockOSVClient{
+		results: []VulnDetail{
 			{
-				OSVID:        "GO-2024-0001",
+				ID:           "GO-2024-0001",
 				Aliases:      []string{"CVE-2024-0001"},
 				Summary:      "Vuln one",
-				Module:       "github.com/a/b",
+				Ecosystem:    "Go",
+				PackageName:  "github.com/a/b",
 				Version:      "v1.0.0",
 				FixedVersion: "v1.1.0",
+				Severity:     "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
 			},
 			{
-				OSVID:        "GO-2024-0002",
+				ID:           "GO-2024-0002",
 				Aliases:      []string{"CVE-2024-0002"},
 				Summary:      "Vuln two",
-				Module:       "github.com/c/d",
+				Ecosystem:    "Go",
+				PackageName:  "github.com/c/d",
 				Version:      "v2.0.0",
 				FixedVersion: "v2.1.0",
+				Severity:     "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
 			},
 			{
-				OSVID:        "GO-2024-0003",
+				ID:           "GO-2024-0003",
 				Aliases:      []string{"CVE-2024-0003"},
 				Summary:      "Vuln three",
-				Module:       "github.com/e/f",
+				Ecosystem:    "Go",
+				PackageName:  "github.com/e/f",
 				Version:      "v3.0.0",
 				FixedVersion: "",
+				Severity:     "",
 			},
 		},
 	}}
@@ -144,16 +167,18 @@ func TestVulnCollector_MultipleVulns(t *testing.T) {
 
 func TestVulnCollector_NoCVEAlias(t *testing.T) {
 	dir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/test\n\ngo 1.22\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), validGoMod(), 0o600))
 
-	c := &VulnCollector{scanner: &mockVulnScanner{
-		results: []vulnResult{{
-			OSVID:        "GO-2024-5555",
-			Aliases:      []string{"GHSA-xxxx-yyyy-zzzz"}, // no CVE alias
+	c := &VulnCollector{osv: &mockOSVClient{
+		results: []VulnDetail{{
+			ID:           "GO-2024-5555",
+			Aliases:      []string{"GHSA-xxxx-yyyy-zzzz"},
 			Summary:      "Some vulnerability",
-			Module:       "github.com/foo/bar",
+			Ecosystem:    "Go",
+			PackageName:  "github.com/foo/bar",
 			Version:      "v1.0.0",
 			FixedVersion: "v1.1.0",
+			Severity:     "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
 		}},
 	}}
 
@@ -171,15 +196,15 @@ func TestVulnCollector_NoCVEAlias(t *testing.T) {
 	}
 }
 
-func TestVulnCollector_ScanError(t *testing.T) {
+func TestVulnCollector_QueryBatchError(t *testing.T) {
 	dir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/test\n\ngo 1.22\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), validGoMod(), 0o600))
 
-	c := &VulnCollector{scanner: &mockVulnScanner{
+	c := &VulnCollector{osv: &mockOSVClient{
 		err: fmt.Errorf("network unavailable"),
 	}}
 
-	// C7.3: graceful degradation — error → nil signals, nil error.
+	// Graceful degradation — error → nil signals, nil error.
 	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{})
 	assert.NoError(t, err)
 	assert.Nil(t, signals)
@@ -187,10 +212,10 @@ func TestVulnCollector_ScanError(t *testing.T) {
 
 func TestVulnCollector_ZeroVulns(t *testing.T) {
 	dir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/test\n\ngo 1.22\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), validGoMod(), 0o600))
 
-	c := &VulnCollector{scanner: &mockVulnScanner{
-		results: []vulnResult{},
+	c := &VulnCollector{osv: &mockOSVClient{
+		results: []VulnDetail{},
 	}}
 
 	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{})
@@ -212,16 +237,18 @@ func TestVulnCollector_Metrics(t *testing.T) {
 
 	// After Collect with a valid go.mod, Metrics is populated.
 	dir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/test\n\ngo 1.22\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), validGoMod(), 0o600))
 
-	c.scanner = &mockVulnScanner{
-		results: []vulnResult{{
-			OSVID:        "GO-2024-1234",
+	c.osv = &mockOSVClient{
+		results: []VulnDetail{{
+			ID:           "GO-2024-1234",
 			Aliases:      []string{"CVE-2024-1234"},
 			Summary:      "Test vuln",
-			Module:       "github.com/x/y",
+			Ecosystem:    "Go",
+			PackageName:  "github.com/x/y",
 			Version:      "v1.0.0",
 			FixedVersion: "v1.1.0",
+			Severity:     "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
 		}},
 	}
 
@@ -239,6 +266,7 @@ func TestVulnCollector_Metrics(t *testing.T) {
 	assert.Equal(t, "github.com/x/y", metrics.Vulns[0].Module)
 	assert.Equal(t, "v1.0.0", metrics.Vulns[0].Version)
 	assert.Equal(t, "v1.1.0", metrics.Vulns[0].FixedVersion)
+	assert.Equal(t, "high", metrics.Vulns[0].Severity)
 }
 
 func TestVulnCollector_ReadFileError(t *testing.T) {
@@ -255,55 +283,134 @@ func TestVulnCollector_ReadFileError(t *testing.T) {
 	signals, err := c.Collect(context.Background(), "/fake", signal.CollectorOpts{})
 	assert.Error(t, err)
 	assert.Nil(t, signals)
-	assert.Contains(t, err.Error(), "checking go.mod")
+	assert.Contains(t, err.Error(), "reading go.mod")
 }
 
-func TestParseVulnOutput(t *testing.T) {
-	// Simulated govulncheck -json output with two OSV entries and
-	// three findings (two for the same OSV → should dedup).
-	input := `{"config":{"protocol_version":"v1.0.0"}}
-{"progress":{"message":"Scanning modules..."}}
-{"osv":{"id":"GO-2024-0001","aliases":["CVE-2024-0001"],"summary":"Vuln A"}}
-{"osv":{"id":"GO-2024-0002","aliases":["CVE-2024-0002"],"summary":"Vuln B"}}
-{"finding":{"osv":"GO-2024-0001","fixed_version":"v1.1.0","trace":[{"module":"github.com/a/b","version":"v1.0.0"}]}}
-{"finding":{"osv":"GO-2024-0001","fixed_version":"v1.1.0","trace":[{"module":"github.com/a/b","version":"v1.0.0"}]}}
-{"finding":{"osv":"GO-2024-0002","fixed_version":"","trace":[{"module":"github.com/c/d","version":"v2.0.0"}]}}
-`
-	results, err := parseVulnOutput([]byte(input))
-	require.NoError(t, err)
-	assert.Len(t, results, 2, "should dedup multiple findings for same OSV")
+func TestVulnCollector_GoModParseError(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("this is not valid go.mod content{{{"), 0o600))
 
-	// Build a map for order-independent assertion.
-	byID := make(map[string]vulnResult)
-	for _, r := range results {
-		byID[r.OSVID] = r
+	c := &VulnCollector{osv: &mockOSVClient{}}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{})
+	assert.Error(t, err)
+	assert.Nil(t, signals)
+	assert.Contains(t, err.Error(), "parsing go.mod")
+}
+
+func TestVulnCollector_NoRequirements(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/test\n\ngo 1.22\n"), 0o600))
+
+	c := &VulnCollector{osv: &mockOSVClient{
+		results: []VulnDetail{{ID: "should-not-reach"}},
+	}}
+
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{})
+	assert.NoError(t, err)
+	assert.Nil(t, signals)
+}
+
+func TestVulnCollector_SeverityBasedConfidence(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), validGoMod(), 0o600))
+
+	tests := []struct {
+		name     string
+		severity string
+		wantConf float64
+		wantSev  string
+	}{
+		{
+			name:     "high severity → 0.95",
+			severity: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+			wantConf: 0.95,
+			wantSev:  "high",
+		},
+		{
+			name:     "medium severity → 0.80",
+			severity: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
+			wantConf: 0.80,
+			wantSev:  "medium",
+		},
+		{
+			name:     "low severity → 0.60",
+			severity: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N",
+			wantConf: 0.60,
+			wantSev:  "low",
+		},
+		{
+			name:     "no severity data → 0.80 default",
+			severity: "",
+			wantConf: 0.80,
+			wantSev:  "",
+		},
 	}
 
-	r1 := byID["GO-2024-0001"]
-	assert.Equal(t, "github.com/a/b", r1.Module)
-	assert.Equal(t, "v1.0.0", r1.Version)
-	assert.Equal(t, "v1.1.0", r1.FixedVersion)
-	assert.Equal(t, "Vuln A", r1.Summary)
-	assert.Equal(t, []string{"CVE-2024-0001"}, r1.Aliases)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &VulnCollector{osv: &mockOSVClient{
+				results: []VulnDetail{{
+					ID:          "GO-2024-0001",
+					Aliases:     []string{"CVE-2024-0001"},
+					Summary:     "Test vuln",
+					Ecosystem:   "Go",
+					PackageName: "github.com/foo/bar",
+					Version:     "v1.0.0",
+					Severity:    tt.severity,
+				}},
+			}}
 
-	r2 := byID["GO-2024-0002"]
-	assert.Equal(t, "github.com/c/d", r2.Module)
-	assert.Equal(t, "", r2.FixedVersion)
+			signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{})
+			require.NoError(t, err)
+			require.Len(t, signals, 1)
+			assert.InDelta(t, tt.wantConf, signals[0].Confidence, 0.001)
+
+			metrics := c.Metrics().(*VulnMetrics)
+			assert.Equal(t, tt.wantSev, metrics.Vulns[0].Severity)
+		})
+	}
 }
 
-func TestParseVulnOutput_Empty(t *testing.T) {
-	results, err := parseVulnOutput([]byte(""))
-	require.NoError(t, err)
-	assert.Empty(t, results)
+func TestSeverityFromCVSS(t *testing.T) {
+	tests := []struct {
+		name string
+		cvss string
+		want string
+	}{
+		{"high - all H", "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", "high"},
+		{"high - one H", "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N", "high"},
+		{"medium - one L", "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N", "medium"},
+		{"medium - mixed L", "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N", "medium"},
+		{"low - all N", "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N", "low"},
+		{"empty string", "", ""},
+		{"malformed - no CIA metrics", "not-a-cvss-string", "low"},
+		{"partial vector", "CVSS:3.1/AV:N", "low"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, severityFromCVSS(tt.cvss))
+		})
+	}
 }
 
-func TestParseVulnOutput_FindingWithoutOSV(t *testing.T) {
-	// A finding referencing an OSV ID that was never sent should be skipped.
-	input := `{"finding":{"osv":"GO-2024-MISSING","fixed_version":"v1.0.0","trace":[{"module":"github.com/x/y","version":"v0.1.0"}]}}
-`
-	results, err := parseVulnOutput([]byte(input))
-	require.NoError(t, err)
-	assert.Empty(t, results)
+func TestConfidenceForSeverity(t *testing.T) {
+	tests := []struct {
+		severity string
+		want     float64
+	}{
+		{"high", 0.95},
+		{"medium", 0.80},
+		{"low", 0.60},
+		{"", 0.80},
+		{"unknown", 0.80},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.severity, func(t *testing.T) {
+			assert.InDelta(t, tt.want, confidenceForSeverity(tt.severity), 0.001)
+		})
+	}
 }
 
 func TestExtractCVE(t *testing.T) {


### PR DESCRIPTION
## Summary
- Removes govulncheck dependency (exec shelling, JSON parsing) from vuln collector
- Wires existing `osvClient.QueryBatch()` into `VulnCollector.Collect()` — parses go.mod with `modfile.Parse`, builds `PackageQuery` structs, queries OSV.dev
- Adds CVSS severity→confidence mapping: high=0.95, medium=0.80, low=0.60, default=0.80
- Adds `Severity` field to `VulnEntry` metrics struct

Closes stringer-uf1.7

## Test plan
- [x] All existing vuln tests updated to use `mockOSVClient` instead of `mockVulnScanner`
- [x] New tests: `TestSeverityFromCVSS`, `TestConfidenceForSeverity`, `TestVulnCollector_GoModParseError`, `TestVulnCollector_NoRequirements`, `TestVulnCollector_SeverityBasedConfidence`
- [x] `go test -race ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] `go build -o stringer ./cmd/stringer` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)