### PR TITLE
chore: add copyright headers to all Go source files

### DIFF
--- a/cmd/stringer/cmd_mock_test.go
+++ b/cmd/stringer/cmd_mock_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package main
 
 import (

--- a/cmd/stringer/collectors.go
+++ b/cmd/stringer/collectors.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package main
 
 import (

--- a/cmd/stringer/collectors_test.go
+++ b/cmd/stringer/collectors_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package main
 
 import (

--- a/cmd/stringer/config.go
+++ b/cmd/stringer/config.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package main
 
 import (

--- a/cmd/stringer/config_precedence_integration_test.go
+++ b/cmd/stringer/config_precedence_integration_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package main
 
 import (

--- a/cmd/stringer/config_test.go
+++ b/cmd/stringer/config_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package main
 
 import (

--- a/cmd/stringer/configwiring.go
+++ b/cmd/stringer/configwiring.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package main
 
 import (

--- a/cmd/stringer/context.go
+++ b/cmd/stringer/context.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package main
 
 import (

--- a/cmd/stringer/context_test.go
+++ b/cmd/stringer/context_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package main
 
 import (

--- a/cmd/stringer/docs.go
+++ b/cmd/stringer/docs.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package main
 
 import (

--- a/cmd/stringer/docs_test.go
+++ b/cmd/stringer/docs_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package main
 
 import (

--- a/cmd/stringer/exitcodes.go
+++ b/cmd/stringer/exitcodes.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package main
 
 // Exit codes for stringer CLI.

--- a/cmd/stringer/fs.go
+++ b/cmd/stringer/fs.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package main
 
 import "github.com/davetashner/stringer/internal/testable"

--- a/cmd/stringer/init.go
+++ b/cmd/stringer/init.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package main
 
 import (

--- a/cmd/stringer/init_security_test.go
+++ b/cmd/stringer/init_security_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package main
 
 import (

--- a/cmd/stringer/init_test.go
+++ b/cmd/stringer/init_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package main
 
 import (

--- a/cmd/stringer/main.go
+++ b/cmd/stringer/main.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package main
 
 import (

--- a/cmd/stringer/main_test.go
+++ b/cmd/stringer/main_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package main
 
 import (

--- a/cmd/stringer/mcp.go
+++ b/cmd/stringer/mcp.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package main
 
 import (

--- a/cmd/stringer/mcp_test.go
+++ b/cmd/stringer/mcp_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package main
 
 import (

--- a/cmd/stringer/report.go
+++ b/cmd/stringer/report.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package main
 
 import (

--- a/cmd/stringer/report_test.go
+++ b/cmd/stringer/report_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package main
 
 import (

--- a/cmd/stringer/root.go
+++ b/cmd/stringer/root.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package main
 
 import (

--- a/cmd/stringer/root_test.go
+++ b/cmd/stringer/root_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package main
 
 import (

--- a/cmd/stringer/scan.go
+++ b/cmd/stringer/scan.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package main
 
 import (

--- a/cmd/stringer/scan_flag_integration_test.go
+++ b/cmd/stringer/scan_flag_integration_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package main
 
 import (

--- a/cmd/stringer/scan_test.go
+++ b/cmd/stringer/scan_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package main
 
 import (

--- a/cmd/stringer/scan_unit_test.go
+++ b/cmd/stringer/scan_unit_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package main
 
 import (

--- a/cmd/stringer/testhelpers_test.go
+++ b/cmd/stringer/testhelpers_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package main
 
 import (

--- a/cmd/stringer/validate.go
+++ b/cmd/stringer/validate.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package main
 
 import (

--- a/cmd/stringer/validate_test.go
+++ b/cmd/stringer/validate_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package main
 
 import (

--- a/cmd/stringer/version.go
+++ b/cmd/stringer/version.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package main
 
 import (

--- a/cmd/stringer/workspacewiring.go
+++ b/cmd/stringer/workspacewiring.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package main
 
 import (

--- a/cmd/stringer/workspacewiring_test.go
+++ b/cmd/stringer/workspacewiring_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package main
 
 import (

--- a/internal/analysis/clustering.go
+++ b/internal/analysis/clustering.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 // Package analysis provides LLM-powered signal clustering and bead generation.
 // It groups related signals by theme, module, or intent, using an LLM provider
 // for semantic understanding, and produces structured beads for backlog import.

--- a/internal/analysis/clustering_test.go
+++ b/internal/analysis/clustering_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package analysis
 
 import (

--- a/internal/analysis/dependency.go
+++ b/internal/analysis/dependency.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package analysis
 
 import (

--- a/internal/analysis/dependency_test.go
+++ b/internal/analysis/dependency_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package analysis
 
 import (

--- a/internal/analysis/hierarchy.go
+++ b/internal/analysis/hierarchy.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package analysis
 
 import (

--- a/internal/analysis/llmcluster.go
+++ b/internal/analysis/llmcluster.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package analysis
 
 import (

--- a/internal/analysis/merge.go
+++ b/internal/analysis/merge.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package analysis
 
 import (

--- a/internal/analysis/priority.go
+++ b/internal/analysis/priority.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package analysis
 
 import (

--- a/internal/analysis/priority_test.go
+++ b/internal/analysis/priority_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package analysis
 
 import (

--- a/internal/analysis/prompt.go
+++ b/internal/analysis/prompt.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package analysis
 
 import (

--- a/internal/analysis/similarity.go
+++ b/internal/analysis/similarity.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package analysis
 
 import (

--- a/internal/beads/conventions.go
+++ b/internal/beads/conventions.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package beads
 
 import "strings"

--- a/internal/beads/conventions_test.go
+++ b/internal/beads/conventions_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package beads
 
 import (

--- a/internal/beads/dedup.go
+++ b/internal/beads/dedup.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package beads
 
 import (

--- a/internal/beads/dedup_test.go
+++ b/internal/beads/dedup_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package beads
 
 import (

--- a/internal/beads/reader.go
+++ b/internal/beads/reader.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package beads
 
 import (

--- a/internal/beads/reader_fuzz_test.go
+++ b/internal/beads/reader_fuzz_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package beads
 
 import (

--- a/internal/beads/reader_test.go
+++ b/internal/beads/reader_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package beads
 
 import (

--- a/internal/bootstrap/agentsmd.go
+++ b/internal/bootstrap/agentsmd.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package bootstrap
 
 import (

--- a/internal/bootstrap/agentsmd_test.go
+++ b/internal/bootstrap/agentsmd_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package bootstrap
 
 import (

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package bootstrap
 
 import (

--- a/internal/bootstrap/bootstrap_mock_test.go
+++ b/internal/bootstrap/bootstrap_mock_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package bootstrap
 
 import (

--- a/internal/bootstrap/bootstrap_security_test.go
+++ b/internal/bootstrap/bootstrap_security_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package bootstrap
 
 import (

--- a/internal/bootstrap/bootstrap_test.go
+++ b/internal/bootstrap/bootstrap_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package bootstrap
 
 import (

--- a/internal/bootstrap/config.go
+++ b/internal/bootstrap/config.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package bootstrap
 
 import (

--- a/internal/bootstrap/config_test.go
+++ b/internal/bootstrap/config_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package bootstrap
 
 import (

--- a/internal/bootstrap/detect.go
+++ b/internal/bootstrap/detect.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 // Package bootstrap implements the `stringer init` command, which detects
 // repository characteristics and generates a starter configuration.
 package bootstrap

--- a/internal/bootstrap/detect_test.go
+++ b/internal/bootstrap/detect_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package bootstrap
 
 import (

--- a/internal/bootstrap/mcpjson.go
+++ b/internal/bootstrap/mcpjson.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package bootstrap
 
 import (

--- a/internal/bootstrap/mcpjson_test.go
+++ b/internal/bootstrap/mcpjson_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package bootstrap
 
 import (

--- a/internal/bootstrap/wizard.go
+++ b/internal/bootstrap/wizard.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package bootstrap
 
 import (

--- a/internal/bootstrap/wizard_test.go
+++ b/internal/bootstrap/wizard_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package bootstrap
 
 import (

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 // Package collector defines the Collector interface and a registry for
 // managing available collectors.
 package collector

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package collector
 
 import (

--- a/internal/collectors/dephealth.go
+++ b/internal/collectors/dephealth.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package collectors
 
 import (

--- a/internal/collectors/dephealth_crates.go
+++ b/internal/collectors/dephealth_crates.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package collectors
 
 import (

--- a/internal/collectors/dephealth_deprecated.go
+++ b/internal/collectors/dephealth_deprecated.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package collectors
 
 import (

--- a/internal/collectors/dephealth_github.go
+++ b/internal/collectors/dephealth_github.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package collectors
 
 import (

--- a/internal/collectors/dephealth_maven.go
+++ b/internal/collectors/dephealth_maven.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package collectors
 
 import (

--- a/internal/collectors/dephealth_npm.go
+++ b/internal/collectors/dephealth_npm.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package collectors
 
 import (

--- a/internal/collectors/dephealth_nuget.go
+++ b/internal/collectors/dephealth_nuget.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package collectors
 
 import (

--- a/internal/collectors/dephealth_pypi.go
+++ b/internal/collectors/dephealth_pypi.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package collectors
 
 import (

--- a/internal/collectors/dephealth_test.go
+++ b/internal/collectors/dephealth_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package collectors
 
 import (

--- a/internal/collectors/duration.go
+++ b/internal/collectors/duration.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package collectors
 
 import (

--- a/internal/collectors/duration_test.go
+++ b/internal/collectors/duration_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package collectors
 
 import (

--- a/internal/collectors/github.go
+++ b/internal/collectors/github.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 // Package collectors provides signal extraction modules for stringer.
 package collectors
 

--- a/internal/collectors/github_test.go
+++ b/internal/collectors/github_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package collectors
 
 import (

--- a/internal/collectors/githubclient.go
+++ b/internal/collectors/githubclient.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package collectors
 
 import (

--- a/internal/collectors/gitlog.go
+++ b/internal/collectors/gitlog.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 // Package collectors provides signal extraction modules for stringer.
 package collectors
 

--- a/internal/collectors/gitlog_test.go
+++ b/internal/collectors/gitlog_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package collectors
 
 import (

--- a/internal/collectors/lotteryrisk.go
+++ b/internal/collectors/lotteryrisk.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package collectors
 
 import (

--- a/internal/collectors/lotteryrisk_ownership.go
+++ b/internal/collectors/lotteryrisk_ownership.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package collectors
 
 import (

--- a/internal/collectors/lotteryrisk_reviews.go
+++ b/internal/collectors/lotteryrisk_reviews.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package collectors
 
 import (

--- a/internal/collectors/lotteryrisk_test.go
+++ b/internal/collectors/lotteryrisk_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package collectors
 
 import (

--- a/internal/collectors/patterns.go
+++ b/internal/collectors/patterns.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package collectors
 
 import (

--- a/internal/collectors/patterns_lang_test.go
+++ b/internal/collectors/patterns_lang_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package collectors
 
 import (

--- a/internal/collectors/patterns_test.go
+++ b/internal/collectors/patterns_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package collectors
 
 import (

--- a/internal/collectors/testhelpers_test.go
+++ b/internal/collectors/testhelpers_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package collectors
 
 import (

--- a/internal/collectors/todos.go
+++ b/internal/collectors/todos.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 // Package collectors provides signal extraction modules for stringer.
 package collectors
 

--- a/internal/collectors/todos_test.go
+++ b/internal/collectors/todos_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package collectors
 
 import (

--- a/internal/collectors/vuln.go
+++ b/internal/collectors/vuln.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package collectors
 
 import (

--- a/internal/collectors/vuln_gradle.go
+++ b/internal/collectors/vuln_gradle.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package collectors
 
 import (

--- a/internal/collectors/vuln_gradle_test.go
+++ b/internal/collectors/vuln_gradle_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package collectors
 
 import (

--- a/internal/collectors/vuln_maven.go
+++ b/internal/collectors/vuln_maven.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package collectors
 
 import (

--- a/internal/collectors/vuln_maven_test.go
+++ b/internal/collectors/vuln_maven_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package collectors
 
 import (

--- a/internal/collectors/vuln_npm.go
+++ b/internal/collectors/vuln_npm.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package collectors
 
 import (

--- a/internal/collectors/vuln_npm_test.go
+++ b/internal/collectors/vuln_npm_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package collectors
 
 import (

--- a/internal/collectors/vuln_nuget.go
+++ b/internal/collectors/vuln_nuget.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package collectors
 
 import (

--- a/internal/collectors/vuln_nuget_test.go
+++ b/internal/collectors/vuln_nuget_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package collectors
 
 import (

--- a/internal/collectors/vuln_osv.go
+++ b/internal/collectors/vuln_osv.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package collectors
 
 import (

--- a/internal/collectors/vuln_osv_test.go
+++ b/internal/collectors/vuln_osv_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package collectors
 
 import (

--- a/internal/collectors/vuln_python.go
+++ b/internal/collectors/vuln_python.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package collectors
 
 import (

--- a/internal/collectors/vuln_python_test.go
+++ b/internal/collectors/vuln_python_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package collectors
 
 import (

--- a/internal/collectors/vuln_rust.go
+++ b/internal/collectors/vuln_rust.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package collectors
 
 import (

--- a/internal/collectors/vuln_rust_test.go
+++ b/internal/collectors/vuln_rust_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package collectors
 
 import (

--- a/internal/collectors/vuln_test.go
+++ b/internal/collectors/vuln_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package collectors
 
 import (

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 // Package config handles .stringer.yaml configuration files.
 package config
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package config
 
 import (

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package config
 
 import (

--- a/internal/config/global_test.go
+++ b/internal/config/global_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package config
 
 import (

--- a/internal/config/keypath.go
+++ b/internal/config/keypath.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package config
 
 import (

--- a/internal/config/keypath_test.go
+++ b/internal/config/keypath_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package config
 
 import (

--- a/internal/config/merge.go
+++ b/internal/config/merge.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package config
 
 import (

--- a/internal/config/merge_test.go
+++ b/internal/config/merge_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package config
 
 import (

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package config
 
 import (

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package config
 
 import (

--- a/internal/config/yaml.go
+++ b/internal/config/yaml.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package config
 
 import (

--- a/internal/config/yaml_fuzz_test.go
+++ b/internal/config/yaml_fuzz_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package config
 
 import (

--- a/internal/config/yaml_test.go
+++ b/internal/config/yaml_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package config
 
 import (

--- a/internal/context/generator.go
+++ b/internal/context/generator.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package context
 
 import (

--- a/internal/context/generator_test.go
+++ b/internal/context/generator_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package context
 
 import (

--- a/internal/context/githistory.go
+++ b/internal/context/githistory.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 // Package context provides CONTEXT.md generation for agent onboarding.
 package context
 

--- a/internal/context/githistory_test.go
+++ b/internal/context/githistory_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package context
 
 import (

--- a/internal/context/render_json.go
+++ b/internal/context/render_json.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package context
 
 import (

--- a/internal/context/render_json_test.go
+++ b/internal/context/render_json_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package context
 
 import (

--- a/internal/docs/analyzer.go
+++ b/internal/docs/analyzer.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package docs
 
 import (

--- a/internal/docs/analyzer_test.go
+++ b/internal/docs/analyzer_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package docs
 
 import (

--- a/internal/docs/detector.go
+++ b/internal/docs/detector.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package docs
 
 import (

--- a/internal/docs/detector_test.go
+++ b/internal/docs/detector_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package docs
 
 import (

--- a/internal/docs/generator.go
+++ b/internal/docs/generator.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package docs
 
 import (

--- a/internal/docs/generator_test.go
+++ b/internal/docs/generator_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package docs
 
 import (

--- a/internal/docs/updater.go
+++ b/internal/docs/updater.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package docs
 
 import (

--- a/internal/docs/updater_test.go
+++ b/internal/docs/updater_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package docs
 
 import (

--- a/internal/gitcli/gitcli.go
+++ b/internal/gitcli/gitcli.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 // Package gitcli provides native git CLI execution for blame operations.
 // It shells out to the system git binary for blame (which uses packfile indexes
 // and runs in milliseconds) while the rest of stringer uses go-git for commit

--- a/internal/gitcli/gitcli_mock_test.go
+++ b/internal/gitcli/gitcli_mock_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package gitcli
 
 import (

--- a/internal/gitcli/gitcli_test.go
+++ b/internal/gitcli/gitcli_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package gitcli
 
 import (

--- a/internal/llm/anthropic.go
+++ b/internal/llm/anthropic.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package llm
 
 import (

--- a/internal/llm/anthropic_test.go
+++ b/internal/llm/anthropic_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package llm_test
 
 import (

--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 // Package llm provides a provider-agnostic LLM client interface and
 // implementations for use by stringer's analysis features.
 package llm

--- a/internal/llm/llm_test.go
+++ b/internal/llm/llm_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package llm_test
 
 import (

--- a/internal/llm/mock.go
+++ b/internal/llm/mock.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package llm
 
 import (

--- a/internal/llm/mock_test.go
+++ b/internal/llm/mock_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package llm_test
 
 import (

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 // Package log configures structured logging for stringer using log/slog.
 package log
 

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package log
 
 import (

--- a/internal/mcpserver/resolve.go
+++ b/internal/mcpserver/resolve.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 // Package mcpserver implements an MCP (Model Context Protocol) server
 // that exposes stringer's core operations as tools over stdio transport.
 package mcpserver

--- a/internal/mcpserver/resolve_fuzz_test.go
+++ b/internal/mcpserver/resolve_fuzz_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package mcpserver
 
 import "testing"

--- a/internal/mcpserver/resolve_security_test.go
+++ b/internal/mcpserver/resolve_security_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package mcpserver
 
 import (

--- a/internal/mcpserver/resolve_test.go
+++ b/internal/mcpserver/resolve_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package mcpserver
 
 import (

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package mcpserver
 
 import (

--- a/internal/mcpserver/server_test.go
+++ b/internal/mcpserver/server_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package mcpserver
 
 import (

--- a/internal/mcpserver/tools.go
+++ b/internal/mcpserver/tools.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package mcpserver
 
 import (

--- a/internal/mcpserver/tools_fuzz_test.go
+++ b/internal/mcpserver/tools_fuzz_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package mcpserver
 
 import (

--- a/internal/mcpserver/tools_security_test.go
+++ b/internal/mcpserver/tools_security_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package mcpserver
 
 import (

--- a/internal/mcpserver/tools_test.go
+++ b/internal/mcpserver/tools_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package mcpserver
 
 import (

--- a/internal/output/beads.go
+++ b/internal/output/beads.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package output
 
 import (

--- a/internal/output/beads_test.go
+++ b/internal/output/beads_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package output
 
 import (

--- a/internal/output/formatter.go
+++ b/internal/output/formatter.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 // Package output defines the OutputFormatter interface for writing scan results
 // in various formats.
 package output

--- a/internal/output/formatter_test.go
+++ b/internal/output/formatter_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package output
 
 import (

--- a/internal/output/html.go
+++ b/internal/output/html.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package output
 
 import (

--- a/internal/output/html_dir.go
+++ b/internal/output/html_dir.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package output
 
 import (

--- a/internal/output/html_dir_test.go
+++ b/internal/output/html_dir_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package output
 
 import (

--- a/internal/output/html_dir_tmpl.go
+++ b/internal/output/html_dir_tmpl.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package output
 
 const htmlDirCSS = `:root {

--- a/internal/output/html_test.go
+++ b/internal/output/html_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package output
 
 import (

--- a/internal/output/html_tmpl.go
+++ b/internal/output/html_tmpl.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package output
 
 const htmlTemplate = `<!DOCTYPE html>

--- a/internal/output/json.go
+++ b/internal/output/json.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package output
 
 import (

--- a/internal/output/json_test.go
+++ b/internal/output/json_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package output
 
 import (

--- a/internal/output/markdown.go
+++ b/internal/output/markdown.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package output
 
 import (

--- a/internal/output/markdown_test.go
+++ b/internal/output/markdown_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package output
 
 import (

--- a/internal/output/signalid.go
+++ b/internal/output/signalid.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package output
 
 import (

--- a/internal/output/signalid_test.go
+++ b/internal/output/signalid_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package output
 
 import (

--- a/internal/output/tasks.go
+++ b/internal/output/tasks.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package output
 
 import (

--- a/internal/output/tasks_test.go
+++ b/internal/output/tasks_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package output
 
 import (

--- a/internal/pipeline/dedup.go
+++ b/internal/pipeline/dedup.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package pipeline
 
 import (

--- a/internal/pipeline/dedup_test.go
+++ b/internal/pipeline/dedup_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package pipeline
 
 import (

--- a/internal/pipeline/integration_test.go
+++ b/internal/pipeline/integration_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package pipeline
 
 import (

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package pipeline
 
 import (

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package pipeline
 
 import (

--- a/internal/pipeline/validate.go
+++ b/internal/pipeline/validate.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 // Package pipeline provides the scan orchestration engine for stringer.
 // It resolves collectors, runs them sequentially, validates their output,
 // and aggregates results into a ScanResult.

--- a/internal/pipeline/validate_test.go
+++ b/internal/pipeline/validate_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package pipeline
 
 import (

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 // Package redact provides utilities to strip sensitive values from strings
 // before they appear in output, logs, or error messages.
 package redact

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package redact
 
 import (

--- a/internal/report/churn.go
+++ b/internal/report/churn.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package report
 
 import (

--- a/internal/report/churn_test.go
+++ b/internal/report/churn_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package report
 
 import (

--- a/internal/report/color.go
+++ b/internal/report/color.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package report
 
 import (

--- a/internal/report/coverage.go
+++ b/internal/report/coverage.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package report
 
 import (

--- a/internal/report/coverage_test.go
+++ b/internal/report/coverage_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package report
 
 import (

--- a/internal/report/lotteryrisk.go
+++ b/internal/report/lotteryrisk.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package report
 
 import (

--- a/internal/report/lotteryrisk_test.go
+++ b/internal/report/lotteryrisk_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package report
 
 import (

--- a/internal/report/recommendations.go
+++ b/internal/report/recommendations.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package report
 
 import (

--- a/internal/report/recommendations_test.go
+++ b/internal/report/recommendations_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package report
 
 import (

--- a/internal/report/render.go
+++ b/internal/report/render.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package report
 
 import (

--- a/internal/report/render_test.go
+++ b/internal/report/render_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package report
 
 import (

--- a/internal/report/section.go
+++ b/internal/report/section.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 // Package report provides a pluggable section registry for stringer report.
 // Each section consumes metrics from collectors and renders a focused analysis.
 package report

--- a/internal/report/section_test.go
+++ b/internal/report/section_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package report
 
 import (

--- a/internal/report/table.go
+++ b/internal/report/table.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package report
 
 import (

--- a/internal/report/table_test.go
+++ b/internal/report/table_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package report
 
 import (

--- a/internal/report/todoage.go
+++ b/internal/report/todoage.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package report
 
 import (

--- a/internal/report/todoage_test.go
+++ b/internal/report/todoage_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package report
 
 import (

--- a/internal/signal/signal.go
+++ b/internal/signal/signal.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 // Package signal defines the core domain types for stringer.
 package signal
 

--- a/internal/signal/signal_test.go
+++ b/internal/signal/signal_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package signal
 
 import (

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 // Package state manages persisted scan state for delta scanning.
 //
 // When --delta is active, stringer saves a record of all signal hashes

--- a/internal/state/state_mock_test.go
+++ b/internal/state/state_mock_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package state
 
 import (

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package state
 
 import (

--- a/internal/testable/exec.go
+++ b/internal/testable/exec.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 // Package testable provides interfaces for mocking external dependencies
 // such as exec.Command and exec.LookPath in tests.
 package testable

--- a/internal/testable/exec_mock.go
+++ b/internal/testable/exec_mock.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package testable
 
 import (

--- a/internal/testable/fs.go
+++ b/internal/testable/fs.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 // Package testable provides interfaces for abstracting OS-level operations,
 // enabling mock injection in tests without modifying production behavior.
 package testable

--- a/internal/testable/git.go
+++ b/internal/testable/git.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 // Package testable provides interfaces for mocking external dependencies
 // such as go-git operations. Production code uses the Real* implementations;
 // tests can inject mock implementations to avoid hitting real git repos.

--- a/internal/testable/git_mock.go
+++ b/internal/testable/git_mock.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package testable
 
 import (

--- a/internal/testable/mock_fs.go
+++ b/internal/testable/mock_fs.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package testable
 
 import (

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 // Package validate provides JSONL validation against the bd import schema.
 // It checks each line of a JSONL file for required fields, valid types,
 // and correct formats, producing detailed error messages with fix suggestions.

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package validate
 
 import (

--- a/internal/workspace/cargo.go
+++ b/internal/workspace/cargo.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package workspace
 
 import (

--- a/internal/workspace/glob.go
+++ b/internal/workspace/glob.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package workspace
 
 import (

--- a/internal/workspace/gowork.go
+++ b/internal/workspace/gowork.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package workspace
 
 import (

--- a/internal/workspace/lerna.go
+++ b/internal/workspace/lerna.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package workspace
 
 import (

--- a/internal/workspace/npm.go
+++ b/internal/workspace/npm.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package workspace
 
 import (

--- a/internal/workspace/nx.go
+++ b/internal/workspace/nx.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package workspace
 
 import (

--- a/internal/workspace/pnpm.go
+++ b/internal/workspace/pnpm.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package workspace
 
 import (

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 // Package workspace detects monorepo structures and enumerates their workspaces.
 package workspace
 

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 package workspace
 
 import (

--- a/test/integration/scan_test.go
+++ b/test/integration/scan_test.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
 // Package integration contains end-to-end tests for stringer.
 //
 // These tests build the stringer binary and exercise it against fixture


### PR DESCRIPTION
## Summary
- Add SPDX-compliant copyright and license headers to all 226 `.go` files
- Format: `// Copyright 2026 The Stringer Authors` + `// SPDX-License-Identifier: MIT`
- Required for OpenSSF Best Practices gold badge (copyright criterion)

## Test plan
- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] `go test -race ./...` passes
- [ ] All CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)