### PR TITLE
feat: add stringer validate command

### DIFF
--- a/cmd/stringer/root.go
+++ b/cmd/stringer/root.go
@@ -46,5 +46,6 @@ func init() {
 	rootCmd.AddCommand(contextCmd)
 	rootCmd.AddCommand(reportCmd)
 	rootCmd.AddCommand(mcpCmd)
+	rootCmd.AddCommand(validateCmd)
 	rootCmd.AddCommand(versionCmd)
 }

--- a/cmd/stringer/validate.go
+++ b/cmd/stringer/validate.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/spf13/cobra"
+
+	"github.com/davetashner/stringer/internal/validate"
+)
+
+// Validate-specific flag values.
+var (
+	validateBdCheck bool
+)
+
+// validateCmd is the subcommand for validating JSONL files against the bd import schema.
+var validateCmd = &cobra.Command{
+	Use:   "validate [file]",
+	Short: "Validate a JSONL file against the bd import schema",
+	Long: `Validate a Beads JSONL file to ensure it will be accepted by 'bd import'.
+
+Checks required fields (id, title, type, priority, status, created_by),
+validates field types and allowed values, and reports errors with fix suggestions.
+
+Pass a file path as an argument, or pipe JSONL via stdin:
+  stringer validate output.jsonl
+  stringer scan . | stringer validate
+  cat output.jsonl | stringer validate`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runValidate,
+}
+
+func init() {
+	validateCmd.Flags().BoolVar(&validateBdCheck, "bd-check", false,
+		"also run 'bd import --dry-run' for additional validation (requires bd on PATH)")
+}
+
+func runValidate(cmd *cobra.Command, args []string) error {
+	// Determine input source: file argument or stdin.
+	var r *os.File
+	if len(args) > 0 {
+		filePath := args[0]
+		f, err := os.Open(filePath) //nolint:gosec // user-provided path is expected
+		if err != nil {
+			return exitError(ExitInvalidArgs, "stringer: cannot open %q (%v)", filePath, err)
+		}
+		defer f.Close() //nolint:errcheck // best-effort close on input file
+		r = f
+	} else {
+		r = os.Stdin
+	}
+
+	// Run validation.
+	result := validate.Validate(r)
+
+	// Print results.
+	if result.Valid() {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "valid: %d beads\n", result.TotalLines)
+	} else {
+		for _, e := range result.Errors {
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "line %d:", e.Line)
+			if e.Field != "" {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), " %s:", e.Field)
+			}
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), " %s\n", e.Message)
+			if e.Suggestion != "" {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "  fix: %s\n", e.Suggestion)
+			}
+		}
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "\n%d error(s) found in %d lines\n",
+			len(result.Errors), result.TotalLines)
+	}
+
+	// Optional: run bd import --dry-run.
+	if validateBdCheck {
+		if err := runBdCheck(cmd, args); err != nil {
+			return err
+		}
+	}
+
+	if !result.Valid() {
+		return exitError(ExitInvalidArgs, "")
+	}
+	return nil
+}
+
+// runBdCheck runs `bd import --dry-run` on the file for additional validation.
+func runBdCheck(cmd *cobra.Command, args []string) error {
+	bdPath, err := exec.LookPath("bd")
+	if err != nil {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
+			"\n--bd-check: 'bd' not found on PATH, skipping bd import validation\n")
+		return nil
+	}
+
+	if len(args) == 0 {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
+			"\n--bd-check: requires a file argument (stdin input not supported for bd import)\n")
+		return nil
+	}
+
+	_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "\nRunning bd import --dry-run...\n")
+
+	bdCmd := exec.Command(bdPath, "import", "--dry-run", args[0]) //nolint:gosec // user-provided path + bd binary
+	bdCmd.Stdout = cmd.OutOrStdout()
+	bdCmd.Stderr = cmd.ErrOrStderr()
+
+	if err := bdCmd.Run(); err != nil {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "bd import --dry-run failed: %v\n", err)
+		// Don't fail the validate command because of bd errors — our validation is the source of truth.
+	} else {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "bd import --dry-run: OK\n")
+	}
+
+	return nil
+}

