### PR TITLE
feat: add LLM-based signal clustering

### DIFF
--- a/cmd/stringer/scan.go
+++ b/cmd/stringer/scan.go
@@ -43,6 +43,8 @@ var (
 	scanExcludeCollectors string
 	scanIncludeDemoPaths  bool
 	scanPaths             []string
+	scanCluster           bool
+	scanClusterThreshold  float64
 )
 
 // scanCmd is the subcommand for scanning a repository.
@@ -79,6 +81,8 @@ func init() {
 	scanCmd.Flags().StringVarP(&scanExcludeCollectors, "exclude-collectors", "x", "", "comma-separated list of collectors to skip")
 	scanCmd.Flags().BoolVar(&scanIncludeDemoPaths, "include-demo-paths", false, "include demo/example/tutorial paths in noise-prone signals")
 	scanCmd.Flags().StringSliceVar(&scanPaths, "paths", nil, "restrict scanning to specific files or directories (comma-separated)")
+	scanCmd.Flags().BoolVar(&scanCluster, "cluster", false, "enable LLM-based signal clustering")
+	scanCmd.Flags().Float64Var(&scanClusterThreshold, "cluster-threshold", 0.7, "similarity threshold for signal pre-filtering (0.0-1.0)")
 }
 
 func runScan(cmd *cobra.Command, args []string) error {

--- a/internal/analysis/clustering.go
+++ b/internal/analysis/clustering.go
@@ -1,0 +1,169 @@
+// Package analysis provides LLM-powered signal clustering and bead generation.
+// It groups related signals by theme, module, or intent, using an LLM provider
+// for semantic understanding, and produces structured beads for backlog import.
+package analysis
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/davetashner/stringer/internal/llm"
+	"github.com/davetashner/stringer/internal/signal"
+)
+
+// DefaultSimilarityThreshold is the default Jaccard similarity threshold
+// used for pre-filtering signals into groups.
+const DefaultSimilarityThreshold = 0.7
+
+// ClusterConfig controls clustering behavior.
+type ClusterConfig struct {
+	// SimilarityThreshold is the Jaccard similarity threshold for pre-filtering.
+	// Signals with similarity above this threshold are grouped together before
+	// being sent to the LLM. Default: 0.7.
+	SimilarityThreshold float64
+
+	// MinClusterSize is the minimum number of signals required to form a cluster.
+	// Clusters below this size are added to the unclustered list. Default: 1.
+	MinClusterSize int
+
+	// MaxClusterSize caps the number of signals in a single cluster.
+	// Larger clusters are split. Default: 20.
+	MaxClusterSize int
+}
+
+// DefaultClusterConfig returns a ClusterConfig with sensible defaults.
+func DefaultClusterConfig() ClusterConfig {
+	return ClusterConfig{
+		SimilarityThreshold: DefaultSimilarityThreshold,
+		MinClusterSize:      1,
+		MaxClusterSize:      20,
+	}
+}
+
+// Cluster represents a group of related signals identified by the LLM.
+type Cluster struct {
+	// ID is a unique identifier for this cluster.
+	ID string
+
+	// Name is a short human-readable name for the cluster theme.
+	Name string
+
+	// Description summarizes what the clustered signals have in common.
+	Description string
+
+	// SignalIDs are the indices (as string keys) of signals in the input slice.
+	SignalIDs []string
+
+	// Confidence is the highest confidence among all member signals.
+	Confidence float64
+
+	// Tags are combined unique tags from all member signals.
+	Tags []string
+}
+
+// ClusterResult holds the output of a clustering operation.
+type ClusterResult struct {
+	// Clusters are the signal groups identified by the LLM.
+	Clusters []Cluster
+
+	// Unclustered contains signal IDs that did not fit any cluster.
+	Unclustered []string
+}
+
+// ClusterSignals is the main entry point for signal clustering. It pre-filters
+// signals by similarity, sends them to the LLM for semantic clustering, and
+// returns the structured result. On LLM failure, it falls back to treating
+// each signal as its own cluster.
+func ClusterSignals(ctx context.Context, signals []signal.RawSignal, provider llm.Provider, cfg ClusterConfig) (*ClusterResult, error) {
+	if len(signals) == 0 {
+		return &ClusterResult{}, nil
+	}
+
+	// Apply defaults for zero-valued config fields.
+	if cfg.SimilarityThreshold <= 0 {
+		cfg.SimilarityThreshold = DefaultSimilarityThreshold
+	}
+	if cfg.MinClusterSize <= 0 {
+		cfg.MinClusterSize = 1
+	}
+	if cfg.MaxClusterSize <= 0 {
+		cfg.MaxClusterSize = 20
+	}
+
+	// Step 1: Pre-filter signals into groups by similarity.
+	groups := PreFilterSignals(signals, cfg.SimilarityThreshold)
+	slog.Debug("pre-filter complete", "signals", len(signals), "groups", len(groups))
+
+	// Step 2: Use LLM to form clusters from the pre-filtered groups.
+	clusters, err := formClustersWithLLM(ctx, groups, provider, signals)
+	if err != nil {
+		slog.Warn("LLM clustering failed, falling back to ungrouped", "error", err)
+		return fallbackResult(signals), nil
+	}
+
+	// Step 3: Apply size constraints and identify unclustered signals.
+	result := applyConstraints(clusters, signals, cfg)
+
+	return result, nil
+}
+
+// fallbackResult creates a ClusterResult where each signal is its own cluster.
+func fallbackResult(signals []signal.RawSignal) *ClusterResult {
+	clusters := make([]Cluster, len(signals))
+	for i, sig := range signals {
+		id := fmt.Sprintf("sig-%d", i)
+		clusters[i] = Cluster{
+			ID:          fmt.Sprintf("cluster-%d", i),
+			Name:        sig.Title,
+			Description: sig.Description,
+			SignalIDs:   []string{id},
+			Confidence:  sig.Confidence,
+			Tags:        sig.Tags,
+		}
+	}
+	return &ClusterResult{Clusters: clusters}
+}
+
+// applyConstraints enforces MinClusterSize and MaxClusterSize on the raw
+// clusters, moving undersized clusters to the unclustered list.
+func applyConstraints(clusters []Cluster, signals []signal.RawSignal, cfg ClusterConfig) *ClusterResult {
+	// Track which signal IDs are claimed by valid clusters.
+	claimed := make(map[string]bool)
+	var validClusters []Cluster
+
+	for _, c := range clusters {
+		if len(c.SignalIDs) < cfg.MinClusterSize {
+			// Too small — mark as unclustered.
+			continue
+		}
+
+		// Enforce max cluster size by truncating.
+		if len(c.SignalIDs) > cfg.MaxClusterSize {
+			c.SignalIDs = c.SignalIDs[:cfg.MaxClusterSize]
+		}
+
+		for _, id := range c.SignalIDs {
+			claimed[id] = true
+		}
+		validClusters = append(validClusters, c)
+	}
+
+	// Identify unclustered signals.
+	allIDs := make(map[string]bool)
+	for i := range signals {
+		allIDs[fmt.Sprintf("sig-%d", i)] = true
+	}
+
+	var unclustered []string
+	for id := range allIDs {
+		if !claimed[id] {
+			unclustered = append(unclustered, id)
+		}
+	}
+
+	return &ClusterResult{
+		Clusters:    validClusters,
+		Unclustered: unclustered,
+	}
+}

