### PR TITLE
feat: add LLM provider abstraction

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.24.0
 
 require (
 	github.com/BurntSushi/toml v1.6.0
+	github.com/anthropics/anthropic-sdk-go v1.22.1
 	github.com/fatih/color v1.18.0
 	github.com/go-git/go-git/v5 v5.16.5
 	github.com/google/go-github/v68 v68.0.0
@@ -38,6 +39,10 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
 	github.com/skeema/knownhosts v1.3.1 // indirect
+	github.com/tidwall/gjson v1.18.0 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.1 // indirect
+	github.com/tidwall/sjson v1.2.5 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	golang.org/x/crypto v0.47.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/ProtonMail/go-crypto v1.1.6 h1:ZcV+Ropw6Qn0AX9brlQLAUXfqLBc7Bl+f/DmNx
 github.com/ProtonMail/go-crypto v1.1.6/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
+github.com/anthropics/anthropic-sdk-go v1.22.1 h1:xbsc3vJKCX/ELDZSpTNfz9wCgrFsamwFewPb1iI0Xh0=
+github.com/anthropics/anthropic-sdk-go v1.22.1/go.mod h1:WTz31rIUHUHqai2UslPpw5CwXrQP3geYBioRV4WOLvE=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=
@@ -94,6 +96,16 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
+github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
+github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
+github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=

--- a/internal/llm/anthropic.go
+++ b/internal/llm/anthropic.go
@@ -1,0 +1,160 @@
+package llm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	"github.com/anthropics/anthropic-sdk-go/option"
+)
+
+const (
+	// defaultAnthropicModel is the model used when no override is provided.
+	defaultAnthropicModel = "claude-sonnet-4-5-20250929"
+
+	// defaultMaxTokens is the default maximum output tokens per request.
+	defaultMaxTokens = 4096
+
+	// defaultMaxRetries is the number of automatic retries on transient errors
+	// (429 rate-limit, 5xx server errors). The SDK handles exponential backoff.
+	defaultMaxRetries = 3
+)
+
+// AnthropicProvider implements Provider using the official Anthropic SDK.
+type AnthropicProvider struct {
+	client     anthropic.Client
+	model      string
+	maxRetries int
+}
+
+// Compile-time check that AnthropicProvider satisfies the Provider interface.
+var _ Provider = (*AnthropicProvider)(nil)
+
+// AnthropicOption configures an AnthropicProvider.
+type AnthropicOption func(*anthropicConfig)
+
+type anthropicConfig struct {
+	apiKey     string
+	model      string
+	maxRetries int
+}
+
+// WithAPIKey sets the API key. If not provided, the provider reads
+// ANTHROPIC_API_KEY from the environment.
+func WithAPIKey(key string) AnthropicOption {
+	return func(c *anthropicConfig) {
+		c.apiKey = key
+	}
+}
+
+// WithModel overrides the default model for all requests.
+func WithModel(model string) AnthropicOption {
+	return func(c *anthropicConfig) {
+		c.model = model
+	}
+}
+
+// WithMaxRetries sets the maximum number of retries for transient errors.
+func WithMaxRetries(n int) AnthropicOption {
+	return func(c *anthropicConfig) {
+		c.maxRetries = n
+	}
+}
+
+// NewAnthropicProvider creates a new Anthropic provider.
+// It returns an error if no API key is available (neither via option nor env).
+func NewAnthropicProvider(opts ...AnthropicOption) (*AnthropicProvider, error) {
+	cfg := anthropicConfig{
+		model:      defaultAnthropicModel,
+		maxRetries: defaultMaxRetries,
+	}
+	for _, o := range opts {
+		o(&cfg)
+	}
+
+	apiKey := cfg.apiKey
+	if apiKey == "" {
+		apiKey = os.Getenv("ANTHROPIC_API_KEY")
+	}
+	if apiKey == "" {
+		return nil, errors.New("llm: ANTHROPIC_API_KEY not set and no API key provided")
+	}
+
+	clientOpts := []option.RequestOption{
+		option.WithAPIKey(apiKey),
+		option.WithMaxRetries(cfg.maxRetries),
+	}
+
+	client := anthropic.NewClient(clientOpts...)
+
+	return &AnthropicProvider{
+		client:     client,
+		model:      cfg.model,
+		maxRetries: cfg.maxRetries,
+	}, nil
+}
+
+// Complete sends a completion request to the Anthropic Messages API.
+func (p *AnthropicProvider) Complete(ctx context.Context, req Request) (*Response, error) {
+	model := p.model
+	if req.Model != "" {
+		model = req.Model
+	}
+
+	maxTokens := int64(defaultMaxTokens)
+	if req.MaxTokens > 0 {
+		maxTokens = int64(req.MaxTokens)
+	}
+
+	params := anthropic.MessageNewParams{
+		Model:     anthropic.Model(model),
+		MaxTokens: maxTokens,
+		Messages: []anthropic.MessageParam{
+			anthropic.NewUserMessage(anthropic.NewTextBlock(req.Prompt)),
+		},
+	}
+
+	if req.SystemPrompt != "" {
+		params.System = []anthropic.TextBlockParam{
+			{Text: req.SystemPrompt},
+		}
+	}
+
+	if req.Temperature != nil {
+		params.Temperature = anthropic.Float(*req.Temperature)
+	}
+
+	msg, err := p.client.Messages.New(ctx, params)
+	if err != nil {
+		return nil, fmt.Errorf("anthropic: completion failed: %w", err)
+	}
+
+	// Extract text from content blocks.
+	var content string
+	for _, block := range msg.Content {
+		if variant, ok := block.AsAny().(anthropic.TextBlock); ok {
+			content += variant.Text
+		}
+	}
+
+	return &Response{
+		Content: content,
+		Model:   string(msg.Model),
+		Usage: Usage{
+			InputTokens:  int(msg.Usage.InputTokens),
+			OutputTokens: int(msg.Usage.OutputTokens),
+		},
+	}, nil
+}
+
+// Model returns the default model configured for this provider.
+func (p *AnthropicProvider) Model() string {
+	return p.model
+}
+
+// MaxRetries returns the configured max retry count.
+func (p *AnthropicProvider) MaxRetries() int {
+	return p.maxRetries
+}

