### PR TITLE
docs: add governance, code of conduct, and continuity plan

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainer at **dave@davetashner.com**. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,50 @@
+# Governance
+
+Stringer uses a **Benevolent Dictator For Life (BDFL)** governance model, which is common for single-maintainer open source projects.
+
+## Roles
+
+### Maintainer (BDFL)
+
+**Dave Tashner** ([@davetashner](https://github.com/davetashner))
+
+The maintainer has final authority on all project decisions, including:
+
+- Feature direction and roadmap priorities
+- Accepting or rejecting pull requests
+- Release timing and versioning
+- Changes to project governance
+
+### Contributors
+
+Anyone who submits a pull request, files an issue, or participates in discussions. Contributors are expected to follow the [Contributing Guide](./CONTRIBUTING.md) and the project's conventions.
+
+## Decision Process
+
+1. **Minor changes** (bug fixes, small improvements): Submit a PR. The maintainer reviews and merges if it meets project standards.
+2. **Significant changes** (new features, architectural changes): Open an issue or discussion first to align on the approach before investing in implementation. Decision records in `docs/decisions/` document non-trivial technical choices.
+3. **Breaking changes**: Require explicit maintainer approval and a major version bump per [Semantic Versioning](https://semver.org/). The CI includes a breaking change guard that flags these automatically.
+
+## Code Review
+
+All changes go through pull requests. Direct pushes to `main` are blocked by branch protection. The maintainer reviews all PRs before merge.
+
+## Security
+
+Vulnerability reports follow the process in [SECURITY.md](./SECURITY.md). The maintainer commits to a 48-hour acknowledgment SLA for security issues.
+
+## Continuity Plan
+
+Stringer is MIT-licensed and hosted on GitHub, so the source code is always publicly available and forkable. To ensure the project can continue with minimal interruption if the maintainer becomes unavailable:
+
+- **Source code**: Publicly available on GitHub under MIT license. Anyone may fork and continue development.
+- **Release infrastructure**: GitHub Actions handles automated builds, signing, and publishing. Workflows are committed to the repository and can be run by anyone with repository write access.
+- **Homebrew tap**: Hosted at [davetashner/homebrew-tap](https://github.com/davetashner/homebrew-tap). A successor maintainer with repository access can continue publishing formula updates.
+- **Package registry**: Published via `go install`, which requires no special credentials — any fork can be installed directly.
+- **Domain/DNS**: No custom domain. All project infrastructure is on GitHub.
+
+If you are interested in serving as a backup maintainer, please open an issue to discuss.
+
+## Evolution
+
+If the project grows to have regular contributors, this governance model may evolve to include additional maintainers or a contributor ladder. Any governance changes will be documented here.


### PR DESCRIPTION
## Summary
- Add GOVERNANCE.md: BDFL model, key roles/responsibilities, decision process, continuity plan
- Add CODE_OF_CONDUCT.md: Contributor Covenant v2.1
- Required for OpenSSF Best Practices gold badge criteria

## Test plan
- [ ] Documents render correctly on GitHub
- [ ] Contact email in CODE_OF_CONDUCT.md is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)