### PR TITLE
docs: add roadmap and security assurance case

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,44 @@
+# Roadmap
+
+Last updated: 2026-02-14
+
+This document describes what Stringer intends to do and not do over the next year (through February 2027).
+
+## Current State (v1.0.x)
+
+Stringer is a stable codebase archaeology CLI tool with seven collectors, four output formats, a report command, MCP server for AI agent integration, and LLM-powered analysis features. See the [README](./README.md) for full feature list.
+
+## Planned (2026)
+
+### H1 2026: Quality & Reach
+
+- **User research and persona validation** — define target personas, validate noise thresholds and LLM-optional positioning
+- **README rewrite** — broaden positioning beyond Beads to highlight standalone analysis value
+- **Real-world stress testing** — run against diverse repos (large monorepos, polyglot projects, minimal repos) to find edge cases
+- **Language support expansion** — add test detection for PHP, Swift, Scala, and Elixir/Erlang ecosystems
+- **HTML dashboard report** (R3) — browser-viewable report output format
+
+### H2 2026: Ecosystem & Integration
+
+- **Additional output integrations** — explore integrations beyond Beads (e.g., GitHub Issues, Jira, Linear)
+- **Performance optimization** — improve scan times for very large repositories (100k+ files)
+- **Plugin system exploration** — evaluate whether user-contributed collectors are feasible and desirable
+
+## Not Planned
+
+The following are explicitly out of scope:
+
+- **GUI or web application** — Stringer is a CLI tool and MCP server. We will not build a standalone web UI.
+- **Language server (LSP)** — IDE integration is handled through MCP, not a custom language server.
+- **Real-time file watching** — Stringer scans on demand. Continuous monitoring is out of scope.
+- **Package registry publishing** — We will not publish to npm, PyPI, or other non-Go registries. Distribution is via Homebrew and `go install`.
+- **Multi-repo orchestration** — Stringer scans one repository at a time. Cross-repo analysis is left to the caller.
+- **Paid features or hosted service** — Stringer is and will remain fully open source (MIT) with no paywalled features.
+
+## How Priorities Are Decided
+
+Priorities are tracked in the [Beads backlog](./.beads/) using priority levels P1 (critical) through P5 (nice-to-have). Run `bd ready` to see current priorities. The maintainer makes final decisions on roadmap changes (see [GOVERNANCE.md](./GOVERNANCE.md)).
+
+## Suggesting Changes
+
+Open a GitHub issue to propose roadmap additions. Include the problem you're trying to solve and why it matters to you.