--- a/internal/llm/anthropic_test.go
+++ b/internal/llm/anthropic_test.go
@@ -1,0 +1,85 @@
+package llm_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/davetashner/stringer/internal/llm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewAnthropicProvider_WithAPIKey(t *testing.T) {
+	p, err := llm.NewAnthropicProvider(llm.WithAPIKey("test-key-123"))
+	require.NoError(t, err)
+	assert.NotNil(t, p)
+}
+
+func TestNewAnthropicProvider_FromEnv(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "env-test-key")
+
+	p, err := llm.NewAnthropicProvider()
+	require.NoError(t, err)
+	assert.NotNil(t, p)
+}
+
+func TestNewAnthropicProvider_NoKeyError(t *testing.T) {
+	// Clear env to ensure no key is available.
+	t.Setenv("ANTHROPIC_API_KEY", "")
+
+	p, err := llm.NewAnthropicProvider()
+	assert.Nil(t, p)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ANTHROPIC_API_KEY")
+}
+
+func TestNewAnthropicProvider_OptionPrecedence(t *testing.T) {
+	// Explicit key should be used even when env is set.
+	t.Setenv("ANTHROPIC_API_KEY", "env-key")
+
+	p, err := llm.NewAnthropicProvider(llm.WithAPIKey("explicit-key"))
+	require.NoError(t, err)
+	assert.NotNil(t, p)
+}
+
+func TestAnthropicProvider_DefaultModel(t *testing.T) {
+	p, err := llm.NewAnthropicProvider(llm.WithAPIKey("test-key"))
+	require.NoError(t, err)
+	assert.Equal(t, "claude-sonnet-4-5-20250929", p.Model())
+}
+
+func TestAnthropicProvider_CustomModel(t *testing.T) {
+	p, err := llm.NewAnthropicProvider(
+		llm.WithAPIKey("test-key"),
+		llm.WithModel("claude-haiku-3-5-20241022"),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "claude-haiku-3-5-20241022", p.Model())
+}
+
+func TestAnthropicProvider_DefaultMaxRetries(t *testing.T) {
+	p, err := llm.NewAnthropicProvider(llm.WithAPIKey("test-key"))
+	require.NoError(t, err)
+	assert.Equal(t, 3, p.MaxRetries())
+}
+
+func TestAnthropicProvider_CustomMaxRetries(t *testing.T) {
+	p, err := llm.NewAnthropicProvider(
+		llm.WithAPIKey("test-key"),
+		llm.WithMaxRetries(5),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 5, p.MaxRetries())
+}
+
+func TestAnthropicProvider_ImplementsProvider(t *testing.T) {
+	// Skip if no API key (we only need construction, not API calls).
+	if os.Getenv("ANTHROPIC_API_KEY") == "" {
+		t.Setenv("ANTHROPIC_API_KEY", "test-key")
+	}
+
+	p, err := llm.NewAnthropicProvider()
+	require.NoError(t, err)
+
+	var _ llm.Provider = p
+}

