### PR TITLE
feat: add LLM-based dependency detection

### DIFF
--- a/internal/analysis/dependency.go
+++ b/internal/analysis/dependency.go
@@ -1,0 +1,354 @@
+package analysis
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/davetashner/stringer/internal/llm"
+	"github.com/davetashner/stringer/internal/output"
+	"github.com/davetashner/stringer/internal/signal"
+)
+
+// BeadDependency represents a dependency relationship between two signals.
+type BeadDependency struct {
+	FromID     string  // Source signal's bead ID.
+	ToID       string  // Target signal's bead ID.
+	Type       string  // Relationship type: "blocks", "parent", "relates-to".
+	Confidence float64 // LLM confidence in this relationship (0.0-1.0).
+}
+
+// depResponseItem represents a single dependency in the LLM's JSON response.
+type depResponseItem struct {
+	From       string  `json:"from"`
+	To         string  `json:"to"`
+	Type       string  `json:"type"`
+	Confidence float64 `json:"confidence"`
+}
+
+// depResponseWrapper is the top-level JSON structure expected from the LLM.
+type depResponseWrapper struct {
+	Dependencies []depResponseItem `json:"dependencies"`
+}
+
+// InferDependencies uses an LLM to identify blocking, parent-child, and
+// relates-to relationships between signals. On LLM error, returns empty deps.
+func InferDependencies(ctx context.Context, signals []signal.RawSignal, provider llm.Provider, idPrefix string) ([]BeadDependency, error) {
+	if len(signals) < 2 {
+		return nil, nil
+	}
+
+	prompt := buildDependencyPrompt(signals)
+
+	resp, err := provider.Complete(ctx, llm.Request{
+		SystemPrompt: "You are a software engineering dependency analysis expert. Always respond with valid JSON only.",
+		Prompt:       prompt,
+		MaxTokens:    4096,
+	})
+	if err != nil {
+		slog.Warn("LLM dependency inference failed, skipping", "error", err)
+		return nil, nil
+	}
+
+	items, err := parseDependencyResponse(resp.Content)
+	if err != nil {
+		slog.Warn("failed to parse dependency response, skipping", "error", err)
+		return nil, nil
+	}
+
+	// Validate signal IDs and build dependencies.
+	validIDs := make(map[string]bool, len(signals))
+	for i := range signals {
+		validIDs[fmt.Sprintf("sig-%d", i)] = true
+	}
+
+	var deps []BeadDependency
+	for _, item := range items {
+		if !validIDs[item.From] || !validIDs[item.To] {
+			slog.Debug("ignoring dependency with unknown signal ID", "from", item.From, "to", item.To)
+			continue
+		}
+		if item.From == item.To {
+			slog.Debug("ignoring self-dependency", "id", item.From)
+			continue
+		}
+		if !isValidDepType(item.Type) {
+			slog.Debug("ignoring invalid dependency type", "type", item.Type)
+			continue
+		}
+		deps = append(deps, BeadDependency{
+			FromID:     item.From,
+			ToID:       item.To,
+			Type:       item.Type,
+			Confidence: item.Confidence,
+		})
+	}
+
+	// Validate DAG for "blocks" edges only.
+	deps = validateDAG(deps)
+
+	// Map sig-N indices to deterministic bead IDs.
+	deps = mapToBeadIDs(deps, signals, idPrefix)
+
+	return deps, nil
+}
+
+// ApplyDepsToSignals populates Blocks and DependsOn fields on signals
+// based on inferred dependencies.
+func ApplyDepsToSignals(signals []signal.RawSignal, deps []BeadDependency, idPrefix string) {
+	// Build a map from bead ID to signal index.
+	beadIDToIdx := make(map[string]int, len(signals))
+	for i, sig := range signals {
+		beadIDToIdx[output.SignalID(sig, idPrefix)] = i
+	}
+
+	for _, dep := range deps {
+		if dep.Type != "blocks" {
+			continue
+		}
+		// FromID blocks ToID: from.Blocks includes to, to.DependsOn includes from.
+		fromIdx, fromOK := beadIDToIdx[dep.FromID]
+		toIdx, toOK := beadIDToIdx[dep.ToID]
+		if !fromOK || !toOK {
+			continue
+		}
+		signals[fromIdx].Blocks = appendUnique(signals[fromIdx].Blocks, dep.ToID)
+		signals[toIdx].DependsOn = appendUnique(signals[toIdx].DependsOn, dep.FromID)
+	}
+}
+
+// buildDependencyPrompt constructs the prompt for dependency inference.
+func buildDependencyPrompt(signals []signal.RawSignal) string {
+	var b strings.Builder
+
+	b.WriteString("You are analyzing work items from a software repository to identify dependencies.\n\n")
+	b.WriteString("Dependency types:\n")
+	b.WriteString("- \"blocks\": Signal A must be completed before Signal B can start\n")
+	b.WriteString("- \"parent\": Signal A is a parent/epic that contains Signal B as a subtask\n")
+	b.WriteString("- \"relates-to\": Signals are related but neither blocks the other\n\n")
+	b.WriteString("SIGNALS:\n")
+	b.WriteString("--------\n")
+
+	for i, sig := range signals {
+		fmt.Fprintf(&b, "ID: sig-%d\n", i)
+		fmt.Fprintf(&b, "  Title: %s\n", sig.Title)
+		fmt.Fprintf(&b, "  Kind: %s\n", sig.Kind)
+		fmt.Fprintf(&b, "  Source: %s\n", sig.Source)
+		if sig.FilePath != "" {
+			fmt.Fprintf(&b, "  Path: %s\n", sig.FilePath)
+		}
+		if len(sig.Tags) > 0 {
+			fmt.Fprintf(&b, "  Tags: %s\n", strings.Join(sig.Tags, ", "))
+		}
+		if sig.Description != "" {
+			desc := sig.Description
+			if len(desc) > 200 {
+				desc = desc[:200] + "..."
+			}
+			fmt.Fprintf(&b, "  Description: %s\n", desc)
+		}
+		b.WriteString("\n")
+	}
+
+	b.WriteString("--------\n\n")
+	b.WriteString("Respond with ONLY a JSON object in the following format (no markdown, no explanation):\n")
+	b.WriteString(`{"dependencies": [{"from": "sig-0", "to": "sig-1", "type": "blocks", "confidence": 0.8}]}`)
+	b.WriteString("\n\n")
+	b.WriteString("Rules:\n")
+	b.WriteString("- Only include dependencies you are confident about (confidence >= 0.6)\n")
+	b.WriteString("- \"blocks\" means the 'from' signal must be done before 'to' can start\n")
+	b.WriteString("- Avoid creating circular blocking chains\n")
+	b.WriteString("- If no dependencies exist, return {\"dependencies\": []}\n")
+	b.WriteString("- A signal cannot depend on itself\n")
+
+	return b.String()
+}
+
+// parseDependencyResponse parses the LLM's JSON response into dependency items.
+func parseDependencyResponse(content string) ([]depResponseItem, error) {
+	content = strings.TrimSpace(content)
+
+	// Strip markdown code fences if present.
+	if strings.HasPrefix(content, "```") {
+		lines := strings.Split(content, "\n")
+		var jsonLines []string
+		inBlock := false
+		for _, line := range lines {
+			trimmed := strings.TrimSpace(line)
+			if strings.HasPrefix(trimmed, "```") {
+				inBlock = !inBlock
+				continue
+			}
+			if inBlock {
+				jsonLines = append(jsonLines, line)
+			}
+		}
+		content = strings.Join(jsonLines, "\n")
+	}
+
+	content = strings.TrimSpace(content)
+
+	// Try wrapper format first.
+	var wrapper depResponseWrapper
+	if err := json.Unmarshal([]byte(content), &wrapper); err == nil {
+		return wrapper.Dependencies, nil
+	}
+
+	// Try raw array.
+	var items []depResponseItem
+	if err := json.Unmarshal([]byte(content), &items); err == nil {
+		return items, nil
+	}
+
+	return nil, fmt.Errorf("failed to parse LLM response as dependency JSON: %.200s", content)
+}
+
+// adjacencyList represents a directed graph.
+type adjacencyList map[string][]string
+
+// buildDependencyGraph constructs a directed graph from "blocks" dependencies.
+func buildDependencyGraph(deps []BeadDependency) adjacencyList {
+	graph := make(adjacencyList)
+	for _, dep := range deps {
+		if dep.Type == "blocks" {
+			graph[dep.FromID] = append(graph[dep.FromID], dep.ToID)
+			// Ensure ToID exists in graph even if it has no outgoing edges.
+			if _, ok := graph[dep.ToID]; !ok {
+				graph[dep.ToID] = nil
+			}
+		}
+	}
+	return graph
+}
+
+// validateDAG checks that "blocks" edges form a DAG. If cycles are detected,
+// the lowest-confidence edge in each cycle is removed.
+func validateDAG(deps []BeadDependency) []BeadDependency {
+	// Extract only "blocks" edges for cycle detection.
+	var blockDeps []BeadDependency
+	var otherDeps []BeadDependency
+	for _, d := range deps {
+		if d.Type == "blocks" {
+			blockDeps = append(blockDeps, d)
+		} else {
+			otherDeps = append(otherDeps, d)
+		}
+	}
+
+	if len(blockDeps) == 0 {
+		return deps
+	}
+
+	// Iteratively remove lowest-confidence edge until DAG.
+	for {
+		graph := buildDependencyGraph(blockDeps)
+		if !hasCycle(graph) {
+			break
+		}
+
+		// Find and remove the lowest-confidence "blocks" edge.
+		minIdx := 0
+		for i, d := range blockDeps {
+			if d.Confidence < blockDeps[minIdx].Confidence {
+				minIdx = i
+			}
+		}
+		slog.Warn("breaking dependency cycle by removing lowest-confidence edge",
+			"from", blockDeps[minIdx].FromID, "to", blockDeps[minIdx].ToID,
+			"confidence", blockDeps[minIdx].Confidence)
+		blockDeps = append(blockDeps[:minIdx], blockDeps[minIdx+1:]...)
+
+		if len(blockDeps) == 0 {
+			break
+		}
+	}
+
+	return append(blockDeps, otherDeps...)
+}
+
+// hasCycle detects cycles using Kahn's algorithm (topological sort).
+// Returns true if the graph contains a cycle.
+func hasCycle(graph adjacencyList) bool {
+	// Compute in-degrees.
+	inDegree := make(map[string]int)
+	for node := range graph {
+		if _, ok := inDegree[node]; !ok {
+			inDegree[node] = 0
+		}
+		for _, neighbor := range graph[node] {
+			inDegree[neighbor]++
+		}
+	}
+
+	// Collect nodes with in-degree 0.
+	var queue []string
+	for node, deg := range inDegree {
+		if deg == 0 {
+			queue = append(queue, node)
+		}
+	}
+
+	visited := 0
+	for len(queue) > 0 {
+		node := queue[0]
+		queue = queue[1:]
+		visited++
+
+		for _, neighbor := range graph[node] {
+			inDegree[neighbor]--
+			if inDegree[neighbor] == 0 {
+				queue = append(queue, neighbor)
+			}
+		}
+	}
+
+	return visited < len(inDegree)
+}
+
+// mapToBeadIDs converts sig-N index references in dependencies to
+// deterministic bead IDs using SignalID.
+func mapToBeadIDs(deps []BeadDependency, signals []signal.RawSignal, idPrefix string) []BeadDependency {
+	// Build index → bead ID map.
+	idMap := make(map[string]string, len(signals))
+	for i, sig := range signals {
+		idMap[fmt.Sprintf("sig-%d", i)] = output.SignalID(sig, idPrefix)
+	}
+
+	result := make([]BeadDependency, 0, len(deps))
+	for _, dep := range deps {
+		fromBead, fromOK := idMap[dep.FromID]
+		toBead, toOK := idMap[dep.ToID]
+		if !fromOK || !toOK {
+			continue
+		}
+		result = append(result, BeadDependency{
+			FromID:     fromBead,
+			ToID:       toBead,
+			Type:       dep.Type,
+			Confidence: dep.Confidence,
+		})
+	}
+	return result
+}
+
+// isValidDepType returns true if the given type is a recognized dependency type.
+func isValidDepType(t string) bool {
+	switch t {
+	case "blocks", "parent", "relates-to":
+		return true
+	default:
+		return false
+	}
+}
+
+// appendUnique appends s to the slice only if it's not already present.
+func appendUnique(slice []string, s string) []string {
+	for _, existing := range slice {
+		if existing == s {
+			return slice
+		}
+	}
+	return append(slice, s)
+}