--- a/internal/analysis/clustering_test.go
+++ b/internal/analysis/clustering_test.go
@@ -1,0 +1,925 @@
+package analysis
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/davetashner/stringer/internal/llm"
+	"github.com/davetashner/stringer/internal/signal"
+)
+
+// -----------------------------------------------------------------------
+// Jaccard similarity tests
+// -----------------------------------------------------------------------
+
+func TestJaccardSimilarity_IdenticalStrings(t *testing.T) {
+	assert.InDelta(t, 1.0, jaccardSimilarity("fix the bug", "fix the bug"), 0.01)
+}
+
+func TestJaccardSimilarity_CompletelyDifferent(t *testing.T) {
+	assert.InDelta(t, 0.0, jaccardSimilarity("authentication module", "database migration"), 0.01)
+}
+
+func TestJaccardSimilarity_PartialOverlap(t *testing.T) {
+	sim := jaccardSimilarity("fix authentication bug", "fix authorization bug")
+	assert.Greater(t, sim, 0.0)
+	assert.Less(t, sim, 1.0)
+}
+
+func TestJaccardSimilarity_EmptyStrings(t *testing.T) {
+	assert.InDelta(t, 0.0, jaccardSimilarity("", ""), 0.01)
+}
+
+func TestJaccardSimilarity_OneEmpty(t *testing.T) {
+	assert.InDelta(t, 0.0, jaccardSimilarity("hello world", ""), 0.01)
+}
+
+func TestJaccardSimilarity_CaseInsensitive(t *testing.T) {
+	assert.InDelta(t, 1.0, jaccardSimilarity("Fix Bug", "fix bug"), 0.01)
+}
+
+func TestJaccardSimilarity_StopWordsFiltered(t *testing.T) {
+	// "fix the bug" and "fix a bug" should be identical after stop word removal.
+	sim := jaccardSimilarity("fix the bug", "fix a bug")
+	assert.InDelta(t, 1.0, sim, 0.01)
+}
+
+func TestJaccardSimilarity_Punctuation(t *testing.T) {
+	sim := jaccardSimilarity("TODO: fix this!", "TODO: fix this")
+	assert.InDelta(t, 1.0, sim, 0.01)
+}
+
+// -----------------------------------------------------------------------
+// normalizeTitle tests
+// -----------------------------------------------------------------------
+
+func TestNormalizeTitle_Basic(t *testing.T) {
+	words := normalizeTitle("Fix the authentication Bug")
+	assert.Contains(t, words, "fix")
+	assert.Contains(t, words, "authentication")
+	assert.Contains(t, words, "bug")
+	assert.NotContains(t, words, "the")
+}
+
+func TestNormalizeTitle_Empty(t *testing.T) {
+	assert.Empty(t, normalizeTitle(""))
+}
+
+func TestNormalizeTitle_SingleChar(t *testing.T) {
+	// Single character words should be filtered.
+	words := normalizeTitle("a b c hello")
+	assert.Equal(t, []string{"hello"}, words)
+}
+
+func TestNormalizeTitle_NumbersPreserved(t *testing.T) {
+	words := normalizeTitle("fix issue 42")
+	assert.Contains(t, words, "fix")
+	assert.Contains(t, words, "issue")
+	assert.Contains(t, words, "42")
+}
+
+// -----------------------------------------------------------------------
+// PreFilterSignals tests
+// -----------------------------------------------------------------------
+
+func TestPreFilterSignals_Empty(t *testing.T) {
+	groups := PreFilterSignals(nil, 0.7)
+	assert.Nil(t, groups)
+}
+
+func TestPreFilterSignals_SingleSignal(t *testing.T) {
+	signals := []signal.RawSignal{
+		{Source: "todos", Title: "fix bug", FilePath: "main.go"},
+	}
+	groups := PreFilterSignals(signals, 0.7)
+	require.Len(t, groups, 1)
+	assert.Len(t, groups[0].Members, 1)
+	assert.Equal(t, []int{0}, groups[0].MemberIndices)
+}
+
+func TestPreFilterSignals_SameDirectory(t *testing.T) {
+	signals := []signal.RawSignal{
+		{Source: "todos", Title: "fix A", FilePath: "internal/auth/login.go"},
+		{Source: "todos", Title: "fix B", FilePath: "internal/auth/logout.go"},
+	}
+	groups := PreFilterSignals(signals, 0.7)
+	// Same source and same directory => grouped together.
+	require.Len(t, groups, 1)
+	assert.Len(t, groups[0].Members, 2)
+}
+
+func TestPreFilterSignals_DifferentSource(t *testing.T) {
+	signals := []signal.RawSignal{
+		{Source: "todos", Title: "fix bug", FilePath: "internal/auth/login.go"},
+		{Source: "gitlog", Title: "fix bug", FilePath: "internal/auth/login.go"},
+	}
+	groups := PreFilterSignals(signals, 0.7)
+	// Different sources => separate groups even with same path.
+	require.Len(t, groups, 2)
+}
+
+func TestPreFilterSignals_SimilarTitles(t *testing.T) {
+	signals := []signal.RawSignal{
+		{Source: "todos", Title: "fix authentication error handling"},
+		{Source: "todos", Title: "fix authentication error logging"},
+	}
+	groups := PreFilterSignals(signals, 0.5) // Lower threshold to catch partial overlap.
+	require.Len(t, groups, 1)
+	assert.Len(t, groups[0].Members, 2)
+}
+
+func TestPreFilterSignals_DissimilarTitles(t *testing.T) {
+	signals := []signal.RawSignal{
+		{Source: "todos", Title: "fix database connection pool"},
+		{Source: "todos", Title: "add user authentication"},
+	}
+	groups := PreFilterSignals(signals, 0.7)
+	require.Len(t, groups, 2)
+}
+
+func TestPreFilterSignals_MemberIndicesCorrect(t *testing.T) {
+	signals := []signal.RawSignal{
+		{Source: "todos", Title: "alpha", FilePath: "pkg/a.go"},
+		{Source: "todos", Title: "beta", FilePath: "pkg/b.go"},
+		{Source: "gitlog", Title: "gamma"},
+	}
+	groups := PreFilterSignals(signals, 0.7)
+
+	// First two share source + directory => one group; third is separate.
+	require.Len(t, groups, 2)
+
+	// Verify indices map correctly.
+	allIndices := make(map[int]bool)
+	for _, g := range groups {
+		for _, idx := range g.MemberIndices {
+			allIndices[idx] = true
+		}
+	}
+	assert.True(t, allIndices[0])
+	assert.True(t, allIndices[1])
+	assert.True(t, allIndices[2])
+}
+
+// -----------------------------------------------------------------------
+// pathSimilar tests
+// -----------------------------------------------------------------------
+
+func TestPathSimilar_SameDirectory(t *testing.T) {
+	assert.True(t, pathSimilar("pkg/auth/login.go", "pkg/auth/logout.go"))
+}
+
+func TestPathSimilar_DifferentDirectory(t *testing.T) {
+	assert.False(t, pathSimilar("pkg/auth/login.go", "pkg/db/conn.go"))
+}
+
+func TestPathSimilar_RootFiles(t *testing.T) {
+	// Both at root "." => false (we require non-"." directory).
+	assert.False(t, pathSimilar("main.go", "utils.go"))
+}
+
+func TestPathSimilar_Empty(t *testing.T) {
+	assert.False(t, pathSimilar("", "main.go"))
+	assert.False(t, pathSimilar("main.go", ""))
+}
+
+// -----------------------------------------------------------------------
+// Prompt building tests
+// -----------------------------------------------------------------------
+
+func TestBuildClusteringPrompt_ContainsSignals(t *testing.T) {
+	groups := []SignalGroup{
+		{
+			Representative: signal.RawSignal{Title: "fix auth bug", Kind: "todo", Source: "todos", FilePath: "auth.go"},
+			Members: []signal.RawSignal{
+				{Title: "fix auth bug", Kind: "todo", Source: "todos", FilePath: "auth.go"},
+			},
+			MemberIndices: []int{0},
+		},
+	}
+	prompt := buildClusteringPrompt(groups)
+
+	assert.Contains(t, prompt, "sig-0")
+	assert.Contains(t, prompt, "fix auth bug")
+	assert.Contains(t, prompt, "todo")
+	assert.Contains(t, prompt, "auth.go")
+	assert.Contains(t, prompt, "JSON")
+}
+
+func TestBuildClusteringPrompt_TruncatesDescription(t *testing.T) {
+	longDesc := ""
+	for i := 0; i < 300; i++ {
+		longDesc += "x"
+	}
+	groups := []SignalGroup{
+		{
+			Representative: signal.RawSignal{Title: "test", Description: longDesc},
+			Members:        []signal.RawSignal{{Title: "test", Description: longDesc}},
+			MemberIndices:  []int{0},
+		},
+	}
+	prompt := buildClusteringPrompt(groups)
+	assert.Contains(t, prompt, "...")
+}
+
+func TestBuildClusteringPrompt_MultipleGroups(t *testing.T) {
+	groups := []SignalGroup{
+		{
+			Representative: signal.RawSignal{Title: "first"},
+			Members:        []signal.RawSignal{{Title: "first"}},
+			MemberIndices:  []int{0},
+		},
+		{
+			Representative: signal.RawSignal{Title: "second"},
+			Members:        []signal.RawSignal{{Title: "second"}},
+			MemberIndices:  []int{1},
+		},
+	}
+	prompt := buildClusteringPrompt(groups)
+	assert.Contains(t, prompt, "sig-0")
+	assert.Contains(t, prompt, "sig-1")
+}
+
+// -----------------------------------------------------------------------
+// parseClusterResponse tests
+// -----------------------------------------------------------------------
+
+func TestParseClusterResponse_ValidWrapper(t *testing.T) {
+	input := `{"clusters": [{"name": "Auth fixes", "description": "auth related", "signal_ids": ["sig-0", "sig-1"]}]}`
+	items, err := parseClusterResponse(input)
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	assert.Equal(t, "Auth fixes", items[0].Name)
+	assert.Equal(t, []string{"sig-0", "sig-1"}, items[0].SignalIDs)
+}
+
+func TestParseClusterResponse_ValidArray(t *testing.T) {
+	input := `[{"name": "DB fixes", "description": "database", "signal_ids": ["sig-0"]}]`
+	items, err := parseClusterResponse(input)
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	assert.Equal(t, "DB fixes", items[0].Name)
+}
+
+func TestParseClusterResponse_WithCodeFences(t *testing.T) {
+	input := "```json\n" + `{"clusters": [{"name": "test", "description": "d", "signal_ids": ["sig-0"]}]}` + "\n```"
+	items, err := parseClusterResponse(input)
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	assert.Equal(t, "test", items[0].Name)
+}
+
+func TestParseClusterResponse_InvalidJSON(t *testing.T) {
+	_, err := parseClusterResponse("not json at all")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse")
+}
+
+func TestParseClusterResponse_EmptyContent(t *testing.T) {
+	_, err := parseClusterResponse("")
+	require.Error(t, err)
+}
+
+func TestParseClusterResponse_MultipleClusters(t *testing.T) {
+	input := `{"clusters": [
+		{"name": "A", "description": "first", "signal_ids": ["sig-0"]},
+		{"name": "B", "description": "second", "signal_ids": ["sig-1", "sig-2"]}
+	]}`
+	items, err := parseClusterResponse(input)
+	require.NoError(t, err)
+	require.Len(t, items, 2)
+	assert.Equal(t, "A", items[0].Name)
+	assert.Equal(t, "B", items[1].Name)
+}
+
+// -----------------------------------------------------------------------
+// parseEpicResponse tests
+// -----------------------------------------------------------------------
+
+func TestParseEpicResponse_Valid(t *testing.T) {
+	input := `{"title": "Auth Improvements", "description": "Several auth fixes needed"}`
+	resp, err := parseEpicResponse(input)
+	require.NoError(t, err)
+	assert.Equal(t, "Auth Improvements", resp.Title)
+	assert.Equal(t, "Several auth fixes needed", resp.Description)
+}
+
+func TestParseEpicResponse_MissingTitle(t *testing.T) {
+	input := `{"title": "", "description": "no title"}`
+	_, err := parseEpicResponse(input)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing title")
+}
+
+func TestParseEpicResponse_InvalidJSON(t *testing.T) {
+	_, err := parseEpicResponse("not json")
+	require.Error(t, err)
+}
+
+func TestParseEpicResponse_WithCodeFences(t *testing.T) {
+	input := "```json\n" + `{"title": "Test Epic", "description": "test"}` + "\n```"
+	resp, err := parseEpicResponse(input)
+	require.NoError(t, err)
+	assert.Equal(t, "Test Epic", resp.Title)
+}
+
+// -----------------------------------------------------------------------
+// formClustersWithLLM tests (using mock provider)
+// -----------------------------------------------------------------------
+
+func TestFormClustersWithLLM_Success(t *testing.T) {
+	signals := testSignals()
+
+	clusterJSON := mustJSON(t, clusterResponseWrapper{
+		Clusters: []clusterResponseItem{
+			{Name: "Auth fixes", Description: "auth related", SignalIDs: []string{"sig-0", "sig-1"}},
+			{Name: "DB work", Description: "database", SignalIDs: []string{"sig-2"}},
+		},
+	})
+
+	mock := llm.NewMockProvider(llm.MockResponse{Content: clusterJSON})
+	groups := PreFilterSignals(signals, 0.7)
+
+	clusters, err := formClustersWithLLM(context.Background(), groups, mock, signals)
+	require.NoError(t, err)
+	require.Len(t, clusters, 2)
+	assert.Equal(t, "Auth fixes", clusters[0].Name)
+	assert.Equal(t, []string{"sig-0", "sig-1"}, clusters[0].SignalIDs)
+	assert.Equal(t, "DB work", clusters[1].Name)
+}
+
+func TestFormClustersWithLLM_InvalidSignalIDs(t *testing.T) {
+	signals := testSignals()
+
+	clusterJSON := mustJSON(t, clusterResponseWrapper{
+		Clusters: []clusterResponseItem{
+			{Name: "Mixed", Description: "some invalid", SignalIDs: []string{"sig-0", "sig-999"}},
+		},
+	})
+
+	mock := llm.NewMockProvider(llm.MockResponse{Content: clusterJSON})
+	groups := PreFilterSignals(signals, 0.7)
+
+	clusters, err := formClustersWithLLM(context.Background(), groups, mock, signals)
+	require.NoError(t, err)
+	require.Len(t, clusters, 1)
+	// sig-999 should be filtered out.
+	assert.Equal(t, []string{"sig-0"}, clusters[0].SignalIDs)
+}
+
+func TestFormClustersWithLLM_LLMError(t *testing.T) {
+	signals := testSignals()
+	mock := llm.NewMockProvider(llm.MockResponse{Err: errors.New("API error")})
+	groups := PreFilterSignals(signals, 0.7)
+
+	_, err := formClustersWithLLM(context.Background(), groups, mock, signals)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "LLM completion failed")
+}
+
+func TestFormClustersWithLLM_BadJSON(t *testing.T) {
+	signals := testSignals()
+	mock := llm.NewMockProvider(llm.MockResponse{Content: "this is not json"})
+	groups := PreFilterSignals(signals, 0.7)
+
+	_, err := formClustersWithLLM(context.Background(), groups, mock, signals)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parse cluster response")
+}
+
+func TestFormClustersWithLLM_EmptyClusterFiltered(t *testing.T) {
+	signals := testSignals()
+
+	// All signal IDs are invalid => empty cluster should be dropped.
+	clusterJSON := mustJSON(t, clusterResponseWrapper{
+		Clusters: []clusterResponseItem{
+			{Name: "Ghost", Description: "all invalid", SignalIDs: []string{"sig-100", "sig-200"}},
+		},
+	})
+
+	mock := llm.NewMockProvider(llm.MockResponse{Content: clusterJSON})
+	groups := PreFilterSignals(signals, 0.7)
+
+	clusters, err := formClustersWithLLM(context.Background(), groups, mock, signals)
+	require.NoError(t, err)
+	assert.Empty(t, clusters)
+}
+
+func TestFormClustersWithLLM_ConfidenceComputed(t *testing.T) {
+	signals := []signal.RawSignal{
+		{Source: "todos", Title: "low conf", Confidence: 0.3},
+		{Source: "todos", Title: "high conf", Confidence: 0.9},
+	}
+
+	clusterJSON := mustJSON(t, clusterResponseWrapper{
+		Clusters: []clusterResponseItem{
+			{Name: "Mixed", Description: "test", SignalIDs: []string{"sig-0", "sig-1"}},
+		},
+	})
+
+	mock := llm.NewMockProvider(llm.MockResponse{Content: clusterJSON})
+	groups := PreFilterSignals(signals, 0.7)
+
+	clusters, err := formClustersWithLLM(context.Background(), groups, mock, signals)
+	require.NoError(t, err)
+	require.Len(t, clusters, 1)
+	assert.InDelta(t, 0.9, clusters[0].Confidence, 0.01)
+}
+
+func TestFormClustersWithLLM_TagsCombined(t *testing.T) {
+	signals := []signal.RawSignal{
+		{Source: "todos", Title: "a", Tags: []string{"auth", "security"}},
+		{Source: "todos", Title: "b", Tags: []string{"security", "backend"}},
+	}
+
+	clusterJSON := mustJSON(t, clusterResponseWrapper{
+		Clusters: []clusterResponseItem{
+			{Name: "Security", Description: "test", SignalIDs: []string{"sig-0", "sig-1"}},
+		},
+	})
+
+	mock := llm.NewMockProvider(llm.MockResponse{Content: clusterJSON})
+	groups := PreFilterSignals(signals, 0.7)
+
+	clusters, err := formClustersWithLLM(context.Background(), groups, mock, signals)
+	require.NoError(t, err)
+	require.Len(t, clusters, 1)
+	assert.Contains(t, clusters[0].Tags, "auth")
+	assert.Contains(t, clusters[0].Tags, "security")
+	assert.Contains(t, clusters[0].Tags, "backend")
+	// "security" should not be duplicated.
+	secCount := 0
+	for _, tag := range clusters[0].Tags {
+		if tag == "security" {
+			secCount++
+		}
+	}
+	assert.Equal(t, 1, secCount)
+}
+
+// -----------------------------------------------------------------------
+// MergeClusterToBeads tests
+// -----------------------------------------------------------------------
+
+func TestMergeClusterToBeads_SingleSignal(t *testing.T) {
+	signals := []signal.RawSignal{
+		{Source: "todos", Title: "fix auth", Description: "auth is broken", Confidence: 0.8, Tags: []string{"auth"}},
+	}
+	cluster := Cluster{
+		ID:        "cluster-0",
+		Name:      "Auth",
+		SignalIDs: []string{"sig-0"},
+		Tags:      []string{"cluster-tag"},
+	}
+
+	beads := MergeClusterToBeads(cluster, signals)
+	require.Len(t, beads, 1)
+	assert.Equal(t, "fix auth", beads[0].Title)
+	assert.Equal(t, "auth is broken", beads[0].Description)
+	assert.Equal(t, "task", beads[0].Type)
+	assert.InDelta(t, 0.8, beads[0].Confidence, 0.01)
+	// Tags should be combined from cluster and signal.
+	assert.Contains(t, beads[0].Tags, "cluster-tag")
+	assert.Contains(t, beads[0].Tags, "auth")
+}
+
+func TestMergeClusterToBeads_MultipleSignals(t *testing.T) {
+	signals := []signal.RawSignal{
+		{Source: "todos", Title: "fix login", FilePath: "auth/login.go", Line: 10, Confidence: 0.6},
+		{Source: "todos", Title: "fix logout", FilePath: "auth/logout.go", Line: 20, Confidence: 0.9},
+	}
+	cluster := Cluster{
+		ID:          "cluster-0",
+		Name:        "Auth Fixes",
+		Description: "Authentication improvements",
+		SignalIDs:   []string{"sig-0", "sig-1"},
+		Confidence:  0.9,
+		Tags:        []string{"auth"},
+	}
+
+	beads := MergeClusterToBeads(cluster, signals)
+	require.Len(t, beads, 1)
+	assert.Equal(t, "Auth Fixes", beads[0].Title)
+	assert.Contains(t, beads[0].Description, "Authentication improvements")
+	assert.Contains(t, beads[0].Description, "fix login")
+	assert.Contains(t, beads[0].Description, "fix logout")
+	assert.Contains(t, beads[0].Description, "auth/login.go:10")
+	assert.InDelta(t, 0.9, beads[0].Confidence, 0.01)
+}
+
+func TestMergeClusterToBeads_EmptyCluster(t *testing.T) {
+	signals := []signal.RawSignal{
+		{Source: "todos", Title: "test"},
+	}
+	cluster := Cluster{
+		ID:        "cluster-0",
+		Name:      "Empty",
+		SignalIDs: []string{}, // No signals.
+	}
+
+	beads := MergeClusterToBeads(cluster, signals)
+	assert.Nil(t, beads)
+}
+
+func TestMergeClusterToBeads_InvalidIDs(t *testing.T) {
+	signals := []signal.RawSignal{
+		{Source: "todos", Title: "test"},
+	}
+	cluster := Cluster{
+		ID:        "cluster-0",
+		Name:      "Ghost",
+		SignalIDs: []string{"sig-999"}, // Invalid index.
+	}
+
+	beads := MergeClusterToBeads(cluster, signals)
+	assert.Nil(t, beads)
+}
+
+// -----------------------------------------------------------------------
+// BeadsToSignals tests
+// -----------------------------------------------------------------------
+
+func TestBeadsToSignals_Basic(t *testing.T) {
+	beads := []AnalysisBead{
+		{
+			ID:          "test-1",
+			Title:       "Fix auth",
+			Description: "Auth is broken",
+			Type:        "task",
+			Confidence:  0.8,
+			Tags:        []string{"auth"},
+			SourceSignals: []signal.RawSignal{
+				{FilePath: "auth.go", Line: 10, Author: "dev", Timestamp: time.Now()},
+			},
+		},
+	}
+
+	signals := BeadsToSignals(beads)
+	require.Len(t, signals, 1)
+	assert.Equal(t, "cluster", signals[0].Source)
+	assert.Equal(t, "Fix auth", signals[0].Title)
+	assert.Equal(t, "auth.go", signals[0].FilePath)
+	assert.Equal(t, 10, signals[0].Line)
+	assert.Equal(t, "dev", signals[0].Author)
+}
+
+func TestBeadsToSignals_NoSourceSignals(t *testing.T) {
+	beads := []AnalysisBead{
+		{
+			ID:    "test-1",
+			Title: "orphan",
+			Type:  "task",
+		},
+	}
+
+	signals := BeadsToSignals(beads)
+	require.Len(t, signals, 1)
+	assert.Equal(t, "", signals[0].FilePath)
+}
+
+// -----------------------------------------------------------------------
+// CreateEpicHierarchy tests
+// -----------------------------------------------------------------------
+
+func TestCreateEpicHierarchy_SmallCluster(t *testing.T) {
+	signals := testSignals() // 3 signals, below EpicThreshold.
+	cluster := Cluster{
+		ID:        "cluster-0",
+		Name:      "Small",
+		SignalIDs: []string{"sig-0", "sig-1", "sig-2"},
+		Tags:      []string{"small"},
+	}
+
+	mock := llm.NewMockProvider() // Should not be called.
+	beads, err := CreateEpicHierarchy(context.Background(), cluster, signals, mock)
+	require.NoError(t, err)
+	// Should fall through to MergeClusterToBeads, not create an epic.
+	require.Len(t, beads, 1)
+	assert.Equal(t, "task", beads[0].Type)
+	assert.Empty(t, mock.Calls(), "LLM should not be called for small clusters")
+}
+
+func TestCreateEpicHierarchy_LargeCluster(t *testing.T) {
+	signals := makeLargeSignalSlice(8)
+	var ids []string
+	for i := 0; i < 8; i++ {
+		ids = append(ids, fmt.Sprintf("sig-%d", i))
+	}
+	cluster := Cluster{
+		ID:          "cluster-0",
+		Name:        "Big Auth",
+		Description: "Lots of auth work",
+		SignalIDs:   ids,
+		Confidence:  0.85,
+		Tags:        []string{"auth"},
+	}
+
+	epicJSON := `{"title": "Authentication Overhaul", "description": "Comprehensive auth improvements needed across 8 modules."}`
+	mock := llm.NewMockProvider(llm.MockResponse{Content: epicJSON})
+
+	beads, err := CreateEpicHierarchy(context.Background(), cluster, signals, mock)
+	require.NoError(t, err)
+
+	// Should be 1 epic + 8 children = 9 total.
+	require.Len(t, beads, 9)
+
+	// First bead is the epic.
+	assert.Equal(t, "epic", beads[0].Type)
+	assert.Equal(t, "Authentication Overhaul", beads[0].Title)
+	assert.Contains(t, beads[0].Tags, "epic")
+
+	// Remaining beads are tasks linked to the epic.
+	for i := 1; i < len(beads); i++ {
+		assert.Equal(t, "task", beads[i].Type)
+		assert.Equal(t, beads[0].ID, beads[i].ParentID)
+	}
+}
+
+func TestCreateEpicHierarchy_LLMFailureFallback(t *testing.T) {
+	signals := makeLargeSignalSlice(7)
+	var ids []string
+	for i := 0; i < 7; i++ {
+		ids = append(ids, fmt.Sprintf("sig-%d", i))
+	}
+	cluster := Cluster{
+		ID:          "cluster-0",
+		Name:        "Fallback Cluster",
+		Description: "Should use cluster name on LLM failure",
+		SignalIDs:   ids,
+		Confidence:  0.7,
+	}
+
+	mock := llm.NewMockProvider(llm.MockResponse{Err: errors.New("LLM down")})
+
+	beads, err := CreateEpicHierarchy(context.Background(), cluster, signals, mock)
+	require.NoError(t, err)
+
+	// Should still produce epic + children, using cluster.Name as title.
+	require.Len(t, beads, 8) // 1 epic + 7 children.
+	assert.Equal(t, "epic", beads[0].Type)
+	assert.Equal(t, "Fallback Cluster", beads[0].Title)
+}
+
+func TestCreateEpicHierarchy_ExactThreshold(t *testing.T) {
+	signals := makeLargeSignalSlice(EpicThreshold)
+	var ids []string
+	for i := 0; i < EpicThreshold; i++ {
+		ids = append(ids, fmt.Sprintf("sig-%d", i))
+	}
+	cluster := Cluster{
+		ID:        "cluster-0",
+		Name:      "Threshold",
+		SignalIDs: ids,
+	}
+
+	mock := llm.NewMockProvider()
+	beads, err := CreateEpicHierarchy(context.Background(), cluster, signals, mock)
+	require.NoError(t, err)
+
+	// At exactly the threshold, should NOT create an epic (uses <=).
+	assert.Equal(t, "task", beads[0].Type)
+	assert.Empty(t, mock.Calls())
+}
+
+// -----------------------------------------------------------------------
+// ClusterSignals end-to-end tests
+// -----------------------------------------------------------------------
+
+func TestClusterSignals_EmptyInput(t *testing.T) {
+	mock := llm.NewMockProvider()
+	result, err := ClusterSignals(context.Background(), nil, mock, DefaultClusterConfig())
+	require.NoError(t, err)
+	assert.Empty(t, result.Clusters)
+	assert.Empty(t, result.Unclustered)
+}
+
+func TestClusterSignals_EndToEnd(t *testing.T) {
+	signals := testSignals()
+
+	clusterJSON := mustJSON(t, clusterResponseWrapper{
+		Clusters: []clusterResponseItem{
+			{Name: "Auth", Description: "auth fixes", SignalIDs: []string{"sig-0", "sig-1"}},
+			{Name: "DB", Description: "db work", SignalIDs: []string{"sig-2"}},
+		},
+	})
+
+	mock := llm.NewMockProvider(llm.MockResponse{Content: clusterJSON})
+	cfg := DefaultClusterConfig()
+
+	result, err := ClusterSignals(context.Background(), signals, mock, cfg)
+	require.NoError(t, err)
+	require.Len(t, result.Clusters, 2)
+	assert.Equal(t, "Auth", result.Clusters[0].Name)
+	assert.Equal(t, "DB", result.Clusters[1].Name)
+	assert.Empty(t, result.Unclustered)
+}
+
+func TestClusterSignals_LLMFailureFallback(t *testing.T) {
+	signals := testSignals()
+	mock := llm.NewMockProvider(llm.MockResponse{Err: errors.New("API down")})
+	cfg := DefaultClusterConfig()
+
+	result, err := ClusterSignals(context.Background(), signals, mock, cfg)
+	require.NoError(t, err)
+	// Fallback: each signal gets its own cluster.
+	assert.Len(t, result.Clusters, len(signals))
+	assert.Empty(t, result.Unclustered)
+}
+
+func TestClusterSignals_MinClusterSize(t *testing.T) {
+	signals := testSignals()
+
+	clusterJSON := mustJSON(t, clusterResponseWrapper{
+		Clusters: []clusterResponseItem{
+			{Name: "Big", Description: "big cluster", SignalIDs: []string{"sig-0", "sig-1"}},
+			{Name: "Tiny", Description: "single", SignalIDs: []string{"sig-2"}},
+		},
+	})
+
+	mock := llm.NewMockProvider(llm.MockResponse{Content: clusterJSON})
+	cfg := ClusterConfig{
+		SimilarityThreshold: 0.7,
+		MinClusterSize:      2, // Require at least 2 signals per cluster.
+		MaxClusterSize:      20,
+	}
+
+	result, err := ClusterSignals(context.Background(), signals, mock, cfg)
+	require.NoError(t, err)
+	assert.Len(t, result.Clusters, 1) // "Tiny" cluster should be filtered out.
+	assert.Equal(t, "Big", result.Clusters[0].Name)
+	assert.Contains(t, result.Unclustered, "sig-2")
+}
+
+func TestClusterSignals_MaxClusterSize(t *testing.T) {
+	signals := makeLargeSignalSlice(10)
+	var allIDs []string
+	for i := 0; i < 10; i++ {
+		allIDs = append(allIDs, fmt.Sprintf("sig-%d", i))
+	}
+
+	clusterJSON := mustJSON(t, clusterResponseWrapper{
+		Clusters: []clusterResponseItem{
+			{Name: "Huge", Description: "too many", SignalIDs: allIDs},
+		},
+	})
+
+	mock := llm.NewMockProvider(llm.MockResponse{Content: clusterJSON})
+	cfg := ClusterConfig{
+		SimilarityThreshold: 0.7,
+		MinClusterSize:      1,
+		MaxClusterSize:      5, // Only allow 5 signals max.
+	}
+
+	result, err := ClusterSignals(context.Background(), signals, mock, cfg)
+	require.NoError(t, err)
+	require.Len(t, result.Clusters, 1)
+	assert.Len(t, result.Clusters[0].SignalIDs, 5) // Truncated to max.
+}
+
+func TestClusterSignals_DefaultConfigApplied(t *testing.T) {
+	signals := testSignals()
+
+	clusterJSON := mustJSON(t, clusterResponseWrapper{
+		Clusters: []clusterResponseItem{
+			{Name: "All", Description: "all signals", SignalIDs: []string{"sig-0", "sig-1", "sig-2"}},
+		},
+	})
+
+	mock := llm.NewMockProvider(llm.MockResponse{Content: clusterJSON})
+
+	// Pass zero-valued config — defaults should be applied.
+	result, err := ClusterSignals(context.Background(), signals, mock, ClusterConfig{})
+	require.NoError(t, err)
+	require.Len(t, result.Clusters, 1)
+}
+
+func TestClusterSignals_ContextCancellation(t *testing.T) {
+	signals := testSignals()
+	mock := llm.NewMockProvider(llm.MockResponse{Content: "{}"})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately.
+
+	// The mock respects context cancellation.
+	result, err := ClusterSignals(ctx, signals, mock, DefaultClusterConfig())
+	// Should fall back gracefully on context cancellation.
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+}
+
+// -----------------------------------------------------------------------
+// DefaultClusterConfig test
+// -----------------------------------------------------------------------
+
+func TestDefaultClusterConfig(t *testing.T) {
+	cfg := DefaultClusterConfig()
+	assert.InDelta(t, 0.7, cfg.SimilarityThreshold, 0.01)
+	assert.Equal(t, 1, cfg.MinClusterSize)
+	assert.Equal(t, 20, cfg.MaxClusterSize)
+}
+
+// -----------------------------------------------------------------------
+// findSignalInSlice tests
+// -----------------------------------------------------------------------
+
+func TestFindSignalInSlice_Valid(t *testing.T) {
+	signals := testSignals()
+	sig := findSignalInSlice("sig-1", signals)
+	require.NotNil(t, sig)
+	assert.Equal(t, "fix login bug", sig.Title)
+}
+
+func TestFindSignalInSlice_OutOfRange(t *testing.T) {
+	signals := testSignals()
+	assert.Nil(t, findSignalInSlice("sig-999", signals))
+}
+
+func TestFindSignalInSlice_InvalidFormat(t *testing.T) {
+	signals := testSignals()
+	assert.Nil(t, findSignalInSlice("invalid", signals))
+	assert.Nil(t, findSignalInSlice("sig-abc", signals))
+	assert.Nil(t, findSignalInSlice("", signals))
+}
+
+func TestFindSignalInSlice_NegativeIndex(t *testing.T) {
+	signals := testSignals()
+	assert.Nil(t, findSignalInSlice("sig--1", signals))
+}
+
+// -----------------------------------------------------------------------
+// combineTags tests
+// -----------------------------------------------------------------------
+
+func TestCombineTags_Dedup(t *testing.T) {
+	tags := combineTags([]string{"a", "b"}, []string{"b", "c"})
+	assert.Equal(t, []string{"a", "b", "c"}, tags)
+}
+
+func TestCombineTags_Empty(t *testing.T) {
+	assert.Nil(t, combineTags(nil, nil))
+}
+
+func TestCombineTags_OneEmpty(t *testing.T) {
+	tags := combineTags([]string{"a"}, nil)
+	assert.Equal(t, []string{"a"}, tags)
+}
+
+// -----------------------------------------------------------------------
+// buildEpicPrompt tests
+// -----------------------------------------------------------------------
+
+func TestBuildEpicPrompt_ContainsClusterInfo(t *testing.T) {
+	signals := testSignals()
+	cluster := Cluster{
+		Name:        "Auth Work",
+		Description: "Auth improvements needed",
+		SignalIDs:   []string{"sig-0", "sig-1"},
+	}
+
+	prompt := buildEpicPrompt(cluster, signals)
+	assert.Contains(t, prompt, "Auth Work")
+	assert.Contains(t, prompt, "Auth improvements needed")
+	assert.Contains(t, prompt, "sig-0")
+	assert.Contains(t, prompt, "fix auth error")
+}
+
+// -----------------------------------------------------------------------
+// Test helpers
+// -----------------------------------------------------------------------
+
+func testSignals() []signal.RawSignal {
+	return []signal.RawSignal{
+		{Source: "todos", Kind: "todo", Title: "fix auth error", FilePath: "internal/auth/handler.go", Line: 42, Confidence: 0.7, Tags: []string{"auth"}},
+		{Source: "todos", Kind: "fixme", Title: "fix login bug", FilePath: "internal/auth/login.go", Line: 15, Confidence: 0.8, Tags: []string{"auth", "bug"}},
+		{Source: "gitlog", Kind: "churn", Title: "high churn in database layer", FilePath: "internal/db/conn.go", Confidence: 0.6, Tags: []string{"db"}},
+	}
+}
+
+func makeLargeSignalSlice(n int) []signal.RawSignal {
+	signals := make([]signal.RawSignal, n)
+	for i := range signals {
+		signals[i] = signal.RawSignal{
+			Source:     "todos",
+			Kind:       "todo",
+			Title:      fmt.Sprintf("signal %d: fix issue in module %d", i, i%3),
+			FilePath:   fmt.Sprintf("internal/mod%d/file.go", i%3),
+			Line:       i*10 + 1,
+			Confidence: 0.5 + float64(i%5)*0.1,
+			Tags:       []string{fmt.Sprintf("mod%d", i%3)},
+		}
+	}
+	return signals
+}
+
+func mustJSON(t *testing.T, v any) string {
+	t.Helper()
+	data, err := json.Marshal(v)
+	require.NoError(t, err)
+	return string(data)
+}