--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -1,0 +1,51 @@
+// Package llm provides a provider-agnostic LLM client interface and
+// implementations for use by stringer's analysis features.
+package llm
+
+import "context"
+
+// Provider abstracts an LLM API behind a single synchronous completion method.
+type Provider interface {
+	// Complete sends a prompt to the LLM and returns the response.
+	// Implementations must respect context cancellation and deadlines.
+	Complete(ctx context.Context, req Request) (*Response, error)
+}
+
+// Request describes a single completion request.
+type Request struct {
+	// Prompt is the user message to send.
+	Prompt string
+
+	// Model overrides the provider's default model. If empty, the provider
+	// uses its configured default.
+	Model string
+
+	// MaxTokens limits the response length. If zero, the provider uses its
+	// own default.
+	MaxTokens int
+
+	// Temperature controls randomness. If nil, the provider uses its default.
+	Temperature *float64
+
+	// SystemPrompt sets the system instruction for the completion.
+	SystemPrompt string
+}
+
+// Response holds the result of a completion call.
+type Response struct {
+	// Content is the text returned by the model.
+	Content string
+
+	// Model is the model that actually served the request (may differ from
+	// the requested model if the provider remapped it).
+	Model string
+
+	// Usage reports token consumption.
+	Usage Usage
+}
+
+// Usage tracks input and output token counts for a single request.
+type Usage struct {
+	InputTokens  int
+	OutputTokens int
+}

--- a/internal/llm/llm_test.go
+++ b/internal/llm/llm_test.go
@@ -1,0 +1,36 @@
+package llm_test
+
+import (
+	"testing"
+
+	"github.com/davetashner/stringer/internal/llm"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestProviderInterfaceCompliance verifies that all provider types satisfy
+// the Provider interface at compile time. The var _ assignments above each
+// type already do this, but this test makes it explicit and documents the
+// contract in test output.
+func TestProviderInterfaceCompliance(t *testing.T) {
+	t.Run("MockProvider implements Provider", func(t *testing.T) {
+		var p llm.Provider = llm.NewMockProvider()
+		assert.NotNil(t, p)
+	})
+}
+
+func TestRequestZeroValue(t *testing.T) {
+	var req llm.Request
+	assert.Empty(t, req.Prompt)
+	assert.Empty(t, req.Model)
+	assert.Zero(t, req.MaxTokens)
+	assert.Nil(t, req.Temperature)
+	assert.Empty(t, req.SystemPrompt)
+}
+
+func TestResponseZeroValue(t *testing.T) {
+	var resp llm.Response
+	assert.Empty(t, resp.Content)
+	assert.Empty(t, resp.Model)
+	assert.Zero(t, resp.Usage.InputTokens)
+	assert.Zero(t, resp.Usage.OutputTokens)
+}

--- a/internal/llm/mock.go
+++ b/internal/llm/mock.go
@@ -1,0 +1,84 @@
+package llm
+
+import (
+	"context"
+	"sync"
+)
+
+// MockResponse defines a canned response for the mock provider.
+type MockResponse struct {
+	Content string
+	Err     error
+}
+
+// MockProvider is a test double that returns pre-configured responses in
+// sequence. After all responses are exhausted, it keeps returning the last one.
+// It records every request for later assertion.
+type MockProvider struct {
+	mu        sync.Mutex
+	responses []MockResponse
+	calls     []Request
+	idx       int
+}
+
+// Compile-time check that MockProvider satisfies the Provider interface.
+var _ Provider = (*MockProvider)(nil)
+
+// NewMockProvider creates a mock that returns the given responses in order.
+// If no responses are provided, Complete returns an empty Response.
+func NewMockProvider(responses ...MockResponse) *MockProvider {
+	return &MockProvider{
+		responses: responses,
+	}
+}
+
+// Complete returns the next canned response and records the request.
+// It respects context cancellation.
+func (m *MockProvider) Complete(ctx context.Context, req Request) (*Response, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.calls = append(m.calls, req)
+
+	if len(m.responses) == 0 {
+		return &Response{Content: "", Model: "mock"}, nil
+	}
+
+	r := m.responses[m.idx]
+	if m.idx < len(m.responses)-1 {
+		m.idx++
+	}
+
+	if r.Err != nil {
+		return nil, r.Err
+	}
+
+	return &Response{
+		Content: r.Content,
+		Model:   "mock",
+		Usage:   Usage{InputTokens: 10, OutputTokens: 5},
+	}, nil
+}
+
+// Calls returns a copy of all requests received by this mock.
+func (m *MockProvider) Calls() []Request {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	out := make([]Request, len(m.calls))
+	copy(out, m.calls)
+	return out
+}
+
+// Reset clears call history and resets the response index to zero.
+func (m *MockProvider) Reset() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.calls = nil
+	m.idx = 0
+}