--- a/docs/security/assurance-case.md
+++ b/docs/security/assurance-case.md
@@ -1,0 +1,140 @@
+# Security Assurance Case
+
+This document provides an assurance case justifying why Stringer's security requirements are met. It follows a claims-evidence structure per [OpenSSF Best Practices](https://www.bestpractices.dev/) silver badge requirements.
+
+## Threat Model
+
+### What Stringer Does
+
+Stringer is a **read-only CLI tool** that analyzes git repositories and produces structured reports. It:
+
+- Reads files from the local filesystem (within a git repository)
+- Executes `git` subcommands to inspect history, blame, and refs
+- Makes HTTPS requests to OSV.dev (vulnerability database) and GitHub API
+- Optionally calls the Anthropic API for LLM-powered analysis
+- Writes output to stdout or a specified file
+
+### What Stringer Does NOT Do
+
+- Does not run as a daemon or long-lived service (except MCP stdio server, which has no network listener)
+- Does not accept network connections
+- Does not modify the scanned repository
+- Does not execute arbitrary code from scanned repositories
+- Does not store credentials (API keys are passed via environment variables)
+
+### Trust Boundaries
+
+| Boundary | Trust Level | Validation |
+|----------|-------------|------------|
+| Local filesystem (scanned repo) | Semi-trusted | Path traversal prevention, symlink resolution |
+| Git CLI output | Semi-trusted | Parsed with strict format expectations |
+| OSV.dev API responses | Untrusted | JSON schema validation, HTTPS with TLS cert verification |
+| GitHub API responses | Untrusted | JSON parsing with error handling, HTTPS with TLS cert verification |
+| Anthropic API responses | Untrusted | Response parsed as text, not executed |
+| MCP tool inputs | Untrusted | Input validation against registries, path resolution with symlink checks |
+| User CLI arguments | Untrusted | Validated by cobra flag parsing, collector/format names checked against registries |
+
+## Security Claims and Evidence
+
+### Claim 1: Stringer does not execute untrusted code
+
+**Argument:** Stringer only reads and analyzes files. It never evaluates, compiles, or executes code found in scanned repositories.
+
+**Evidence:**
+- No use of `os/exec` except for invoking the `git` binary with controlled arguments
+- Git commands are constructed with fixed subcommands and validated arguments — no shell interpolation
+- `internal/gitcli/gitcli.go` uses `exec.CommandContext` with argument arrays, not shell strings
+- gosec (G204) exclusion is scoped only to git CLI invocation, with justification documented in `.golangci.yml`
+
+### Claim 2: Path traversal is prevented
+
+**Argument:** All file access is constrained to the target repository directory.
+
+**Evidence:**
+- `internal/mcpserver/resolve.go` resolves paths with `filepath.Abs()` + `filepath.EvalSymlinks()`
+- MCP server validates resolved paths are within the git repository root
+- Collector file enumeration uses `git ls-files` (respects .gitignore) rather than raw filesystem walks
+- Fuzz testing on path resolution: `FuzzResolvePath` in CI
+
+### Claim 3: Network communications are secure
+
+**Argument:** All outbound network requests use HTTPS with TLS certificate verification.
+
+**Evidence:**
+- OSV.dev client (`internal/collectors/vuln_osv.go`) uses `http.DefaultClient` which enforces TLS cert verification
+- GitHub collector (`internal/collectors/github.go`) uses `http.DefaultClient` with HTTPS URLs
+- Anthropic LLM client (`internal/llm/anthropic.go`) uses HTTPS endpoint
+- Go's `net/http` enforces TLS 1.2+ and certificate verification by default
+- No `InsecureSkipVerify` anywhere in the codebase
+
+### Claim 4: No secrets are leaked
+
+**Argument:** Stringer does not store, log, or output credentials.
+
+**Evidence:**
+- API keys (Anthropic, GitHub) are read from environment variables, never written to disk
+- `internal/redact/redact.go` redacts sensitive patterns from output
+- gitleaks pre-commit hook prevents credential commits (`.githooks/pre-commit`)
+- CI runs gitleaks on every commit
+- No credential files in repository
+
+### Claim 5: Dependencies are monitored and secure
+
+**Argument:** Third-party dependencies are continuously monitored for known vulnerabilities.
+
+**Evidence:**
+- `govulncheck` runs in CI on every PR and before every release
+- Dependabot monitors Go modules and GitHub Actions weekly (`.github/dependabot.yml`)
+- License compliance check ensures only approved licenses (MIT, BSD, Apache, ISC, MPL-2.0)
+- Archived dependency check warns when upstream repos are abandoned
+- `go.sum` provides integrity verification for all module downloads
+
+### Claim 6: Static and dynamic analysis catch vulnerabilities
+
+**Argument:** Multiple analysis tools run continuously to detect security issues.
+
+**Evidence:**
+- **Static analysis:** gosec (Go security linter), CodeQL (GitHub SAST), golangci-lint with errcheck/staticcheck
+- **Dynamic analysis:** Race detector (`-race` flag on all test runs), fuzz testing (4 fuzz targets in CI)
+- **Coverage:** 91%+ test coverage with 90% CI gate
+- All analysis runs on every PR and must pass before merge
+- See `.github/workflows/ci.yml` and `.github/workflows/codeql.yml`
+
+### Claim 7: Releases are tamper-resistant
+
+**Argument:** Published artifacts are signed and verifiable.
+
+**Evidence:**
+- All release artifacts signed with Sigstore cosign (`.goreleaser.yml`)
+- SLSA Level 2 provenance generated via `slsa-framework/slsa-github-generator`
+- SHA-256 checksums published with every release
+- SBOMs (SPDX) generated for all archives
+- Release pipeline: GoReleaser (draft) → SLSA provenance → publish
+- See `docs/release-strategy.md` for full details
+
+### Claim 8: Input validation follows allowlist principle
+
+**Argument:** All inputs from untrusted sources are validated against known-good values.
+
+**Evidence:**
+- Collector names validated against `collector.List()` registry
+- Output format names validated against `output.GetFormatter()` registry
+- Report section names validated against `report` registry
+- CLI flags parsed by cobra with type enforcement
+- MCP server inputs validated before processing (see `docs/security/mcp-server-audit.md`)
+
+## Residual Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Git binary could have vulnerabilities | Low | Stringer uses git as an external tool; users control their git version |
+| OSV.dev API could return malicious data | Low | Responses are parsed as JSON data, never executed |
+| Large repositories could cause resource exhaustion | Low | Timeouts on git commands, context cancellation support |
+| Shallow clones reduce lottery risk accuracy | Low | Documented limitation, not a security issue |
+
+## Review Schedule
+
+This assurance case is reviewed when:
+- New collectors or network-facing features are added
+- Security-relevant dependencies are updated
+- A vulnerability is reported and resolved


### PR DESCRIPTION
## Summary
- Add ROADMAP.md: planned features (H1/H2 2026), explicit not-planned items, priority process
- Add docs/security/assurance-case.md: 8 security claims with evidence, threat model, residual risks
- Required for OpenSSF Best Practices silver badge (documentation_roadmap, assurance_case)

## Test plan
- [ ] Documents render correctly on GitHub
- [ ] Roadmap items align with current backlog (`bd ready`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)