### PR TITLE
fix: pass Go 1.26 to govulncheck-action in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Run tests
         run: go test -race -count=1 ./...
       - uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
+        with:
+          go-version-input: "1.26"
+          repo-checkout: false
       - uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v3.10.1
       - uses: anchore/sbom-action/download-syft@28d71544de8eaf1b958d335707167c5f783590ad # v0.22.2
       - name: Run GoReleaser


### PR DESCRIPTION
## Summary
- Adds `go-version-input: "1.26"` and `repo-checkout: false` to govulncheck-action in the release workflow, matching the fix already applied to CI in #212

## Test plan
- [ ] Verify release workflow passes govulncheck step on next tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)