### PR TITLE
fix: update fuzz schedule and add manual trigger

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -2,7 +2,8 @@ name: Fuzz (Thorough)
 
 on:
   schedule:
-    - cron: "0 3 * * 0"  # Sunday 3am UTC
+    - cron: "0 6 * * 1"  # Monday 6am UTC
+  workflow_dispatch:
   push:
     tags:
       - "v*"


### PR DESCRIPTION
## Summary
- Move thorough fuzz schedule from Sunday 3am to Monday 6am UTC
- Add `workflow_dispatch` trigger for manual runs
- CI fuzz job already uses `-fuzztime=10s` for fast PR feedback; thorough fuzz continues at `-fuzztime=2m` on schedule

Closes stringer-xui

## Test plan
- [x] `go test -race ./internal/beads/...` passes
- [ ] CI checks pass
- [ ] Thorough fuzz workflow can be manually triggered via `workflow_dispatch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)