### PR TITLE
fix: exclude vendor and third-party code from scanning

### DIFF
--- a/internal/collectors/todos.go
+++ b/internal/collectors/todos.go
@@ -62,6 +62,12 @@ var defaultExcludePatterns = []string{
 	"CHANGES*",
 	"HISTORY*",
 	"NEWS*",
+	"third_party/**",
+	"3rdparty/**",
+	"extern/**",
+	"external/**",
+	"bower_components/**",
+	"wwwroot/lib/**",
 }
 
 // defaultDemoPatterns are directory globs for demo/example/tutorial paths.
@@ -386,7 +392,14 @@ func shouldExclude(relPath string, patterns []string) bool {
 		// Handle ** patterns: "vendor/**" should match vendor/ and anything below.
 		if strings.HasSuffix(pattern, "/**") {
 			dir := strings.TrimSuffix(pattern, "/**")
-			if relPath == dir || strings.HasPrefix(relPath, dir+string(filepath.Separator)) {
+			sep := string(filepath.Separator)
+			// Match at root: vendor/foo.go
+			if relPath == dir || strings.HasPrefix(relPath, dir+sep) {
+				return true
+			}
+			// Match interior segments: "wwwroot/lib/**" matches
+			// "samples/foo/wwwroot/lib/bootstrap.js"
+			if strings.Contains(relPath, sep+dir+sep) || strings.HasSuffix(relPath, sep+dir) {
 				return true
 			}
 		}


### PR DESCRIPTION
## Summary

- Add 6 new vendor/third-party directory patterns to `defaultExcludePatterns`: `third_party/**`, `3rdparty/**`, `extern/**`, `external/**`, `bower_components/**`, `wwwroot/lib/**`
- Update `shouldExclude()` to match `/**` patterns at any directory depth (interior segment matching), not just the repo root — fixes missed exclusions like `samples/foo/wwwroot/lib/bootstrap.js`
- Add unit tests for interior matching and an integration test verifying vendored TODOs are excluded end-to-end

Fixes [stringer-4q1] — cross-language evaluation found Aspire samples produce 102 of 104 TODO signals from vendored Bootstrap JS under `wwwroot/lib/`.

## Test plan

- [x] `TestShouldExclude` — 6 new cases for interior matching and false-match prevention
- [x] `TestCollect_VendoredWwwrootLibExcluded` — integration test with nested vendor paths
- [x] Full `go test -race ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)