--- a/internal/analysis/hierarchy.go
+++ b/internal/analysis/hierarchy.go
@@ -1,0 +1,87 @@
+package analysis
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/davetashner/stringer/internal/llm"
+	"github.com/davetashner/stringer/internal/signal"
+)
+
+// EpicThreshold is the minimum number of signals in a cluster before an
+// epic hierarchy is created. Clusters at or below this size produce flat beads.
+const EpicThreshold = 5
+
+// CreateEpicHierarchy generates a parent epic bead with child task beads for
+// clusters that exceed EpicThreshold signals. It uses the LLM to generate
+// an appropriate epic title and description. For clusters with 5 or fewer
+// signals, it falls back to MergeClusterToBeads.
+func CreateEpicHierarchy(ctx context.Context, cluster Cluster, signals []signal.RawSignal, provider llm.Provider) ([]AnalysisBead, error) {
+	memberSignals := resolveClusterSignals(cluster, signals)
+
+	// For small clusters, don't create an epic hierarchy.
+	if len(memberSignals) <= EpicThreshold {
+		return MergeClusterToBeads(cluster, signals), nil
+	}
+
+	// Use LLM to generate epic title and description.
+	epicTitle, epicDesc, err := generateEpicMetadata(ctx, cluster, signals, provider)
+	if err != nil {
+		slog.Warn("LLM epic generation failed, using cluster name", "error", err)
+		epicTitle = cluster.Name
+		epicDesc = cluster.Description
+	}
+
+	epicID := fmt.Sprintf("epic-%s", cluster.ID)
+
+	// Create the parent epic bead.
+	epic := AnalysisBead{
+		ID:          epicID,
+		Title:       epicTitle,
+		Description: epicDesc,
+		Type:        "epic",
+		Confidence:  cluster.Confidence,
+		Tags:        append(cluster.Tags, "epic"),
+	}
+
+	// Create child task beads, each linked to the parent epic.
+	beads := []AnalysisBead{epic}
+	for i, sig := range memberSignals {
+		child := AnalysisBead{
+			ID:            fmt.Sprintf("%s-task-%d", cluster.ID, i),
+			Title:         sig.Title,
+			Description:   sig.Description,
+			Type:          "task",
+			Confidence:    sig.Confidence,
+			Tags:          sig.Tags,
+			ParentID:      epicID,
+			SourceSignals: []signal.RawSignal{sig},
+		}
+		beads = append(beads, child)
+	}
+
+	return beads, nil
+}
+
+// generateEpicMetadata uses the LLM to create an epic title and description
+// that summarizes the cluster's work items.
+func generateEpicMetadata(ctx context.Context, cluster Cluster, signals []signal.RawSignal, provider llm.Provider) (title, description string, err error) {
+	prompt := buildEpicPrompt(cluster, signals)
+
+	resp, err := provider.Complete(ctx, llm.Request{
+		SystemPrompt: "You are a software engineering assistant that creates concise epic summaries. Always respond with valid JSON only.",
+		Prompt:       prompt,
+		MaxTokens:    1024,
+	})
+	if err != nil {
+		return "", "", fmt.Errorf("LLM completion failed: %w", err)
+	}
+
+	parsed, err := parseEpicResponse(resp.Content)
+	if err != nil {
+		return "", "", fmt.Errorf("parse epic response: %w", err)
+	}
+
+	return parsed.Title, parsed.Description, nil
+}