--- a/internal/analysis/dependency_test.go
+++ b/internal/analysis/dependency_test.go
@@ -1,0 +1,478 @@
+package analysis
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/davetashner/stringer/internal/llm"
+	"github.com/davetashner/stringer/internal/output"
+	"github.com/davetashner/stringer/internal/signal"
+)
+
+// -----------------------------------------------------------------------
+// buildDependencyPrompt tests
+// -----------------------------------------------------------------------
+
+func TestBuildDependencyPrompt_ContainsSignals(t *testing.T) {
+	signals := testSignals()
+	prompt := buildDependencyPrompt(signals)
+
+	assert.Contains(t, prompt, "sig-0")
+	assert.Contains(t, prompt, "sig-1")
+	assert.Contains(t, prompt, "sig-2")
+	assert.Contains(t, prompt, "fix auth error")
+	assert.Contains(t, prompt, "blocks")
+	assert.Contains(t, prompt, "parent")
+	assert.Contains(t, prompt, "relates-to")
+	assert.Contains(t, prompt, "JSON")
+}
+
+func TestBuildDependencyPrompt_TruncatesDescription(t *testing.T) {
+	longDesc := ""
+	for i := 0; i < 300; i++ {
+		longDesc += "y"
+	}
+	signals := []signal.RawSignal{
+		{Source: "todos", Kind: "todo", Title: "test", Description: longDesc},
+		{Source: "todos", Kind: "todo", Title: "test2"},
+	}
+	prompt := buildDependencyPrompt(signals)
+	assert.Contains(t, prompt, "...")
+}
+
+// -----------------------------------------------------------------------
+// parseDependencyResponse tests
+// -----------------------------------------------------------------------
+
+func TestParseDependencyResponse_ValidWrapper(t *testing.T) {
+	input := `{"dependencies": [{"from": "sig-0", "to": "sig-1", "type": "blocks", "confidence": 0.9}]}`
+	items, err := parseDependencyResponse(input)
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	assert.Equal(t, "sig-0", items[0].From)
+	assert.Equal(t, "sig-1", items[0].To)
+	assert.Equal(t, "blocks", items[0].Type)
+	assert.InDelta(t, 0.9, items[0].Confidence, 0.01)
+}
+
+func TestParseDependencyResponse_ValidArray(t *testing.T) {
+	input := `[{"from": "sig-0", "to": "sig-1", "type": "blocks", "confidence": 0.8}]`
+	items, err := parseDependencyResponse(input)
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+}
+
+func TestParseDependencyResponse_EmptyDeps(t *testing.T) {
+	input := `{"dependencies": []}`
+	items, err := parseDependencyResponse(input)
+	require.NoError(t, err)
+	assert.Empty(t, items)
+}
+
+func TestParseDependencyResponse_WithCodeFences(t *testing.T) {
+	input := "```json\n" + `{"dependencies": [{"from": "sig-0", "to": "sig-1", "type": "blocks", "confidence": 0.7}]}` + "\n```"
+	items, err := parseDependencyResponse(input)
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+}
+
+func TestParseDependencyResponse_InvalidJSON(t *testing.T) {
+	_, err := parseDependencyResponse("not json")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse")
+}
+
+func TestParseDependencyResponse_EmptyContent(t *testing.T) {
+	_, err := parseDependencyResponse("")
+	require.Error(t, err)
+}
+
+func TestParseDependencyResponse_MultipleDeps(t *testing.T) {
+	input := `{"dependencies": [
+		{"from": "sig-0", "to": "sig-1", "type": "blocks", "confidence": 0.9},
+		{"from": "sig-1", "to": "sig-2", "type": "relates-to", "confidence": 0.7},
+		{"from": "sig-0", "to": "sig-2", "type": "parent", "confidence": 0.8}
+	]}`
+	items, err := parseDependencyResponse(input)
+	require.NoError(t, err)
+	require.Len(t, items, 3)
+}
+
+// -----------------------------------------------------------------------
+// hasCycle tests
+// -----------------------------------------------------------------------
+
+func TestHasCycle_NoCycle(t *testing.T) {
+	graph := adjacencyList{
+		"sig-0": {"sig-1"},
+		"sig-1": {"sig-2"},
+		"sig-2": nil,
+	}
+	assert.False(t, hasCycle(graph))
+}
+
+func TestHasCycle_WithCycle(t *testing.T) {
+	graph := adjacencyList{
+		"sig-0": {"sig-1"},
+		"sig-1": {"sig-2"},
+		"sig-2": {"sig-0"},
+	}
+	assert.True(t, hasCycle(graph))
+}
+
+func TestHasCycle_SelfLoop(t *testing.T) {
+	graph := adjacencyList{
+		"sig-0": {"sig-0"},
+	}
+	assert.True(t, hasCycle(graph))
+}
+
+func TestHasCycle_Empty(t *testing.T) {
+	assert.False(t, hasCycle(adjacencyList{}))
+}
+
+func TestHasCycle_DiamondNoCycle(t *testing.T) {
+	graph := adjacencyList{
+		"sig-0": {"sig-1", "sig-2"},
+		"sig-1": {"sig-3"},
+		"sig-2": {"sig-3"},
+		"sig-3": nil,
+	}
+	assert.False(t, hasCycle(graph))
+}
+
+// -----------------------------------------------------------------------
+// validateDAG tests
+// -----------------------------------------------------------------------
+
+func TestValidateDAG_NoCycle(t *testing.T) {
+	deps := []BeadDependency{
+		{FromID: "sig-0", ToID: "sig-1", Type: "blocks", Confidence: 0.9},
+		{FromID: "sig-1", ToID: "sig-2", Type: "blocks", Confidence: 0.8},
+	}
+	result := validateDAG(deps)
+	assert.Len(t, result, 2)
+}
+
+func TestValidateDAG_CycleBreaksLowestConfidence(t *testing.T) {
+	deps := []BeadDependency{
+		{FromID: "sig-0", ToID: "sig-1", Type: "blocks", Confidence: 0.9},
+		{FromID: "sig-1", ToID: "sig-2", Type: "blocks", Confidence: 0.5}, // Lowest confidence.
+		{FromID: "sig-2", ToID: "sig-0", Type: "blocks", Confidence: 0.7},
+	}
+	result := validateDAG(deps)
+
+	// The cycle should be broken by removing the edge with confidence 0.5.
+	assert.Less(t, len(result), 3)
+
+	// Verify remaining edges form a DAG.
+	var blockDeps []BeadDependency
+	for _, d := range result {
+		if d.Type == "blocks" {
+			blockDeps = append(blockDeps, d)
+		}
+	}
+	graph := buildDependencyGraph(blockDeps)
+	assert.False(t, hasCycle(graph))
+}
+
+func TestValidateDAG_PreservesNonBlockEdges(t *testing.T) {
+	deps := []BeadDependency{
+		{FromID: "sig-0", ToID: "sig-1", Type: "blocks", Confidence: 0.9},
+		{FromID: "sig-1", ToID: "sig-0", Type: "blocks", Confidence: 0.5}, // Creates cycle.
+		{FromID: "sig-0", ToID: "sig-1", Type: "relates-to", Confidence: 0.7},
+	}
+	result := validateDAG(deps)
+
+	// "relates-to" should always be preserved.
+	var relatesToCount int
+	for _, d := range result {
+		if d.Type == "relates-to" {
+			relatesToCount++
+		}
+	}
+	assert.Equal(t, 1, relatesToCount)
+}
+
+func TestValidateDAG_NoDeps(t *testing.T) {
+	result := validateDAG(nil)
+	assert.Nil(t, result)
+}
+
+// -----------------------------------------------------------------------
+// mapToBeadIDs tests
+// -----------------------------------------------------------------------
+
+func TestMapToBeadIDs_ConvertsIDs(t *testing.T) {
+	signals := []signal.RawSignal{
+		{Source: "todos", Kind: "todo", Title: "fix auth", FilePath: "auth.go", Line: 1},
+		{Source: "todos", Kind: "todo", Title: "fix db", FilePath: "db.go", Line: 1},
+	}
+	deps := []BeadDependency{
+		{FromID: "sig-0", ToID: "sig-1", Type: "blocks", Confidence: 0.9},
+	}
+
+	result := mapToBeadIDs(deps, signals, "str-")
+	require.Len(t, result, 1)
+
+	expectedFrom := output.SignalID(signals[0], "str-")
+	expectedTo := output.SignalID(signals[1], "str-")
+	assert.Equal(t, expectedFrom, result[0].FromID)
+	assert.Equal(t, expectedTo, result[0].ToID)
+	assert.Equal(t, "blocks", result[0].Type)
+}
+
+func TestMapToBeadIDs_InvalidIDsDropped(t *testing.T) {
+	signals := []signal.RawSignal{
+		{Source: "todos", Kind: "todo", Title: "test"},
+	}
+	deps := []BeadDependency{
+		{FromID: "sig-0", ToID: "sig-999", Type: "blocks", Confidence: 0.9},
+	}
+
+	result := mapToBeadIDs(deps, signals, "str-")
+	assert.Empty(t, result)
+}
+
+// -----------------------------------------------------------------------
+// ApplyDepsToSignals tests
+// -----------------------------------------------------------------------
+
+func TestApplyDepsToSignals_SetsBlocksAndDependsOn(t *testing.T) {
+	signals := []signal.RawSignal{
+		{Source: "todos", Kind: "todo", Title: "fix auth", FilePath: "auth.go", Line: 1},
+		{Source: "todos", Kind: "todo", Title: "fix db", FilePath: "db.go", Line: 1},
+	}
+
+	id0 := output.SignalID(signals[0], "str-")
+	id1 := output.SignalID(signals[1], "str-")
+
+	deps := []BeadDependency{
+		{FromID: id0, ToID: id1, Type: "blocks", Confidence: 0.9},
+	}
+
+	ApplyDepsToSignals(signals, deps, "str-")
+
+	assert.Contains(t, signals[0].Blocks, id1)
+	assert.Contains(t, signals[1].DependsOn, id0)
+}
+
+func TestApplyDepsToSignals_IgnoresNonBlockDeps(t *testing.T) {
+	signals := []signal.RawSignal{
+		{Source: "todos", Kind: "todo", Title: "a"},
+		{Source: "todos", Kind: "todo", Title: "b"},
+	}
+
+	id0 := output.SignalID(signals[0], "str-")
+	id1 := output.SignalID(signals[1], "str-")
+
+	deps := []BeadDependency{
+		{FromID: id0, ToID: id1, Type: "relates-to", Confidence: 0.7},
+	}
+
+	ApplyDepsToSignals(signals, deps, "str-")
+
+	assert.Empty(t, signals[0].Blocks)
+	assert.Empty(t, signals[1].DependsOn)
+}
+
+func TestApplyDepsToSignals_NoDuplicates(t *testing.T) {
+	signals := []signal.RawSignal{
+		{Source: "todos", Kind: "todo", Title: "fix auth", FilePath: "auth.go", Line: 1},
+		{Source: "todos", Kind: "todo", Title: "fix db", FilePath: "db.go", Line: 1},
+	}
+
+	id0 := output.SignalID(signals[0], "str-")
+	id1 := output.SignalID(signals[1], "str-")
+
+	deps := []BeadDependency{
+		{FromID: id0, ToID: id1, Type: "blocks", Confidence: 0.9},
+		{FromID: id0, ToID: id1, Type: "blocks", Confidence: 0.8}, // Duplicate.
+	}
+
+	ApplyDepsToSignals(signals, deps, "str-")
+
+	assert.Len(t, signals[0].Blocks, 1)
+	assert.Len(t, signals[1].DependsOn, 1)
+}
+
+// -----------------------------------------------------------------------
+// InferDependencies end-to-end tests
+// -----------------------------------------------------------------------
+
+func TestInferDependencies_Success(t *testing.T) {
+	signals := testSignals()
+
+	responseJSON := mustJSON(t, depResponseWrapper{
+		Dependencies: []depResponseItem{
+			{From: "sig-0", To: "sig-1", Type: "blocks", Confidence: 0.9},
+			{From: "sig-1", To: "sig-2", Type: "relates-to", Confidence: 0.7},
+		},
+	})
+
+	mock := llm.NewMockProvider(llm.MockResponse{Content: responseJSON})
+	deps, err := InferDependencies(context.Background(), signals, mock, "str-")
+	require.NoError(t, err)
+	require.Len(t, deps, 2)
+
+	// IDs should be mapped to bead IDs (not sig-N).
+	assert.NotContains(t, deps[0].FromID, "sig-")
+	assert.NotContains(t, deps[0].ToID, "sig-")
+
+	// Verify LLM was called.
+	calls := mock.Calls()
+	require.Len(t, calls, 1)
+	assert.Contains(t, calls[0].SystemPrompt, "dependency analysis expert")
+}
+
+func TestInferDependencies_LLMError_Fallback(t *testing.T) {
+	signals := testSignals()
+	mock := llm.NewMockProvider(llm.MockResponse{Err: errors.New("API down")})
+
+	deps, err := InferDependencies(context.Background(), signals, mock, "str-")
+	require.NoError(t, err)
+	assert.Empty(t, deps)
+}
+
+func TestInferDependencies_BadJSON_Fallback(t *testing.T) {
+	signals := testSignals()
+	mock := llm.NewMockProvider(llm.MockResponse{Content: "not json"})
+
+	deps, err := InferDependencies(context.Background(), signals, mock, "str-")
+	require.NoError(t, err)
+	assert.Empty(t, deps)
+}
+
+func TestInferDependencies_SingleSignal(t *testing.T) {
+	signals := []signal.RawSignal{{Source: "todos", Title: "lonely"}}
+	mock := llm.NewMockProvider()
+
+	deps, err := InferDependencies(context.Background(), signals, mock, "str-")
+	require.NoError(t, err)
+	assert.Nil(t, deps)
+	assert.Empty(t, mock.Calls(), "LLM should not be called for <2 signals")
+}
+
+func TestInferDependencies_EmptySignals(t *testing.T) {
+	mock := llm.NewMockProvider()
+	deps, err := InferDependencies(context.Background(), nil, mock, "str-")
+	require.NoError(t, err)
+	assert.Nil(t, deps)
+}
+
+func TestInferDependencies_InvalidSignalIDsIgnored(t *testing.T) {
+	signals := testSignals()
+
+	responseJSON := mustJSON(t, depResponseWrapper{
+		Dependencies: []depResponseItem{
+			{From: "sig-999", To: "sig-0", Type: "blocks", Confidence: 0.9},
+		},
+	})
+
+	mock := llm.NewMockProvider(llm.MockResponse{Content: responseJSON})
+	deps, err := InferDependencies(context.Background(), signals, mock, "str-")
+	require.NoError(t, err)
+	assert.Empty(t, deps)
+}
+
+func TestInferDependencies_SelfDependencyIgnored(t *testing.T) {
+	signals := testSignals()
+
+	responseJSON := mustJSON(t, depResponseWrapper{
+		Dependencies: []depResponseItem{
+			{From: "sig-0", To: "sig-0", Type: "blocks", Confidence: 0.9},
+		},
+	})
+
+	mock := llm.NewMockProvider(llm.MockResponse{Content: responseJSON})
+	deps, err := InferDependencies(context.Background(), signals, mock, "str-")
+	require.NoError(t, err)
+	assert.Empty(t, deps)
+}
+
+func TestInferDependencies_InvalidTypeIgnored(t *testing.T) {
+	signals := testSignals()
+
+	responseJSON := mustJSON(t, depResponseWrapper{
+		Dependencies: []depResponseItem{
+			{From: "sig-0", To: "sig-1", Type: "invalid-type", Confidence: 0.9},
+		},
+	})
+
+	mock := llm.NewMockProvider(llm.MockResponse{Content: responseJSON})
+	deps, err := InferDependencies(context.Background(), signals, mock, "str-")
+	require.NoError(t, err)
+	assert.Empty(t, deps)
+}
+
+func TestInferDependencies_CycleDetectionAndBreaking(t *testing.T) {
+	signals := testSignals()
+
+	responseJSON := mustJSON(t, depResponseWrapper{
+		Dependencies: []depResponseItem{
+			{From: "sig-0", To: "sig-1", Type: "blocks", Confidence: 0.9},
+			{From: "sig-1", To: "sig-2", Type: "blocks", Confidence: 0.5}, // Lowest confidence.
+			{From: "sig-2", To: "sig-0", Type: "blocks", Confidence: 0.7},
+		},
+	})
+
+	mock := llm.NewMockProvider(llm.MockResponse{Content: responseJSON})
+	deps, err := InferDependencies(context.Background(), signals, mock, "str-")
+	require.NoError(t, err)
+
+	// Cycle should be broken — fewer than 3 "blocks" edges remain.
+	var blockCount int
+	for _, d := range deps {
+		if d.Type == "blocks" {
+			blockCount++
+		}
+	}
+	assert.Less(t, blockCount, 3)
+}
+
+func TestInferDependencies_ContextCancelled(t *testing.T) {
+	signals := testSignals()
+	mock := llm.NewMockProvider(llm.MockResponse{Content: "{}"})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	deps, err := InferDependencies(ctx, signals, mock, "str-")
+	require.NoError(t, err)
+	assert.Empty(t, deps)
+}
+
+// -----------------------------------------------------------------------
+// isValidDepType tests
+// -----------------------------------------------------------------------
+
+func TestIsValidDepType(t *testing.T) {
+	assert.True(t, isValidDepType("blocks"))
+	assert.True(t, isValidDepType("parent"))
+	assert.True(t, isValidDepType("relates-to"))
+	assert.False(t, isValidDepType("unknown"))
+	assert.False(t, isValidDepType(""))
+}
+
+// -----------------------------------------------------------------------
+// appendUnique tests
+// -----------------------------------------------------------------------
+
+func TestAppendUnique_AddsNew(t *testing.T) {
+	result := appendUnique([]string{"a", "b"}, "c")
+	assert.Equal(t, []string{"a", "b", "c"}, result)
+}
+
+func TestAppendUnique_SkipsDuplicate(t *testing.T) {
+	result := appendUnique([]string{"a", "b"}, "a")
+	assert.Equal(t, []string{"a", "b"}, result)
+}
+
+func TestAppendUnique_NilSlice(t *testing.T) {
+	result := appendUnique(nil, "a")
+	assert.Equal(t, []string{"a"}, result)
+}

