### PR TITLE
fix: scope workflow permissions to job level

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,12 +10,14 @@ on:
 
 permissions:
   contents: read
-  security-events: write
 
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,14 +6,16 @@ on:
       - "v*"
 
 permissions:
-  contents: write
-  id-token: write  # Required for cosign keyless signing via Sigstore/Fulcio OIDC
-  actions: read     # Required for SLSA provenance workflow path verification
+  contents: read
 
 jobs:
   release:
     name: GoReleaser
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write  # Required for cosign keyless signing via Sigstore/Fulcio OIDC
+      actions: read     # Required for SLSA provenance workflow path verification
     outputs:
       hashes: ${{ steps.hash.outputs.hashes }}
     steps:
@@ -62,6 +64,8 @@ jobs:
   publish:
     needs: [provenance]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Publish release
         env:


### PR DESCRIPTION
## Summary
- Move `security-events: write` from top-level to job-level in `codeql.yml`
- Move `contents: write`, `id-token: write` from top-level to job-level in `release.yml`
- Top-level permissions now read-only in both workflows
- Fixes OpenSSF Scorecard "Token-Permissions" warning about excessive permissions

## Test plan
- [ ] CodeQL workflow still runs successfully
- [ ] Release workflow unaffected (only triggers on tags)

🤖 Generated with [Claude Code](https://claude.com/claude-code)