--- a/internal/llm/mock_test.go
+++ b/internal/llm/mock_test.go
@@ -1,0 +1,190 @@
+package llm_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/davetashner/stringer/internal/llm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMockProvider_EmptyResponses(t *testing.T) {
+	m := llm.NewMockProvider()
+	resp, err := m.Complete(context.Background(), llm.Request{Prompt: "hello"})
+	require.NoError(t, err)
+	assert.Empty(t, resp.Content)
+	assert.Equal(t, "mock", resp.Model)
+}
+
+func TestMockProvider_SequentialResponses(t *testing.T) {
+	m := llm.NewMockProvider(
+		llm.MockResponse{Content: "first"},
+		llm.MockResponse{Content: "second"},
+		llm.MockResponse{Content: "third"},
+	)
+
+	ctx := context.Background()
+
+	resp1, err := m.Complete(ctx, llm.Request{Prompt: "a"})
+	require.NoError(t, err)
+	assert.Equal(t, "first", resp1.Content)
+
+	resp2, err := m.Complete(ctx, llm.Request{Prompt: "b"})
+	require.NoError(t, err)
+	assert.Equal(t, "second", resp2.Content)
+
+	resp3, err := m.Complete(ctx, llm.Request{Prompt: "c"})
+	require.NoError(t, err)
+	assert.Equal(t, "third", resp3.Content)
+}
+
+func TestMockProvider_StaysOnLastResponse(t *testing.T) {
+	m := llm.NewMockProvider(
+		llm.MockResponse{Content: "only"},
+	)
+
+	ctx := context.Background()
+
+	for range 5 {
+		resp, err := m.Complete(ctx, llm.Request{Prompt: "x"})
+		require.NoError(t, err)
+		assert.Equal(t, "only", resp.Content)
+	}
+}
+
+func TestMockProvider_ErrorResponse(t *testing.T) {
+	expectedErr := errors.New("api failure")
+	m := llm.NewMockProvider(
+		llm.MockResponse{Err: expectedErr},
+	)
+
+	resp, err := m.Complete(context.Background(), llm.Request{Prompt: "fail"})
+	assert.Nil(t, resp)
+	assert.ErrorIs(t, err, expectedErr)
+}
+
+func TestMockProvider_MixedResponses(t *testing.T) {
+	expectedErr := errors.New("temporary error")
+	m := llm.NewMockProvider(
+		llm.MockResponse{Content: "ok"},
+		llm.MockResponse{Err: expectedErr},
+		llm.MockResponse{Content: "recovered"},
+	)
+
+	ctx := context.Background()
+
+	resp1, err := m.Complete(ctx, llm.Request{Prompt: "1"})
+	require.NoError(t, err)
+	assert.Equal(t, "ok", resp1.Content)
+
+	resp2, err := m.Complete(ctx, llm.Request{Prompt: "2"})
+	assert.Nil(t, resp2)
+	assert.ErrorIs(t, err, expectedErr)
+
+	resp3, err := m.Complete(ctx, llm.Request{Prompt: "3"})
+	require.NoError(t, err)
+	assert.Equal(t, "recovered", resp3.Content)
+}
+
+func TestMockProvider_CallHistory(t *testing.T) {
+	m := llm.NewMockProvider(
+		llm.MockResponse{Content: "r1"},
+		llm.MockResponse{Content: "r2"},
+	)
+
+	ctx := context.Background()
+
+	_, _ = m.Complete(ctx, llm.Request{
+		Prompt:       "first prompt",
+		Model:        "test-model",
+		MaxTokens:    100,
+		SystemPrompt: "be helpful",
+	})
+	_, _ = m.Complete(ctx, llm.Request{
+		Prompt: "second prompt",
+	})
+
+	calls := m.Calls()
+	require.Len(t, calls, 2)
+
+	assert.Equal(t, "first prompt", calls[0].Prompt)
+	assert.Equal(t, "test-model", calls[0].Model)
+	assert.Equal(t, 100, calls[0].MaxTokens)
+	assert.Equal(t, "be helpful", calls[0].SystemPrompt)
+
+	assert.Equal(t, "second prompt", calls[1].Prompt)
+	assert.Empty(t, calls[1].Model)
+}
+
+func TestMockProvider_CancelledContext(t *testing.T) {
+	m := llm.NewMockProvider(
+		llm.MockResponse{Content: "should not get this"},
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	resp, err := m.Complete(ctx, llm.Request{Prompt: "cancelled"})
+	assert.Nil(t, resp)
+	assert.ErrorIs(t, err, context.Canceled)
+
+	// Cancelled requests should not be recorded.
+	assert.Empty(t, m.Calls())
+}
+
+func TestMockProvider_Reset(t *testing.T) {
+	m := llm.NewMockProvider(
+		llm.MockResponse{Content: "first"},
+		llm.MockResponse{Content: "second"},
+	)
+
+	ctx := context.Background()
+
+	resp, err := m.Complete(ctx, llm.Request{Prompt: "a"})
+	require.NoError(t, err)
+	assert.Equal(t, "first", resp.Content)
+	assert.Len(t, m.Calls(), 1)
+
+	m.Reset()
+	assert.Empty(t, m.Calls())
+
+	// After reset, responses start from the beginning again.
+	resp, err = m.Complete(ctx, llm.Request{Prompt: "b"})
+	require.NoError(t, err)
+	assert.Equal(t, "first", resp.Content)
+}
+
+func TestMockProvider_UsageReported(t *testing.T) {
+	m := llm.NewMockProvider(
+		llm.MockResponse{Content: "hello"},
+	)
+
+	resp, err := m.Complete(context.Background(), llm.Request{Prompt: "x"})
+	require.NoError(t, err)
+	assert.Greater(t, resp.Usage.InputTokens, 0)
+	assert.Greater(t, resp.Usage.OutputTokens, 0)
+}
+
+func TestMockProvider_ConcurrentAccess(t *testing.T) {
+	m := llm.NewMockProvider(
+		llm.MockResponse{Content: "safe"},
+	)
+
+	ctx := context.Background()
+	done := make(chan struct{})
+
+	for range 10 {
+		go func() {
+			defer func() { done <- struct{}{} }()
+			_, _ = m.Complete(ctx, llm.Request{Prompt: "concurrent"})
+		}()
+	}
+
+	for range 10 {
+		<-done
+	}
+
+	assert.Len(t, m.Calls(), 10)
+}


### PR DESCRIPTION
## Summary
- Adds `internal/llm` package with provider-agnostic LLM client interface
- Implements Anthropic provider using official `anthropic-sdk-go` SDK with retry logic
- Implements mock provider for deterministic testing with call history tracking
- Configurable model selection and retry count via functional options

Beads: stringer-azr (LLM1: LLM Provider Abstraction)
Stories: stringer-azr.1, stringer-azr.2, stringer-azr.3, stringer-azr.4

## Test plan
- [x] Unit tests for Provider interface compliance
- [x] Unit tests for Anthropic provider construction, options, and defaults
- [x] Unit tests for mock provider: sequential responses, cycling, errors, concurrency, reset
- [x] No real API calls in tests
- [x] Race detector clean (`go test -race`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)