### PR TITLE
feat: add DCO enforcement for OpenSSF gold badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -517,6 +517,41 @@ jobs:
               print('✓ No stale blockers')
           "
 
+  dco:
+    name: DCO
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          fetch-depth: 0
+      - name: Check DCO sign-off
+        run: |
+          base="${{ github.event.pull_request.base.sha }}"
+          head="${{ github.event.pull_request.head.sha }}"
+          failed=0
+          while IFS= read -r sha; do
+            # Skip merge commits
+            parents=$(git rev-list --parents -n1 "$sha" | wc -w)
+            if [ "$parents" -gt 2 ]; then
+              continue
+            fi
+            body=$(git log -1 --format=%B "$sha")
+            if ! echo "$body" | grep -qiE '^Signed-off-by: .+ <.+>'; then
+              subject=$(git log -1 --format=%s "$sha")
+              echo "::error::Missing DCO sign-off in commit ${sha:0:8}: $subject"
+              echo "  Add: git commit --amend -s --no-edit"
+              failed=1
+            fi
+          done < <(git rev-list "$base".."$head")
+          if [ "$failed" -eq 1 ]; then
+            echo ""
+            echo "All commits must include a Signed-off-by line."
+            echo "See https://developercertificate.org/ and CONTRIBUTING.md for details."
+            exit 1
+          fi
+          echo "All commits have DCO sign-off."
+
   fuzz:
     name: Fuzz
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,6 +123,37 @@ git push origin v0.x.0
 # GoReleaser builds binaries, publishes GitHub Release, updates Homebrew tap
 ```
 
+## Developer Certificate of Origin (DCO)
+
+All contributions to Stringer must be signed off to certify that you have the right to submit the work under the project's MIT license. This is enforced via the [Developer Certificate of Origin](https://developercertificate.org/).
+
+Add a `Signed-off-by` line to every commit:
+
+```bash
+git commit -s -m "feat: add new collector"
+```
+
+This adds a line like:
+
+```
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+Git uses your `user.name` and `user.email` settings. If you haven't configured them:
+
+```bash
+git config --global user.name "Your Name"
+git config --global user.email "your.email@example.com"
+```
+
+If you forget to sign off, amend the commit:
+
+```bash
+git commit --amend -s --no-edit
+```
+
+The DCO check in CI will fail if any commit in a PR is missing a sign-off.
+
 ## License
 
 By contributing, you agree that your contributions will be licensed under the [MIT License](./LICENSE).


### PR DESCRIPTION
## Summary
- Add Developer Certificate of Origin (DCO) requirement to CONTRIBUTING.md with sign-off instructions
- Add DCO CI check that verifies all PR commits include `Signed-off-by` line
- Required for OpenSSF Best Practices gold badge criterion

## Test plan
- [ ] DCO CI check passes on this PR (commits are signed off)
- [ ] DCO check would fail on commits without sign-off

🤖 Generated with [Claude Code](https://claude.com/claude-code)