--- a/internal/output/beads.go
+++ b/internal/output/beads.go
@@ -25,6 +25,8 @@ type beadRecord struct {
 	Labels      []string `json:"labels,omitempty"`
 	ClosedAt    string   `json:"closed_at,omitempty"`
 	CloseReason string   `json:"close_reason,omitempty"`
+	Blocks      []string `json:"blocks,omitempty"`
+	DependsOn   []string `json:"depends_on,omitempty"`
 }
 
 func init() {
@@ -91,6 +93,8 @@ func (b *BeadsFormatter) signalToBead(sig signal.RawSignal) beadRecord {
 		CreatedAt:   formatTimestamp(sig.Timestamp),
 		CreatedBy:   resolveAuthor(sig.Author),
 		Labels:      b.buildLabels(sig),
+		Blocks:      sig.Blocks,
+		DependsOn:   sig.DependsOn,
 	}
 
 	if hasTag(sig.Tags, "pre-closed") {
@@ -127,13 +131,13 @@ func deriveCloseReason(kind string) string {
 }
 
 // generateID produces a deterministic ID from signal content.
-// It delegates to the shared signalID helper and applies convention overrides.
+// It delegates to the shared SignalID helper and applies convention overrides.
 func (b *BeadsFormatter) generateID(sig signal.RawSignal) string {
 	prefix := "str-"
 	if b.conventions != nil && b.conventions.IDPrefix != "" {
 		prefix = b.conventions.IDPrefix
 	}
-	return signalID(sig, prefix)
+	return SignalID(sig, prefix)
 }
 
 // mapKindToType maps a signal Kind to a bead type.

--- a/internal/output/signalid.go
+++ b/internal/output/signalid.go
@@ -7,10 +7,10 @@ import (
 	"github.com/davetashner/stringer/internal/signal"
 )
 
-// signalID produces a deterministic ID from signal content.
+// SignalID produces a deterministic ID from signal content.
 // It hashes Source + Kind + FilePath + Line + Title using SHA-256,
 // truncates to 8 hex characters, and prepends the given prefix.
-func signalID(sig signal.RawSignal, prefix string) string {
+func SignalID(sig signal.RawSignal, prefix string) string {
 	h := sha256.New()
 	// Write each field separated by null bytes to avoid collisions
 	// from field concatenation (e.g., "ab"+"c" vs "a"+"bc").

--- a/internal/output/signalid_test.go
+++ b/internal/output/signalid_test.go
@@ -16,8 +16,8 @@ func TestSignalID_Deterministic(t *testing.T) {
 		Title:    "Add tests",
 	}
 
-	id1 := signalID(sig, "str-")
-	id2 := signalID(sig, "str-")
+	id1 := SignalID(sig, "str-")
+	id2 := SignalID(sig, "str-")
 	assert.Equal(t, id1, id2, "same signal should produce the same ID")
 }
 
@@ -30,7 +30,7 @@ func TestSignalID_Format(t *testing.T) {
 		Title:    "Test",
 	}
 
-	id := signalID(sig, "str-")
+	id := SignalID(sig, "str-")
 	assert.Regexp(t, `^str-[0-9a-f]{8}$`, id, "ID should be str- prefix + 8 hex chars")
 }
 
@@ -43,7 +43,7 @@ func TestSignalID_CustomPrefix(t *testing.T) {
 		Title:    "Test",
 	}
 
-	id := signalID(sig, "proj-")
+	id := SignalID(sig, "proj-")
 	assert.Regexp(t, `^proj-[0-9a-f]{8}$`, id, "ID should use the given prefix")
 }
 
@@ -67,11 +67,11 @@ func TestSignalID_FieldSensitivity(t *testing.T) {
 		{"different_title", func(s signal.RawSignal) signal.RawSignal { s.Title = "Different title"; return s }},
 	}
 
-	baseID := signalID(base, "str-")
+	baseID := SignalID(base, "str-")
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mutated := tt.mutate(base)
-			mutatedID := signalID(mutated, "str-")
+			mutatedID := SignalID(mutated, "str-")
 			assert.NotEqual(t, baseID, mutatedID, "changing %s should produce a different ID", tt.name)
 		})
 	}