--- a/internal/analysis/llmcluster.go
+++ b/internal/analysis/llmcluster.go
@@ -1,0 +1,116 @@
+package analysis
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"strings"
+
+	"github.com/davetashner/stringer/internal/llm"
+	"github.com/davetashner/stringer/internal/signal"
+)
+
+// formClustersWithLLM sends pre-filtered signal groups to the LLM for semantic
+// clustering. It builds a prompt, sends it to the provider, parses the response,
+// and validates that all returned signal IDs exist in the input. On any LLM or
+// parsing error, it returns an error so the caller can fall back.
+func formClustersWithLLM(ctx context.Context, groups []SignalGroup, provider llm.Provider, signals []signal.RawSignal) ([]Cluster, error) {
+	prompt := buildClusteringPrompt(groups)
+
+	resp, err := provider.Complete(ctx, llm.Request{
+		SystemPrompt: "You are a software engineering assistant that analyzes code signals and groups related work items. Always respond with valid JSON only.",
+		Prompt:       prompt,
+		MaxTokens:    4096,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("LLM completion failed: %w", err)
+	}
+
+	items, err := parseClusterResponse(resp.Content)
+	if err != nil {
+		return nil, fmt.Errorf("parse cluster response: %w", err)
+	}
+
+	// Build a set of valid signal IDs for validation.
+	validIDs := make(map[string]bool, len(signals))
+	for i := range signals {
+		validIDs[fmt.Sprintf("sig-%d", i)] = true
+	}
+
+	// Convert parsed items to Cluster structs, validating signal IDs.
+	clusters := make([]Cluster, 0, len(items))
+	for i, item := range items {
+		var validSignalIDs []string
+		for _, id := range item.SignalIDs {
+			if validIDs[id] {
+				validSignalIDs = append(validSignalIDs, id)
+			} else {
+				slog.Debug("ignoring unknown signal ID from LLM", "id", id, "cluster", item.Name)
+			}
+		}
+
+		if len(validSignalIDs) == 0 {
+			continue
+		}
+
+		cluster := Cluster{
+			ID:          fmt.Sprintf("cluster-%d", i),
+			Name:        item.Name,
+			Description: item.Description,
+			SignalIDs:   validSignalIDs,
+			Confidence:  computeClusterConfidence(validSignalIDs, signals),
+			Tags:        computeClusterTags(validSignalIDs, signals),
+		}
+		clusters = append(clusters, cluster)
+	}
+
+	return clusters, nil
+}
+
+// computeClusterConfidence returns the highest confidence among the signals
+// referenced by the given IDs.
+func computeClusterConfidence(signalIDs []string, signals []signal.RawSignal) float64 {
+	var maxConf float64
+	for _, id := range signalIDs {
+		sig := findSignalInSlice(id, signals)
+		if sig != nil && sig.Confidence > maxConf {
+			maxConf = sig.Confidence
+		}
+	}
+	return maxConf
+}
+
+// computeClusterTags returns the deduplicated union of tags from all signals
+// referenced by the given IDs.
+func computeClusterTags(signalIDs []string, signals []signal.RawSignal) []string {
+	seen := make(map[string]bool)
+	var tags []string
+	for _, id := range signalIDs {
+		sig := findSignalInSlice(id, signals)
+		if sig == nil {
+			continue
+		}
+		for _, tag := range sig.Tags {
+			if !seen[tag] {
+				seen[tag] = true
+				tags = append(tags, tag)
+			}
+		}
+	}
+	return tags
+}
+
+// findSignalInSlice looks up a signal by its "sig-N" ID string in the signals
+// slice. Returns nil if the ID is invalid or out of range.
+func findSignalInSlice(id string, signals []signal.RawSignal) *signal.RawSignal {
+	if !strings.HasPrefix(id, "sig-") {
+		return nil
+	}
+	idxStr := strings.TrimPrefix(id, "sig-")
+	idx, err := strconv.Atoi(idxStr)
+	if err != nil || idx < 0 || idx >= len(signals) {
+		return nil
+	}
+	return &signals[idx]
+}

--- a/internal/analysis/merge.go
+++ b/internal/analysis/merge.go
@@ -1,0 +1,169 @@
+package analysis
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/davetashner/stringer/internal/signal"
+)
+
+// AnalysisBead represents a bead produced by the clustering analysis. It
+// extends the basic signal with cluster metadata and parent-child relationships.
+type AnalysisBead struct {
+	// ID is a generated identifier for this bead.
+	ID string
+
+	// Title is the bead title.
+	Title string
+
+	// Description is the full bead description.
+	Description string
+
+	// Type is the bead type (e.g., "task", "epic").
+	Type string
+
+	// Confidence is the confidence level (0.0-1.0).
+	Confidence float64
+
+	// Tags are labels for the bead.
+	Tags []string
+
+	// ParentID links child beads to their parent epic. Empty for top-level beads.
+	ParentID string
+
+	// SourceSignals references the original signals that contributed to this bead.
+	SourceSignals []signal.RawSignal
+}
+
+// MergeClusterToBeads converts a Cluster and its member signals into
+// AnalysisBeads. Single-signal clusters produce one bead directly.
+// Multi-signal clusters produce one bead with a rich description listing
+// all member signals.
+func MergeClusterToBeads(cluster Cluster, signals []signal.RawSignal) []AnalysisBead {
+	memberSignals := resolveClusterSignals(cluster, signals)
+
+	if len(memberSignals) == 0 {
+		return nil
+	}
+
+	// Single-signal cluster: create one simple bead.
+	if len(memberSignals) == 1 {
+		sig := memberSignals[0]
+		return []AnalysisBead{
+			{
+				ID:            cluster.ID,
+				Title:         sig.Title,
+				Description:   sig.Description,
+				Type:          "task",
+				Confidence:    sig.Confidence,
+				Tags:          combineTags(cluster.Tags, sig.Tags),
+				SourceSignals: memberSignals,
+			},
+		}
+	}
+
+	// Multi-signal cluster: create one bead with a merged description.
+	description := buildMergedDescription(cluster, memberSignals)
+	maxConf := cluster.Confidence
+	for _, sig := range memberSignals {
+		if sig.Confidence > maxConf {
+			maxConf = sig.Confidence
+		}
+	}
+
+	return []AnalysisBead{
+		{
+			ID:            cluster.ID,
+			Title:         cluster.Name,
+			Description:   description,
+			Type:          "task",
+			Confidence:    maxConf,
+			Tags:          cluster.Tags,
+			SourceSignals: memberSignals,
+		},
+	}
+}
+
+// buildMergedDescription creates a rich description that lists all member
+// signals with their titles, locations, and the cluster's overall description.
+func buildMergedDescription(cluster Cluster, members []signal.RawSignal) string {
+	var b strings.Builder
+
+	if cluster.Description != "" {
+		b.WriteString(cluster.Description)
+		b.WriteString("\n\n")
+	}
+
+	b.WriteString("Related signals:\n")
+	for i, sig := range members {
+		fmt.Fprintf(&b, "- %s", sig.Title)
+		if sig.FilePath != "" {
+			if sig.Line > 0 {
+				fmt.Fprintf(&b, " (%s:%d)", sig.FilePath, sig.Line)
+			} else {
+				fmt.Fprintf(&b, " (%s)", sig.FilePath)
+			}
+		}
+		if i < len(members)-1 {
+			b.WriteString("\n")
+		}
+	}
+
+	return b.String()
+}
+
+// resolveClusterSignals maps cluster signal IDs back to actual RawSignals.
+func resolveClusterSignals(cluster Cluster, signals []signal.RawSignal) []signal.RawSignal {
+	var result []signal.RawSignal
+	for _, id := range cluster.SignalIDs {
+		sig := findSignalInSlice(id, signals)
+		if sig != nil {
+			result = append(result, *sig)
+		}
+	}
+	return result
+}
+
+// combineTags returns the deduplicated union of two tag slices.
+func combineTags(a, b []string) []string {
+	seen := make(map[string]bool, len(a)+len(b))
+	var result []string
+	for _, tag := range a {
+		if !seen[tag] {
+			seen[tag] = true
+			result = append(result, tag)
+		}
+	}
+	for _, tag := range b {
+		if !seen[tag] {
+			seen[tag] = true
+			result = append(result, tag)
+		}
+	}
+	return result
+}
+
+// BeadsToSignals converts AnalysisBeads back to RawSignals for output
+// formatting. This bridges the analysis results back into the existing
+// pipeline output flow.
+func BeadsToSignals(beads []AnalysisBead) []signal.RawSignal {
+	signals := make([]signal.RawSignal, len(beads))
+	for i, b := range beads {
+		signals[i] = signal.RawSignal{
+			Source:      "cluster",
+			Kind:        b.Type,
+			Title:       b.Title,
+			Description: b.Description,
+			Confidence:  b.Confidence,
+			Tags:        b.Tags,
+		}
+		// Inherit file path from first source signal if available.
+		if len(b.SourceSignals) > 0 {
+			signals[i].FilePath = b.SourceSignals[0].FilePath
+			signals[i].Line = b.SourceSignals[0].Line
+			signals[i].Author = b.SourceSignals[0].Author
+			signals[i].Timestamp = b.SourceSignals[0].Timestamp
+		}
+	}
+	return signals
+}