--- a/cmd/stringer/validate_test.go
+++ b/cmd/stringer/validate_test.go
@@ -1,0 +1,432 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// resetValidateFlags resets all package-level validate flags to their default values.
+func resetValidateFlags() {
+	validateBdCheck = false
+
+	validateCmd.Flags().VisitAll(func(f *pflag.Flag) {
+		f.Changed = false
+		_ = f.Value.Set(f.DefValue)
+	})
+	rootCmd.PersistentFlags().VisitAll(func(f *pflag.Flag) {
+		f.Changed = false
+		_ = f.Value.Set(f.DefValue)
+	})
+}
+
+// writeJSONLFile creates a temporary JSONL file with the given content.
+func writeJSONLFile(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.jsonl")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	return path
+}
+
+// validJSONL is a valid JSONL line for testing.
+const validJSONL = `{"id":"str-12345678","title":"Fix bug","type":"task","priority":2,"status":"open","created_by":"stringer"}`
+
+// -----------------------------------------------------------------------
+// Flag registration tests
+// -----------------------------------------------------------------------
+
+func TestValidateCmd_FlagsRegistered(t *testing.T) {
+	f := validateCmd.Flags().Lookup("bd-check")
+	require.NotNil(t, f, "flag --bd-check not registered")
+	assert.Equal(t, "false", f.DefValue)
+}
+
+func TestValidateCmd_Help(t *testing.T) {
+	resetValidateFlags()
+
+	cmd, stdout, _ := newTestCmd()
+	cmd.SetArgs([]string{"validate", "--help"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	out := stdout.String()
+	assert.Contains(t, out, "Validate a Beads JSONL file")
+	assert.Contains(t, out, "--bd-check")
+	assert.Contains(t, out, "bd import")
+}
+
+// -----------------------------------------------------------------------
+// Valid file tests
+// -----------------------------------------------------------------------
+
+func TestRunValidate_ValidFile(t *testing.T) {
+	resetValidateFlags()
+	path := writeJSONLFile(t, validJSONL+"\n")
+
+	cmd, stdout, _ := newTestCmd()
+	cmd.SetArgs([]string{"validate", path})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	out := stdout.String()
+	assert.Contains(t, out, "valid: 1 beads")
+}
+
+func TestRunValidate_MultipleValidLines(t *testing.T) {
+	resetValidateFlags()
+	content := validJSONL + "\n" +
+		`{"id":"str-87654321","title":"Add feature","type":"feature","priority":1,"status":"open","created_by":"alice"}` + "\n"
+	path := writeJSONLFile(t, content)
+
+	cmd, stdout, _ := newTestCmd()
+	cmd.SetArgs([]string{"validate", path})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "valid: 2 beads")
+}
+
+// -----------------------------------------------------------------------
+// Invalid file tests — exit code
+// -----------------------------------------------------------------------
+
+func TestRunValidate_InvalidFile_ExitCode(t *testing.T) {
+	resetValidateFlags()
+	content := `{"id":"str-12345678","title":"Fix bug","type":"wrong","priority":2,"status":"open","created_by":"stringer"}` + "\n"
+	path := writeJSONLFile(t, content)
+
+	cmd, _, _ := newTestCmd()
+	cmd.SetArgs([]string{"validate", path})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+
+	var ece *exitCodeError
+	require.True(t, errors.As(err, &ece))
+	assert.Equal(t, ExitInvalidArgs, ece.ExitCode())
+}
+
+func TestRunValidate_InvalidFile_ErrorOutput(t *testing.T) {
+	resetValidateFlags()
+	content := `{"id":"str-12345678","title":"Fix bug","type":"wrong","priority":7,"status":"done","created_by":"stringer"}` + "\n"
+	path := writeJSONLFile(t, content)
+
+	cmd, _, stderr := newTestCmd()
+	cmd.SetArgs([]string{"validate", path})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+
+	out := stderr.String()
+	assert.Contains(t, out, "line 1:")
+	assert.Contains(t, out, "type:")
+	assert.Contains(t, out, "invalid type")
+	assert.Contains(t, out, "priority:")
+	assert.Contains(t, out, "invalid priority")
+	assert.Contains(t, out, "status:")
+	assert.Contains(t, out, "invalid status")
+	assert.Contains(t, out, "error(s) found")
+}
+
+// -----------------------------------------------------------------------
+// Missing field error output tests
+// -----------------------------------------------------------------------
+
+func TestRunValidate_MissingRequiredFields(t *testing.T) {
+	resetValidateFlags()
+	content := `{"id":"str-12345678"}` + "\n"
+	path := writeJSONLFile(t, content)
+
+	cmd, _, stderr := newTestCmd()
+	cmd.SetArgs([]string{"validate", path})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+
+	out := stderr.String()
+	assert.Contains(t, out, "title:")
+	assert.Contains(t, out, "missing required field")
+	assert.Contains(t, out, "type:")
+	assert.Contains(t, out, "priority:")
+	assert.Contains(t, out, "status:")
+	assert.Contains(t, out, "created_by:")
+}
+
+// -----------------------------------------------------------------------
+// Fix suggestion output tests
+// -----------------------------------------------------------------------
+
+func TestRunValidate_FixSuggestions(t *testing.T) {
+	resetValidateFlags()
+	content := `{"id":"str-12345678","title":"Fix bug","type":"bugg","priority":2,"status":"open","created_by":"stringer"}` + "\n"
+	path := writeJSONLFile(t, content)
+
+	cmd, _, stderr := newTestCmd()
+	cmd.SetArgs([]string{"validate", path})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+
+	out := stderr.String()
+	assert.Contains(t, out, "fix:")
+	assert.Contains(t, out, "did you mean")
+}
+
+// -----------------------------------------------------------------------
+// File not found test
+// -----------------------------------------------------------------------
+
+func TestRunValidate_FileNotFound(t *testing.T) {
+	resetValidateFlags()
+
+	cmd, _, _ := newTestCmd()
+	cmd.SetArgs([]string{"validate", "/nonexistent/path/test.jsonl"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+
+	var ece *exitCodeError
+	require.True(t, errors.As(err, &ece))
+	assert.Equal(t, ExitInvalidArgs, ece.ExitCode())
+	assert.Contains(t, ece.Error(), "cannot open")
+}
+
+// -----------------------------------------------------------------------
+// Too many args test
+// -----------------------------------------------------------------------
+
+func TestRunValidate_TooManyArgs(t *testing.T) {
+	resetValidateFlags()
+
+	cmd, _, _ := newTestCmd()
+	cmd.SetArgs([]string{"validate", "file1", "file2"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+}
+
+// -----------------------------------------------------------------------
+// Invalid JSON test
+// -----------------------------------------------------------------------
+
+func TestRunValidate_InvalidJSON(t *testing.T) {
+	resetValidateFlags()
+	content := "this is not json\n"
+	path := writeJSONLFile(t, content)
+
+	cmd, _, stderr := newTestCmd()
+	cmd.SetArgs([]string{"validate", path})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+
+	out := stderr.String()
+	assert.Contains(t, out, "line 1:")
+	assert.Contains(t, out, "invalid JSON")
+}
+
+// -----------------------------------------------------------------------
+// Empty file test
+// -----------------------------------------------------------------------
+
+func TestRunValidate_EmptyFile(t *testing.T) {
+	resetValidateFlags()
+	path := writeJSONLFile(t, "")
+
+	cmd, stdout, _ := newTestCmd()
+	cmd.SetArgs([]string{"validate", path})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "valid: 0 beads")
+}
+
+// -----------------------------------------------------------------------
+// Optional fields valid test
+// -----------------------------------------------------------------------
+
+func TestRunValidate_AllOptionalFields(t *testing.T) {
+	resetValidateFlags()
+	content := `{"id":"str-12345678","title":"Fix bug","type":"task","priority":2,"status":"closed","created_by":"stringer","created_at":"2024-01-15T10:30:00Z","closed_at":"2024-02-01T12:00:00Z","labels":["bug"],"description":"Details","close_reason":"resolved"}` + "\n"
+	path := writeJSONLFile(t, content)
+
+	cmd, stdout, _ := newTestCmd()
+	cmd.SetArgs([]string{"validate", path})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "valid: 1 beads")
+}
+
+// -----------------------------------------------------------------------
+// Invalid timestamp test
+// -----------------------------------------------------------------------
+
+func TestRunValidate_InvalidTimestamp(t *testing.T) {
+	resetValidateFlags()
+	content := `{"id":"str-12345678","title":"Fix bug","type":"task","priority":2,"status":"open","created_by":"stringer","created_at":"not-a-date"}` + "\n"
+	path := writeJSONLFile(t, content)
+
+	cmd, _, stderr := newTestCmd()
+	cmd.SetArgs([]string{"validate", path})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, stderr.String(), "created_at:")
+	assert.Contains(t, stderr.String(), "ISO 8601")
+}
+
+// -----------------------------------------------------------------------
+// Invalid labels test
+// -----------------------------------------------------------------------
+
+func TestRunValidate_InvalidLabels(t *testing.T) {
+	resetValidateFlags()
+	content := `{"id":"str-12345678","title":"Fix bug","type":"task","priority":2,"status":"open","created_by":"stringer","labels":"not-an-array"}` + "\n"
+	path := writeJSONLFile(t, content)
+
+	cmd, _, stderr := newTestCmd()
+	cmd.SetArgs([]string{"validate", path})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, stderr.String(), "labels:")
+}
+
+// -----------------------------------------------------------------------
+// --bd-check flag behavior (bd not on PATH)
+// -----------------------------------------------------------------------
+
+func TestRunValidate_BdCheckNoBd(t *testing.T) {
+	resetValidateFlags()
+	path := writeJSONLFile(t, validJSONL+"\n")
+
+	// Override PATH to ensure bd is not found.
+	origPath := os.Getenv("PATH")
+	t.Setenv("PATH", t.TempDir()) // empty dir, no binaries
+	t.Cleanup(func() { _ = os.Setenv("PATH", origPath) })
+
+	cmd, stdout, stderr := newTestCmd()
+	cmd.SetArgs([]string{"validate", path, "--bd-check"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "valid: 1 beads")
+	assert.Contains(t, stderr.String(), "not found on PATH")
+}
+
+// -----------------------------------------------------------------------
+// --bd-check with stdin (should skip)
+// -----------------------------------------------------------------------
+
+func TestRunValidate_BdCheckStdinSkip(t *testing.T) {
+	resetValidateFlags()
+
+	// Create a pipe for stdin.
+	pipeR, pipeW, err := os.Pipe()
+	require.NoError(t, err)
+	_, _ = pipeW.WriteString(validJSONL + "\n")
+	_ = pipeW.Close()
+
+	// Temporarily replace os.Stdin.
+	origStdin := os.Stdin
+	os.Stdin = pipeR
+	t.Cleanup(func() { os.Stdin = origStdin })
+
+	// Make sure bd is not on path so we get the skip message, not a bd error.
+	origPath := os.Getenv("PATH")
+	t.Setenv("PATH", t.TempDir())
+	t.Cleanup(func() { _ = os.Setenv("PATH", origPath) })
+
+	cmd := rootCmd
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetArgs([]string{"validate", "--bd-check"})
+
+	execErr := cmd.Execute()
+	require.NoError(t, execErr)
+	assert.Contains(t, stdout.String(), "valid: 1 beads")
+}
+
+// -----------------------------------------------------------------------
+// Mixed valid and invalid lines — summary message
+// -----------------------------------------------------------------------
+
+func TestRunValidate_MixedLines(t *testing.T) {
+	resetValidateFlags()
+	content := validJSONL + "\n" +
+		`{"id":"bad"}` + "\n" +
+		validJSONL + "\n"
+	path := writeJSONLFile(t, content)
+
+	cmd, _, stderr := newTestCmd()
+	cmd.SetArgs([]string{"validate", path})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+
+	out := stderr.String()
+	assert.Contains(t, out, "error(s) found in 3 lines")
+}
+
+// -----------------------------------------------------------------------
+// Priority edge cases via CLI
+// -----------------------------------------------------------------------
+
+func TestRunValidate_PriorityBoundary(t *testing.T) {
+	resetValidateFlags()
+
+	tests := []struct {
+		name    string
+		content string
+		valid   bool
+	}{
+		{"zero", `{"id":"str-12345678","title":"T","type":"task","priority":0,"status":"open","created_by":"s"}`, true},
+		{"four", `{"id":"str-12345678","title":"T","type":"task","priority":4,"status":"open","created_by":"s"}`, true},
+		{"five", `{"id":"str-12345678","title":"T","type":"task","priority":5,"status":"open","created_by":"s"}`, false},
+		{"neg", `{"id":"str-12345678","title":"T","type":"task","priority":-1,"status":"open","created_by":"s"}`, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetValidateFlags()
+			path := writeJSONLFile(t, tt.content+"\n")
+
+			cmd, _, _ := newTestCmd()
+			cmd.SetArgs([]string{"validate", path})
+
+			err := cmd.Execute()
+			if tt.valid {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
+}
+
+// -----------------------------------------------------------------------
+// Validate registered in root command
+// -----------------------------------------------------------------------
+
+func TestRootCmd_HasValidateSubcommand(t *testing.T) {
+	found := false
+	for _, sub := range rootCmd.Commands() {
+		if sub.Name() == "validate" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "validate subcommand should be registered")
+}

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -1,0 +1,431 @@
+// Package validate provides JSONL validation against the bd import schema.
+// It checks each line of a JSONL file for required fields, valid types,
+// and correct formats, producing detailed error messages with fix suggestions.
+package validate
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+)
+
+// ValidTypes are the allowed values for the "type" field in a bead record.
+var ValidTypes = []string{"bug", "task", "chore", "epic", "feature"}
+
+// ValidStatuses are the allowed values for the "status" field in a bead record.
+var ValidStatuses = []string{"open", "closed"}
+
+// ValidationError represents a single validation issue on a specific line.
+type ValidationError struct {
+	Line       int    // 1-based line number
+	Field      string // field name (empty if line-level error)
+	Message    string // what's wrong
+	Suggestion string // how to fix it
+}
+
+// Error implements the error interface.
+func (e *ValidationError) Error() string {
+	if e.Field != "" {
+		return fmt.Sprintf("line %d: %s", e.Line, e.Message)
+	}
+	return fmt.Sprintf("line %d: %s", e.Line, e.Message)
+}
+
+// Result contains the outcome of validating a JSONL file.
+type Result struct {
+	TotalLines int
+	Errors     []ValidationError
+}
+
+// Valid returns true if no errors were found.
+func (r *Result) Valid() bool {
+	return len(r.Errors) == 0
+}
+
+// Validate reads JSONL from r and validates each line against the bd import schema.
+// It returns a Result with all validation errors found.
+func Validate(r io.Reader) *Result {
+	result := &Result{}
+	scanner := bufio.NewScanner(r)
+
+	lineNum := 0
+	for scanner.Scan() {
+		lineNum++
+		line := strings.TrimSpace(scanner.Text())
+
+		// Skip empty lines.
+		if line == "" {
+			continue
+		}
+
+		result.TotalLines++
+		validateLine(line, lineNum, result)
+	}
+
+	return result
+}
+
+// validateLine parses a single JSON line and checks all fields.
+func validateLine(line string, lineNum int, result *Result) {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(line), &raw); err != nil {
+		result.Errors = append(result.Errors, ValidationError{
+			Line:       lineNum,
+			Message:    fmt.Sprintf("invalid JSON: %v", err),
+			Suggestion: "ensure each line is a valid JSON object",
+		})
+		return
+	}
+
+	// Check required fields.
+	checkRequiredString(raw, "id", lineNum, result)
+	checkRequiredString(raw, "title", lineNum, result)
+	checkType(raw, lineNum, result)
+	checkPriority(raw, lineNum, result)
+	checkStatus(raw, lineNum, result)
+	checkRequiredString(raw, "created_by", lineNum, result)
+
+	// Check optional fields if present.
+	checkOptionalTimestamp(raw, "created_at", lineNum, result)
+	checkOptionalTimestamp(raw, "closed_at", lineNum, result)
+	checkOptionalLabels(raw, lineNum, result)
+	checkOptionalString(raw, "description", lineNum, result)
+	checkOptionalString(raw, "close_reason", lineNum, result)
+}
+
+// checkRequiredString validates that a required string field is present and non-empty.
+func checkRequiredString(raw map[string]json.RawMessage, field string, lineNum int, result *Result) {
+	val, ok := raw[field]
+	if !ok {
+		result.Errors = append(result.Errors, ValidationError{
+			Line:       lineNum,
+			Field:      field,
+			Message:    fmt.Sprintf("missing required field %q", field),
+			Suggestion: fmt.Sprintf("add a %q field with a descriptive string", field),
+		})
+		return
+	}
+
+	var s string
+	if err := json.Unmarshal(val, &s); err != nil {
+		result.Errors = append(result.Errors, ValidationError{
+			Line:       lineNum,
+			Field:      field,
+			Message:    fmt.Sprintf("field %q must be a string", field),
+			Suggestion: fmt.Sprintf("set %q to a JSON string value", field),
+		})
+		return
+	}
+
+	if s == "" {
+		result.Errors = append(result.Errors, ValidationError{
+			Line:       lineNum,
+			Field:      field,
+			Message:    fmt.Sprintf("field %q must not be empty", field),
+			Suggestion: fmt.Sprintf("provide a non-empty value for %q", field),
+		})
+	}
+}
+
+// checkType validates the "type" field.
+func checkType(raw map[string]json.RawMessage, lineNum int, result *Result) {
+	val, ok := raw["type"]
+	if !ok {
+		result.Errors = append(result.Errors, ValidationError{
+			Line:       lineNum,
+			Field:      "type",
+			Message:    "missing required field \"type\"",
+			Suggestion: fmt.Sprintf("add a \"type\" field with one of: %s", strings.Join(ValidTypes, ", ")),
+		})
+		return
+	}
+
+	var s string
+	if err := json.Unmarshal(val, &s); err != nil {
+		result.Errors = append(result.Errors, ValidationError{
+			Line:       lineNum,
+			Field:      "type",
+			Message:    "field \"type\" must be a string",
+			Suggestion: fmt.Sprintf("set \"type\" to one of: %s", strings.Join(ValidTypes, ", ")),
+		})
+		return
+	}
+
+	for _, valid := range ValidTypes {
+		if s == valid {
+			return
+		}
+	}
+
+	suggestion := fmt.Sprintf("type must be one of: %s", strings.Join(ValidTypes, ", "))
+	if hint := suggestType(s); hint != "" {
+		suggestion = fmt.Sprintf("did you mean %q?", hint)
+	}
+
+	result.Errors = append(result.Errors, ValidationError{
+		Line:       lineNum,
+		Field:      "type",
+		Message:    fmt.Sprintf("invalid type %q", s),
+		Suggestion: suggestion,
+	})
+}
+
+// checkPriority validates the "priority" field.
+func checkPriority(raw map[string]json.RawMessage, lineNum int, result *Result) {
+	val, ok := raw["priority"]
+	if !ok {
+		result.Errors = append(result.Errors, ValidationError{
+			Line:       lineNum,
+			Field:      "priority",
+			Message:    "missing required field \"priority\"",
+			Suggestion: "add a \"priority\" field with an integer 0-4",
+		})
+		return
+	}
+
+	var f float64
+	if err := json.Unmarshal(val, &f); err != nil {
+		result.Errors = append(result.Errors, ValidationError{
+			Line:       lineNum,
+			Field:      "priority",
+			Message:    "field \"priority\" must be an integer",
+			Suggestion: "set \"priority\" to an integer 0-4",
+		})
+		return
+	}
+
+	p := int(f)
+	if float64(p) != f {
+		result.Errors = append(result.Errors, ValidationError{
+			Line:       lineNum,
+			Field:      "priority",
+			Message:    fmt.Sprintf("priority must be an integer, got %v", f),
+			Suggestion: "priority must be 0-4",
+		})
+		return
+	}
+
+	if p < 0 || p > 4 {
+		result.Errors = append(result.Errors, ValidationError{
+			Line:       lineNum,
+			Field:      "priority",
+			Message:    fmt.Sprintf("invalid priority %d", p),
+			Suggestion: "priority must be 0-4",
+		})
+	}
+}
+
+// checkStatus validates the "status" field.
+func checkStatus(raw map[string]json.RawMessage, lineNum int, result *Result) {
+	val, ok := raw["status"]
+	if !ok {
+		result.Errors = append(result.Errors, ValidationError{
+			Line:       lineNum,
+			Field:      "status",
+			Message:    "missing required field \"status\"",
+			Suggestion: fmt.Sprintf("add a \"status\" field with one of: %s", strings.Join(ValidStatuses, ", ")),
+		})
+		return
+	}
+
+	var s string
+	if err := json.Unmarshal(val, &s); err != nil {
+		result.Errors = append(result.Errors, ValidationError{
+			Line:       lineNum,
+			Field:      "status",
+			Message:    "field \"status\" must be a string",
+			Suggestion: fmt.Sprintf("set \"status\" to one of: %s", strings.Join(ValidStatuses, ", ")),
+		})
+		return
+	}
+
+	for _, valid := range ValidStatuses {
+		if s == valid {
+			return
+		}
+	}
+
+	suggestion := fmt.Sprintf("status must be one of: %s", strings.Join(ValidStatuses, ", "))
+	if hint := suggestStatus(s); hint != "" {
+		suggestion = fmt.Sprintf("did you mean %q?", hint)
+	}
+
+	result.Errors = append(result.Errors, ValidationError{
+		Line:       lineNum,
+		Field:      "status",
+		Message:    fmt.Sprintf("invalid status %q", s),
+		Suggestion: suggestion,
+	})
+}
+
+// checkOptionalTimestamp validates an optional ISO 8601 timestamp field.
+func checkOptionalTimestamp(raw map[string]json.RawMessage, field string, lineNum int, result *Result) {
+	val, ok := raw[field]
+	if !ok {
+		return
+	}
+
+	var s string
+	if err := json.Unmarshal(val, &s); err != nil {
+		result.Errors = append(result.Errors, ValidationError{
+			Line:       lineNum,
+			Field:      field,
+			Message:    fmt.Sprintf("field %q must be a string", field),
+			Suggestion: fmt.Sprintf("set %q to an ISO 8601 timestamp (e.g., \"2024-01-15T10:30:00Z\")", field),
+		})
+		return
+	}
+
+	// Empty string is allowed for optional timestamps.
+	if s == "" {
+		return
+	}
+
+	if !isValidISO8601(s) {
+		result.Errors = append(result.Errors, ValidationError{
+			Line:       lineNum,
+			Field:      field,
+			Message:    fmt.Sprintf("field %q is not a valid ISO 8601 timestamp: %q", field, s),
+			Suggestion: fmt.Sprintf("use ISO 8601 format for %q (e.g., \"2024-01-15T10:30:00Z\")", field),
+		})
+	}
+}
+
+// checkOptionalLabels validates the optional "labels" field.
+func checkOptionalLabels(raw map[string]json.RawMessage, lineNum int, result *Result) {
+	val, ok := raw["labels"]
+	if !ok {
+		return
+	}
+
+	var labels []json.RawMessage
+	if err := json.Unmarshal(val, &labels); err != nil {
+		result.Errors = append(result.Errors, ValidationError{
+			Line:       lineNum,
+			Field:      "labels",
+			Message:    "field \"labels\" must be an array of strings",
+			Suggestion: "set \"labels\" to a JSON array of strings (e.g., [\"bug\", \"high-priority\"])",
+		})
+		return
+	}
+
+	for i, lbl := range labels {
+		var s string
+		if err := json.Unmarshal(lbl, &s); err != nil {
+			result.Errors = append(result.Errors, ValidationError{
+				Line:       lineNum,
+				Field:      "labels",
+				Message:    fmt.Sprintf("labels[%d] must be a string", i),
+				Suggestion: "all labels must be strings",
+			})
+		}
+	}
+}
+
+// checkOptionalString validates an optional string field if present.
+func checkOptionalString(raw map[string]json.RawMessage, field string, lineNum int, result *Result) {
+	val, ok := raw[field]
+	if !ok {
+		return
+	}
+
+	var s string
+	if err := json.Unmarshal(val, &s); err != nil {
+		result.Errors = append(result.Errors, ValidationError{
+			Line:       lineNum,
+			Field:      field,
+			Message:    fmt.Sprintf("field %q must be a string", field),
+			Suggestion: fmt.Sprintf("set %q to a JSON string value", field),
+		})
+	}
+	_ = s // value is not used; just checking type
+}
+
+// isValidISO8601 checks if a string is a valid ISO 8601 timestamp.
+// It accepts several common ISO 8601 formats.
+func isValidISO8601(s string) bool {
+	formats := []string{
+		time.RFC3339,
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05Z",
+		"2006-01-02T15:04:05-07:00",
+		"2006-01-02T15:04:05",
+		"2006-01-02",
+	}
+	for _, f := range formats {
+		if _, err := time.Parse(f, s); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// suggestType uses Levenshtein distance to suggest a valid type for a misspelled one.
+func suggestType(input string) string {
+	return closestMatch(strings.ToLower(input), ValidTypes, 3)
+}
+
+// suggestStatus uses Levenshtein distance to suggest a valid status for a misspelled one.
+func suggestStatus(input string) string {
+	return closestMatch(strings.ToLower(input), ValidStatuses, 3)
+}
+
+// closestMatch finds the closest string in candidates to input using
+// Levenshtein distance. Returns empty string if no match is within maxDist.
+func closestMatch(input string, candidates []string, maxDist int) string {
+	best := ""
+	bestDist := maxDist + 1
+
+	for _, c := range candidates {
+		d := levenshtein(input, c)
+		if d < bestDist {
+			bestDist = d
+			best = c
+		}
+	}
+
+	if bestDist <= maxDist {
+		return best
+	}
+	return ""
+}
+
+// levenshtein computes the Levenshtein edit distance between two strings.
+func levenshtein(a, b string) int {
+	la, lb := len(a), len(b)
+	if la == 0 {
+		return lb
+	}
+	if lb == 0 {
+		return la
+	}
+
+	// Use a single-row DP approach.
+	prev := make([]int, lb+1)
+	curr := make([]int, lb+1)
+
+	for j := 0; j <= lb; j++ {
+		prev[j] = j
+	}
+
+	for i := 1; i <= la; i++ {
+		curr[0] = i
+		for j := 1; j <= lb; j++ {
+			cost := 1
+			if a[i-1] == b[j-1] {
+				cost = 0
+			}
+			curr[j] = min(
+				prev[j]+1,      // deletion
+				curr[j-1]+1,    // insertion
+				prev[j-1]+cost, // substitution
+			)
+		}
+		prev, curr = curr, prev
+	}
+
+	return prev[lb]
+}

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -1,0 +1,532 @@
+package validate
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// validLine is a minimal valid JSONL line for testing.
+const validLine = `{"id":"str-12345678","title":"Fix bug","type":"task","priority":2,"status":"open","created_by":"stringer"}`
+
+func TestValidate_ValidLine(t *testing.T) {
+	r := strings.NewReader(validLine + "\n")
+	result := Validate(r)
+	assert.True(t, result.Valid())
+	assert.Equal(t, 1, result.TotalLines)
+	assert.Empty(t, result.Errors)
+}
+
+func TestValidate_MultipleValidLines(t *testing.T) {
+	input := validLine + "\n" +
+		`{"id":"str-87654321","title":"Add feature","type":"feature","priority":1,"status":"open","created_by":"alice"}` + "\n" +
+		`{"id":"str-abcdef12","title":"Clean up","type":"chore","priority":3,"status":"closed","created_by":"bob","closed_at":"2024-01-15T10:30:00Z"}` + "\n"
+	r := strings.NewReader(input)
+	result := Validate(r)
+	assert.True(t, result.Valid())
+	assert.Equal(t, 3, result.TotalLines)
+}
+
+func TestValidate_EmptyInput(t *testing.T) {
+	r := strings.NewReader("")
+	result := Validate(r)
+	assert.True(t, result.Valid())
+	assert.Equal(t, 0, result.TotalLines)
+}
+
+func TestValidate_EmptyLines(t *testing.T) {
+	input := "\n\n" + validLine + "\n\n"
+	r := strings.NewReader(input)
+	result := Validate(r)
+	assert.True(t, result.Valid())
+	assert.Equal(t, 1, result.TotalLines)
+}
+
+func TestValidate_InvalidJSON(t *testing.T) {
+	r := strings.NewReader("not json\n")
+	result := Validate(r)
+	assert.False(t, result.Valid())
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, 1, result.Errors[0].Line)
+	assert.Contains(t, result.Errors[0].Message, "invalid JSON")
+	assert.Contains(t, result.Errors[0].Suggestion, "valid JSON")
+}
+
+func TestValidate_MissingID(t *testing.T) {
+	line := `{"title":"Fix bug","type":"task","priority":2,"status":"open","created_by":"stringer"}`
+	r := strings.NewReader(line + "\n")
+	result := Validate(r)
+	assert.False(t, result.Valid())
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "id", result.Errors[0].Field)
+	assert.Contains(t, result.Errors[0].Message, "missing required field")
+}
+
+func TestValidate_MissingTitle(t *testing.T) {
+	line := `{"id":"str-12345678","type":"task","priority":2,"status":"open","created_by":"stringer"}`
+	r := strings.NewReader(line + "\n")
+	result := Validate(r)
+	assert.False(t, result.Valid())
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "title", result.Errors[0].Field)
+	assert.Contains(t, result.Errors[0].Message, "missing required field")
+}
+
+func TestValidate_MissingType(t *testing.T) {
+	line := `{"id":"str-12345678","title":"Fix bug","priority":2,"status":"open","created_by":"stringer"}`
+	r := strings.NewReader(line + "\n")
+	result := Validate(r)
+	assert.False(t, result.Valid())
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "type", result.Errors[0].Field)
+}
+
+func TestValidate_MissingPriority(t *testing.T) {
+	line := `{"id":"str-12345678","title":"Fix bug","type":"task","status":"open","created_by":"stringer"}`
+	r := strings.NewReader(line + "\n")
+	result := Validate(r)
+	assert.False(t, result.Valid())
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "priority", result.Errors[0].Field)
+}
+
+func TestValidate_MissingStatus(t *testing.T) {
+	line := `{"id":"str-12345678","title":"Fix bug","type":"task","priority":2,"created_by":"stringer"}`
+	r := strings.NewReader(line + "\n")
+	result := Validate(r)
+	assert.False(t, result.Valid())
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "status", result.Errors[0].Field)
+}
+
+func TestValidate_MissingCreatedBy(t *testing.T) {
+	line := `{"id":"str-12345678","title":"Fix bug","type":"task","priority":2,"status":"open"}`
+	r := strings.NewReader(line + "\n")
+	result := Validate(r)
+	assert.False(t, result.Valid())
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "created_by", result.Errors[0].Field)
+}
+
+func TestValidate_MultipleRequiredFieldsMissing(t *testing.T) {
+	line := `{"id":"str-12345678"}`
+	r := strings.NewReader(line + "\n")
+	result := Validate(r)
+	assert.False(t, result.Valid())
+	assert.GreaterOrEqual(t, len(result.Errors), 4) // title, type, priority, status, created_by
+}
+
+func TestValidate_InvalidType(t *testing.T) {
+	line := `{"id":"str-12345678","title":"Fix bug","type":"enhancement","priority":2,"status":"open","created_by":"stringer"}`
+	r := strings.NewReader(line + "\n")
+	result := Validate(r)
+	assert.False(t, result.Valid())
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "type", result.Errors[0].Field)
+	assert.Contains(t, result.Errors[0].Message, "invalid type")
+}
+
+func TestValidate_InvalidType_DidYouMean(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"bugg", "bug"},
+		{"taks", "task"},
+		{"chor", "chore"},
+		{"epics", "epic"},
+		{"featur", "feature"},
+		{"enhancement", ""}, // too far from any valid type
+		{"xyz_unknown", ""}, // no reasonable suggestion
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			line := `{"id":"str-12345678","title":"Fix bug","type":"` + tt.input + `","priority":2,"status":"open","created_by":"stringer"}`
+			r := strings.NewReader(line + "\n")
+			result := Validate(r)
+			require.Len(t, result.Errors, 1)
+			if tt.want != "" {
+				assert.Contains(t, result.Errors[0].Suggestion, "did you mean")
+				assert.Contains(t, result.Errors[0].Suggestion, tt.want)
+			} else {
+				assert.Contains(t, result.Errors[0].Suggestion, "type must be one of")
+			}
+		})
+	}
+}
+
+func TestValidate_InvalidStatus(t *testing.T) {
+	line := `{"id":"str-12345678","title":"Fix bug","type":"task","priority":2,"status":"done","created_by":"stringer"}`
+	r := strings.NewReader(line + "\n")
+	result := Validate(r)
+	assert.False(t, result.Valid())
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "status", result.Errors[0].Field)
+	assert.Contains(t, result.Errors[0].Message, "invalid status")
+}
+
+func TestValidate_InvalidStatus_DidYouMean(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"opn", "open"},
+		{"close", "closed"},
+		{"closd", "closed"},
+		{"xyz_unknown", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			line := `{"id":"str-12345678","title":"Fix bug","type":"task","priority":2,"status":"` + tt.input + `","created_by":"stringer"}`
+			r := strings.NewReader(line + "\n")
+			result := Validate(r)
+			require.Len(t, result.Errors, 1)
+			if tt.want != "" {
+				assert.Contains(t, result.Errors[0].Suggestion, "did you mean")
+			} else {
+				assert.Contains(t, result.Errors[0].Suggestion, "status must be one of")
+			}
+		})
+	}
+}
+
+func TestValidate_PriorityOutOfRange(t *testing.T) {
+	tests := []struct {
+		name     string
+		priority string
+	}{
+		{"too high", "7"},
+		{"negative", "-1"},
+		{"way too high", "100"},
+		{"five", "5"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			line := `{"id":"str-12345678","title":"Fix bug","type":"task","priority":` + tt.priority + `,"status":"open","created_by":"stringer"}`
+			r := strings.NewReader(line + "\n")
+			result := Validate(r)
+			assert.False(t, result.Valid())
+			require.Len(t, result.Errors, 1)
+			assert.Equal(t, "priority", result.Errors[0].Field)
+			assert.Contains(t, result.Errors[0].Suggestion, "0-4")
+		})
+	}
+}
+
+func TestValidate_PriorityNotInteger(t *testing.T) {
+	line := `{"id":"str-12345678","title":"Fix bug","type":"task","priority":"high","status":"open","created_by":"stringer"}`
+	r := strings.NewReader(line + "\n")
+	result := Validate(r)
+	assert.False(t, result.Valid())
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "priority", result.Errors[0].Field)
+	assert.Contains(t, result.Errors[0].Message, "must be an integer")
+}
+
+func TestValidate_PriorityFloat(t *testing.T) {
+	line := `{"id":"str-12345678","title":"Fix bug","type":"task","priority":2.5,"status":"open","created_by":"stringer"}`
+	r := strings.NewReader(line + "\n")
+	result := Validate(r)
+	assert.False(t, result.Valid())
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "priority", result.Errors[0].Field)
+	assert.Contains(t, result.Errors[0].Message, "must be an integer")
+}
+
+func TestValidate_PriorityZero(t *testing.T) {
+	line := `{"id":"str-12345678","title":"Fix bug","type":"task","priority":0,"status":"open","created_by":"stringer"}`
+	r := strings.NewReader(line + "\n")
+	result := Validate(r)
+	assert.True(t, result.Valid())
+}
+
+func TestValidate_PriorityFour(t *testing.T) {
+	line := `{"id":"str-12345678","title":"Fix bug","type":"task","priority":4,"status":"open","created_by":"stringer"}`
+	r := strings.NewReader(line + "\n")
+	result := Validate(r)
+	assert.True(t, result.Valid())
+}
+
+func TestValidate_InvalidCreatedAt(t *testing.T) {
+	line := `{"id":"str-12345678","title":"Fix bug","type":"task","priority":2,"status":"open","created_by":"stringer","created_at":"not-a-date"}`
+	r := strings.NewReader(line + "\n")
+	result := Validate(r)
+	assert.False(t, result.Valid())
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "created_at", result.Errors[0].Field)
+	assert.Contains(t, result.Errors[0].Message, "not a valid ISO 8601")
+}
+
+func TestValidate_InvalidClosedAt(t *testing.T) {
+	line := `{"id":"str-12345678","title":"Fix bug","type":"task","priority":2,"status":"closed","created_by":"stringer","closed_at":"yesterday"}`
+	r := strings.NewReader(line + "\n")
+	result := Validate(r)
+	assert.False(t, result.Valid())
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "closed_at", result.Errors[0].Field)
+}
+
+func TestValidate_ValidTimestampFormats(t *testing.T) {
+	timestamps := []string{
+		"2024-01-15T10:30:00Z",
+		"2024-01-15T10:30:00+05:00",
+		"2024-01-15T10:30:00-07:00",
+		"2024-01-15T10:30:00.123456Z",
+		"2024-01-15",
+	}
+
+	for _, ts := range timestamps {
+		t.Run(ts, func(t *testing.T) {
+			line := `{"id":"str-12345678","title":"Fix bug","type":"task","priority":2,"status":"open","created_by":"stringer","created_at":"` + ts + `"}`
+			r := strings.NewReader(line + "\n")
+			result := Validate(r)
+			assert.True(t, result.Valid(), "timestamp %q should be valid, got errors: %v", ts, result.Errors)
+		})
+	}
+}
+
+func TestValidate_EmptyTimestampIsValid(t *testing.T) {
+	line := `{"id":"str-12345678","title":"Fix bug","type":"task","priority":2,"status":"open","created_by":"stringer","created_at":""}`
+	r := strings.NewReader(line + "\n")
+	result := Validate(r)
+	assert.True(t, result.Valid())
+}
+
+func TestValidate_InvalidLabels_NotArray(t *testing.T) {
+	line := `{"id":"str-12345678","title":"Fix bug","type":"task","priority":2,"status":"open","created_by":"stringer","labels":"bug"}`
+	r := strings.NewReader(line + "\n")
+	result := Validate(r)
+	assert.False(t, result.Valid())
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "labels", result.Errors[0].Field)
+	assert.Contains(t, result.Errors[0].Message, "array of strings")
+}
+
+func TestValidate_InvalidLabels_NonStringElement(t *testing.T) {
+	line := `{"id":"str-12345678","title":"Fix bug","type":"task","priority":2,"status":"open","created_by":"stringer","labels":["bug",123]}`
+	r := strings.NewReader(line + "\n")
+	result := Validate(r)
+	assert.False(t, result.Valid())
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "labels", result.Errors[0].Field)
+	assert.Contains(t, result.Errors[0].Message, "labels[1] must be a string")
+}
+
+func TestValidate_ValidLabels(t *testing.T) {
+	line := `{"id":"str-12345678","title":"Fix bug","type":"task","priority":2,"status":"open","created_by":"stringer","labels":["bug","high-priority","stringer-generated"]}`
+	r := strings.NewReader(line + "\n")
+	result := Validate(r)
+	assert.True(t, result.Valid())
+}
+
+func TestValidate_AllOptionalFields(t *testing.T) {
+	line := `{"id":"str-12345678","title":"Fix bug","type":"task","priority":2,"status":"closed","created_by":"stringer","created_at":"2024-01-15T10:30:00Z","closed_at":"2024-02-01T12:00:00Z","labels":["bug"],"description":"A detailed description","close_reason":"resolved"}`
+	r := strings.NewReader(line + "\n")
+	result := Validate(r)
+	assert.True(t, result.Valid())
+}
+
+func TestValidate_AllTypes(t *testing.T) {
+	for _, typ := range ValidTypes {
+		t.Run(typ, func(t *testing.T) {
+			line := `{"id":"str-12345678","title":"Test","type":"` + typ + `","priority":2,"status":"open","created_by":"stringer"}`
+			r := strings.NewReader(line + "\n")
+			result := Validate(r)
+			assert.True(t, result.Valid(), "type %q should be valid", typ)
+		})
+	}
+}
+
+func TestValidate_AllStatuses(t *testing.T) {
+	for _, status := range ValidStatuses {
+		t.Run(status, func(t *testing.T) {
+			line := `{"id":"str-12345678","title":"Test","type":"task","priority":2,"status":"` + status + `","created_by":"stringer"}`
+			r := strings.NewReader(line + "\n")
+			result := Validate(r)
+			assert.True(t, result.Valid(), "status %q should be valid", status)
+		})
+	}
+}
+
+func TestValidate_EmptyID(t *testing.T) {
+	line := `{"id":"","title":"Fix bug","type":"task","priority":2,"status":"open","created_by":"stringer"}`
+	r := strings.NewReader(line + "\n")
+	result := Validate(r)
+	assert.False(t, result.Valid())
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "id", result.Errors[0].Field)
+	assert.Contains(t, result.Errors[0].Message, "must not be empty")
+}
+
+func TestValidate_EmptyTitle(t *testing.T) {
+	line := `{"id":"str-12345678","title":"","type":"task","priority":2,"status":"open","created_by":"stringer"}`
+	r := strings.NewReader(line + "\n")
+	result := Validate(r)
+	assert.False(t, result.Valid())
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "title", result.Errors[0].Field)
+	assert.Contains(t, result.Errors[0].Message, "must not be empty")
+}
+
+func TestValidate_NonStringID(t *testing.T) {
+	line := `{"id":12345,"title":"Fix bug","type":"task","priority":2,"status":"open","created_by":"stringer"}`
+	r := strings.NewReader(line + "\n")
+	result := Validate(r)
+	assert.False(t, result.Valid())
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "id", result.Errors[0].Field)
+	assert.Contains(t, result.Errors[0].Message, "must be a string")
+}
+
+func TestValidate_NonStringType(t *testing.T) {
+	line := `{"id":"str-12345678","title":"Fix bug","type":1,"priority":2,"status":"open","created_by":"stringer"}`
+	r := strings.NewReader(line + "\n")
+	result := Validate(r)
+	assert.False(t, result.Valid())
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "type", result.Errors[0].Field)
+	assert.Contains(t, result.Errors[0].Message, "must be a string")
+}
+
+func TestValidate_NonStringStatus(t *testing.T) {
+	line := `{"id":"str-12345678","title":"Fix bug","type":"task","priority":2,"status":true,"created_by":"stringer"}`
+	r := strings.NewReader(line + "\n")
+	result := Validate(r)
+	assert.False(t, result.Valid())
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "status", result.Errors[0].Field)
+	assert.Contains(t, result.Errors[0].Message, "must be a string")
+}
+
+func TestValidate_MixedValidAndInvalidLines(t *testing.T) {
+	input := validLine + "\n" +
+		`{"id":"str-bad","type":"wrong","priority":10}` + "\n" +
+		validLine + "\n"
+	r := strings.NewReader(input)
+	result := Validate(r)
+	assert.False(t, result.Valid())
+	assert.Equal(t, 3, result.TotalLines)
+	// Line 2 should have multiple errors (missing title, invalid type, invalid priority, missing status, missing created_by).
+	lineErrors := 0
+	for _, e := range result.Errors {
+		if e.Line == 2 {
+			lineErrors++
+		}
+	}
+	assert.GreaterOrEqual(t, lineErrors, 3, "line 2 should have multiple errors")
+}
+
+func TestValidate_DescriptionNotString(t *testing.T) {
+	line := `{"id":"str-12345678","title":"Fix bug","type":"task","priority":2,"status":"open","created_by":"stringer","description":42}`
+	r := strings.NewReader(line + "\n")
+	result := Validate(r)
+	assert.False(t, result.Valid())
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "description", result.Errors[0].Field)
+}
+
+func TestValidate_CloseReasonNotString(t *testing.T) {
+	line := `{"id":"str-12345678","title":"Fix bug","type":"task","priority":2,"status":"open","created_by":"stringer","close_reason":true}`
+	r := strings.NewReader(line + "\n")
+	result := Validate(r)
+	assert.False(t, result.Valid())
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "close_reason", result.Errors[0].Field)
+}
+
+func TestValidate_CreatedAtNotString(t *testing.T) {
+	line := `{"id":"str-12345678","title":"Fix bug","type":"task","priority":2,"status":"open","created_by":"stringer","created_at":12345}`
+	r := strings.NewReader(line + "\n")
+	result := Validate(r)
+	assert.False(t, result.Valid())
+	require.Len(t, result.Errors, 1)
+	assert.Equal(t, "created_at", result.Errors[0].Field)
+	assert.Contains(t, result.Errors[0].Message, "must be a string")
+}
+
+// -----------------------------------------------------------------------
+// Levenshtein distance tests
+// -----------------------------------------------------------------------
+
+func TestLevenshtein(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		{"", "", 0},
+		{"a", "", 1},
+		{"", "b", 1},
+		{"abc", "abc", 0},
+		{"abc", "abd", 1},
+		{"kitten", "sitting", 3},
+		{"bug", "bugg", 1},
+		{"task", "taks", 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.a+"_"+tt.b, func(t *testing.T) {
+			assert.Equal(t, tt.want, levenshtein(tt.a, tt.b))
+		})
+	}
+}
+
+func TestClosestMatch(t *testing.T) {
+	tests := []struct {
+		input      string
+		candidates []string
+		maxDist    int
+		want       string
+	}{
+		{"bugg", []string{"bug", "task", "chore"}, 3, "bug"},
+		{"xyz", []string{"bug", "task", "chore"}, 1, ""},
+		{"epik", []string{"epic", "feature"}, 2, "epic"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.want, closestMatch(tt.input, tt.candidates, tt.maxDist))
+		})
+	}
+}
+
+// -----------------------------------------------------------------------
+// ValidationError.Error()
+// -----------------------------------------------------------------------
+
+func TestValidationError_Error(t *testing.T) {
+	e := &ValidationError{
+		Line:    5,
+		Field:   "title",
+		Message: "missing required field \"title\"",
+	}
+	assert.Equal(t, "line 5: missing required field \"title\"", e.Error())
+}
+
+func TestValidationError_ErrorNoField(t *testing.T) {
+	e := &ValidationError{
+		Line:    3,
+		Message: "invalid JSON: unexpected end of JSON input",
+	}
+	assert.Equal(t, "line 3: invalid JSON: unexpected end of JSON input", e.Error())
+}
+
+// -----------------------------------------------------------------------
+// Result.Valid()
+// -----------------------------------------------------------------------
+
+func TestResult_Valid_Empty(t *testing.T) {
+	r := &Result{}
+	assert.True(t, r.Valid())
+}
+
+func TestResult_Valid_WithErrors(t *testing.T) {
+	r := &Result{
+		Errors: []ValidationError{{Line: 1, Message: "bad"}},
+	}
+	assert.False(t, r.Valid())
+}


### PR DESCRIPTION
Add stringer validate command for JSONL schema validation against bd import. Validates required/optional fields, reports errors with fix suggestions. Beads: stringer-754