@@ -80,7 +80,7 @@ func TestSignalID_FieldSensitivity(t *testing.T) {
 func TestSignalID_MatchesBeadsFormatter(t *testing.T) {
 	sig := testSignal()
 
-	sharedID := signalID(sig, "str-")
+	sharedID := SignalID(sig, "str-")
 	beadsID := NewBeadsFormatter().generateID(sig)
-	assert.Equal(t, beadsID, sharedID, "signalID and BeadsFormatter.generateID should produce identical IDs")
+	assert.Equal(t, beadsID, sharedID, "SignalID and BeadsFormatter.generateID should produce identical IDs")
 }

--- a/internal/output/tasks.go
+++ b/internal/output/tasks.go
@@ -131,7 +131,7 @@ func signalToTask(s signal.RawSignal) taskRecord {
 	}
 
 	return taskRecord{
-		ID:          signalID(s, "str-"),
+		ID:          SignalID(s, "str-"),
 		Subject:     subjectForSignal(s),
 		Description: descriptionForSignal(s),
 		ActiveForm:  activeFormForSignal(s),

--- a/internal/signal/signal.go
+++ b/internal/signal/signal.go
@@ -31,6 +31,8 @@ type RawSignal struct {
 	Tags        []string  // Free-form tags for clustering hints.
 	ClosedAt    time.Time // When this signal was closed/resolved (zero if open).
 	Priority    *int      // LLM-inferred priority (1-4). Nil = use confidence mapping.
+	Blocks      []string  // Bead IDs this signal blocks (downstream depends on this).
+	DependsOn   []string  // Bead IDs this signal depends on (upstream blockers).
 }
 
 // CollectorOpts holds per-collector configuration options.


### PR DESCRIPTION
## Summary
- Adds `--infer-deps` flag that uses an LLM to identify blocking, parent-child, and relates-to relationships between signals
- Adds `Blocks` and `DependsOn` fields to `RawSignal` and the beads JSONL output
- Exports `SignalID()` for cross-package bead ID computation
- Implements Kahn's algorithm for DAG validation — cycles are broken by removing the lowest-confidence edge
- Shared LLM provider with `--infer-priority` when both flags are used together
- Graceful fallback: on LLM error, no dependencies emitted

**Epic**: `stringer-3cs` (LLM4: Dependency Detection)
**Depends on**: PR #161 (LLM3: Priority Inference)

## Test plan
- [x] Unit tests for prompt building and description truncation
- [x] Unit tests for response parsing (valid JSON, array, code fences, empty deps, invalid JSON)
- [x] Unit tests for cycle detection (no cycle, cycle, self-loop, diamond)
- [x] Unit tests for DAG validation (cycle breaking with lowest confidence edge removal, non-block edge preservation)
- [x] Unit tests for bead ID mapping (valid conversion, invalid IDs dropped)
- [x] Unit tests for ApplyDepsToSignals (blocks/dependsOn set, non-block ignored, no duplicates)
- [x] Integration tests for InferDependencies (success, LLM error, bad JSON, single signal, empty, invalid IDs, self-dep, invalid type, cycles, context cancellation)
- [x] Full test suite passes (`go test -race ./...`)
- [x] Linter passes (`golangci-lint run ./...`)
- [ ] Manual: `stringer scan --infer-deps .` with ANTHROPIC_API_KEY set
- [ ] Manual: verify beads JSONL includes `blocks` and `depends_on` fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)