--- a/internal/analysis/prompt.go
+++ b/internal/analysis/prompt.go
@@ -1,0 +1,181 @@
+package analysis
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/davetashner/stringer/internal/signal"
+)
+
+// clusterResponseItem represents a single cluster in the LLM's JSON response.
+type clusterResponseItem struct {
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	SignalIDs   []string `json:"signal_ids"`
+}
+
+// clusterResponseWrapper is the top-level JSON structure expected from the LLM.
+type clusterResponseWrapper struct {
+	Clusters []clusterResponseItem `json:"clusters"`
+}
+
+// buildClusteringPrompt constructs the prompt sent to the LLM for clustering.
+// It lists the pre-filtered signal groups with their IDs, titles, kinds, paths,
+// and descriptions, then instructs the LLM to group them by theme.
+func buildClusteringPrompt(groups []SignalGroup) string {
+	var b strings.Builder
+
+	b.WriteString("You are analyzing signals extracted from a software repository. ")
+	b.WriteString("Each signal represents an actionable work item (TODO, bug, code smell, etc.).\n\n")
+	b.WriteString("Below is a list of signals. Group related signals into clusters based on:\n")
+	b.WriteString("- Common theme or topic (e.g., all related to authentication)\n")
+	b.WriteString("- Same module or directory (e.g., all in the database layer)\n")
+	b.WriteString("- Similar intent (e.g., all are performance improvements)\n\n")
+	b.WriteString("SIGNALS:\n")
+	b.WriteString("--------\n")
+
+	for _, group := range groups {
+		for i, idx := range group.MemberIndices {
+			sig := group.Members[i]
+			fmt.Fprintf(&b, "ID: sig-%d\n", idx)
+			fmt.Fprintf(&b, "  Title: %s\n", sig.Title)
+			fmt.Fprintf(&b, "  Kind: %s\n", sig.Kind)
+			fmt.Fprintf(&b, "  Source: %s\n", sig.Source)
+			if sig.FilePath != "" {
+				fmt.Fprintf(&b, "  Path: %s\n", sig.FilePath)
+			}
+			if sig.Description != "" {
+				desc := sig.Description
+				if len(desc) > 200 {
+					desc = desc[:200] + "..."
+				}
+				fmt.Fprintf(&b, "  Description: %s\n", desc)
+			}
+			b.WriteString("\n")
+		}
+	}
+
+	b.WriteString("--------\n\n")
+	b.WriteString("Respond with ONLY a JSON object in the following format (no markdown, no explanation):\n")
+	b.WriteString(`{"clusters": [{"name": "short cluster name", "description": "why these signals are related", "signal_ids": ["sig-0", "sig-1"]}]}`)
+	b.WriteString("\n\n")
+	b.WriteString("Rules:\n")
+	b.WriteString("- Every signal ID must appear in exactly one cluster\n")
+	b.WriteString("- Cluster names should be short (3-6 words)\n")
+	b.WriteString("- If a signal doesn't fit any group, put it in its own single-signal cluster\n")
+	b.WriteString("- Prefer fewer, meaningful clusters over many small ones\n")
+
+	return b.String()
+}
+
+// parseClusterResponse parses the LLM's JSON response into cluster items.
+// It attempts to extract JSON from the response content, handling cases where
+// the LLM wraps the JSON in markdown code fences.
+func parseClusterResponse(content string) ([]clusterResponseItem, error) {
+	content = strings.TrimSpace(content)
+
+	// Strip markdown code fences if present.
+	if strings.HasPrefix(content, "```") {
+		lines := strings.Split(content, "\n")
+		var jsonLines []string
+		inBlock := false
+		for _, line := range lines {
+			trimmed := strings.TrimSpace(line)
+			if strings.HasPrefix(trimmed, "```") {
+				inBlock = !inBlock
+				continue
+			}
+			if inBlock {
+				jsonLines = append(jsonLines, line)
+			}
+		}
+		content = strings.Join(jsonLines, "\n")
+	}
+
+	content = strings.TrimSpace(content)
+
+	// Try parsing as the wrapper format first.
+	var wrapper clusterResponseWrapper
+	if err := json.Unmarshal([]byte(content), &wrapper); err == nil && len(wrapper.Clusters) > 0 {
+		return wrapper.Clusters, nil
+	}
+
+	// Try parsing as a raw array of cluster items.
+	var items []clusterResponseItem
+	if err := json.Unmarshal([]byte(content), &items); err == nil && len(items) > 0 {
+		return items, nil
+	}
+
+	return nil, fmt.Errorf("failed to parse LLM response as cluster JSON: %.200s", content)
+}
+
+// buildEpicPrompt constructs the prompt for generating an epic title and
+// description from a large cluster of signals.
+func buildEpicPrompt(cluster Cluster, signals []signal.RawSignal) string {
+	var b strings.Builder
+
+	b.WriteString("You are summarizing a group of related work items from a software repository.\n\n")
+	fmt.Fprintf(&b, "Cluster name: %s\n", cluster.Name)
+	fmt.Fprintf(&b, "Cluster description: %s\n\n", cluster.Description)
+	b.WriteString("The cluster contains these signals:\n")
+
+	for _, id := range cluster.SignalIDs {
+		sig := findSignalInSlice(id, signals)
+		if sig == nil {
+			continue
+		}
+		fmt.Fprintf(&b, "- %s: %s", id, sig.Title)
+		if sig.FilePath != "" {
+			fmt.Fprintf(&b, " (%s)", sig.FilePath)
+		}
+		b.WriteString("\n")
+	}
+
+	b.WriteString("\nRespond with ONLY a JSON object:\n")
+	b.WriteString(`{"title": "epic title (under 80 chars)", "description": "2-3 sentence summary of the work needed"}`)
+	b.WriteString("\n")
+
+	return b.String()
+}
+
+// epicResponse is the JSON structure for the epic generation LLM response.
+type epicResponse struct {
+	Title       string `json:"title"`
+	Description string `json:"description"`
+}
+
+// parseEpicResponse parses the LLM's response for epic generation.
+func parseEpicResponse(content string) (*epicResponse, error) {
+	content = strings.TrimSpace(content)
+
+	// Strip markdown code fences if present.
+	if strings.HasPrefix(content, "```") {
+		lines := strings.Split(content, "\n")
+		var jsonLines []string
+		inBlock := false
+		for _, line := range lines {
+			trimmed := strings.TrimSpace(line)
+			if strings.HasPrefix(trimmed, "```") {
+				inBlock = !inBlock
+				continue
+			}
+			if inBlock {
+				jsonLines = append(jsonLines, line)
+			}
+		}
+		content = strings.Join(jsonLines, "\n")
+	}
+
+	content = strings.TrimSpace(content)
+
+	var resp epicResponse
+	if err := json.Unmarshal([]byte(content), &resp); err != nil {
+		return nil, fmt.Errorf("failed to parse epic response: %w", err)
+	}
+	if resp.Title == "" {
+		return nil, fmt.Errorf("epic response missing title")
+	}
+
+	return &resp, nil
+}

--- a/internal/analysis/similarity.go
+++ b/internal/analysis/similarity.go
@@ -1,0 +1,164 @@
+package analysis
+
+import (
+	"path/filepath"
+	"strings"
+	"unicode"
+
+	"github.com/davetashner/stringer/internal/signal"
+)
+
+// SignalGroup represents a set of signals that are similar enough to be
+// considered together for LLM clustering. The representative signal is the
+// first signal added to the group.
+type SignalGroup struct {
+	// Representative is the first signal in the group, used as the exemplar.
+	Representative signal.RawSignal
+
+	// Members contains all signals in the group, including the representative.
+	Members []signal.RawSignal
+
+	// MemberIndices tracks the original indices of member signals in the
+	// input slice, used for mapping back to signal IDs.
+	MemberIndices []int
+}
+
+// PreFilterSignals groups signals by similarity to reduce the number of items
+// sent to the LLM. Signals are grouped when they share a common collector
+// source AND either their file paths share a directory prefix OR their titles
+// have a Jaccard similarity above the given threshold.
+func PreFilterSignals(signals []signal.RawSignal, threshold float64) []SignalGroup {
+	if len(signals) == 0 {
+		return nil
+	}
+
+	// assigned tracks which signal indices have been placed into a group.
+	assigned := make([]bool, len(signals))
+	var groups []SignalGroup
+
+	for i := range signals {
+		if assigned[i] {
+			continue
+		}
+
+		group := SignalGroup{
+			Representative: signals[i],
+			Members:        []signal.RawSignal{signals[i]},
+			MemberIndices:  []int{i},
+		}
+		assigned[i] = true
+
+		for j := i + 1; j < len(signals); j++ {
+			if assigned[j] {
+				continue
+			}
+
+			if areSimilar(signals[i], signals[j], threshold) {
+				group.Members = append(group.Members, signals[j])
+				group.MemberIndices = append(group.MemberIndices, j)
+				assigned[j] = true
+			}
+		}
+
+		groups = append(groups, group)
+	}
+
+	return groups
+}
+
+// areSimilar returns true if two signals should be grouped together.
+// Signals must share the same collector source, and either have similar
+// file paths (same directory) or similar titles (Jaccard above threshold).
+func areSimilar(a, b signal.RawSignal, threshold float64) bool {
+	// Must come from the same collector.
+	if a.Source != b.Source {
+		return false
+	}
+
+	// Check directory proximity.
+	if pathSimilar(a.FilePath, b.FilePath) {
+		return true
+	}
+
+	// Check title similarity.
+	return jaccardSimilarity(a.Title, b.Title) >= threshold
+}
+
+// pathSimilar returns true if two file paths share the same parent directory.
+func pathSimilar(a, b string) bool {
+	if a == "" || b == "" {
+		return false
+	}
+	dirA := filepath.Dir(a)
+	dirB := filepath.Dir(b)
+	return dirA == dirB && dirA != "."
+}
+
+// jaccardSimilarity computes the Jaccard index between two strings based on
+// their word tokens. Returns 0.0 for empty inputs and 1.0 for identical inputs.
+func jaccardSimilarity(a, b string) float64 {
+	wordsA := normalizeTitle(a)
+	wordsB := normalizeTitle(b)
+
+	if len(wordsA) == 0 && len(wordsB) == 0 {
+		return 0.0
+	}
+
+	setA := make(map[string]bool, len(wordsA))
+	for _, w := range wordsA {
+		setA[w] = true
+	}
+
+	setB := make(map[string]bool, len(wordsB))
+	for _, w := range wordsB {
+		setB[w] = true
+	}
+
+	// Compute intersection and union sizes.
+	intersection := 0
+	for w := range setA {
+		if setB[w] {
+			intersection++
+		}
+	}
+
+	// Union = |A| + |B| - |intersection|
+	union := len(setA) + len(setB) - intersection
+	if union == 0 {
+		return 0.0
+	}
+
+	return float64(intersection) / float64(union)
+}
+
+// normalizeTitle tokenizes a string into lowercase words, removing
+// punctuation and common stop words.
+func normalizeTitle(s string) []string {
+	s = strings.ToLower(s)
+
+	// Split on non-letter, non-digit characters.
+	words := strings.FieldsFunc(s, func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+	})
+
+	// Filter out very short words and common stop words.
+	stopWords := map[string]bool{
+		"a": true, "an": true, "the": true, "is": true, "it": true,
+		"in": true, "of": true, "to": true, "and": true, "or": true,
+		"for": true, "on": true, "at": true, "by": true, "with": true,
+		"this": true, "that": true, "from": true, "as": true, "be": true,
+	}
+
+	var result []string
+	for _, w := range words {
+		if len(w) < 2 {
+			continue
+		}
+		if stopWords[w] {
+			continue
+		}
+		result = append(result, w)
+	}
+
+	return result
+}


### PR DESCRIPTION
## Summary
- Implements LLM-based signal clustering pipeline (`internal/analysis/`) for grouping related signals into actionable work items [stringer-5zs]
- Pre-filters signals using Jaccard word-level similarity and path proximity before sending to LLM
- Parses LLM JSON responses into typed clusters with confidence scores and combined tags
- Converts clusters to beads output format; creates epic hierarchy for large clusters (>5 signals)
- Adds `--cluster` and `--cluster-threshold` flags to `scan` command (wiring deferred to follow-up PR)
- 65 tests covering similarity, prompt building, response parsing, clustering, merging, and hierarchy

## Test plan
- [x] `go test -race ./internal/analysis/` — all 65 tests pass
- [x] `go test -race ./...` — full suite passes
- [x] `golangci-lint run ./...` — 0 issues
- [x] Non-test lines: ~890 (under 1000-line PR size guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)