### PR TITLE
feat: add complexity hotspot collector and report sections

### DIFF
--- a/cmd/stringer/collectors.go
+++ b/cmd/stringer/collectors.go
@@ -64,6 +64,11 @@ var knownCollectors = map[string]collectorMeta{
 		SignalKinds:  []string{"deprecated-dependency", "yanked-dependency", "archived-dependency", "stale-dependency"},
 		ConfigFields: []string{},
 	},
+	"complexity": {
+		Description:  "Detects complex functions using composite scoring (lines/50 + branches)",
+		SignalKinds:  []string{"complex-function"},
+		ConfigFields: []string{"min_function_lines", "min_complexity_score"},
+	},
 }
 
 // Common config fields that apply to every collector.

--- a/docs/decisions/013-complexity-hotspot-design.md
+++ b/docs/decisions/013-complexity-hotspot-design.md
@@ -1,0 +1,102 @@
+# 013: Complexity Hotspot Collector Design
+
+**Status:** Proposed
+**Date:** 2026-02-21
+**Context:** stringer-b9u (C9: Complexity Hotspot Detector). Adding complexity detection as a new signal source to identify high-value refactoring targets.
+
+## Problem
+
+Stringer detects churn (files that change often) via the gitlog collector but not *why* those files are painful to change. Complex functions that also churn frequently are the highest-value refactoring targets — the "toxic hotspots" from Adam Tornhill's *Your Code as a Crime Scene*. We need a way to detect function-level complexity and cross-reference it with churn data.
+
+Key questions:
+1. How should we measure complexity without AST parsing?
+2. Should complexity detection live in its own collector or extend an existing one?
+3. How should the hotspot cross-reference work?
+
+## Options
+
+### Option A: AST-based complexity analysis
+
+Use language-specific AST parsers (go/ast for Go, tree-sitter for others) for precise function detection and cyclomatic complexity calculation.
+
+**Pros:**
+- Accurate function boundary detection
+- Standard cyclomatic complexity metric
+- Handles edge cases (nested functions, closures) correctly
+
+**Cons:**
+- Requires AST parser per language — massive dependency surface
+- tree-sitter CGO bindings add build complexity
+- Overkill for archaeological signals where ~80% accuracy suffices
+- Doesn't match stringer's zero-external-tooling philosophy
+
+### Option B: Regex-based function detection with composite scoring
+
+Use regex patterns to detect function boundaries and count control flow keywords. Score = lines/50 + branches.
+
+**Pros:**
+- Zero external dependencies
+- Fast — single-pass line-by-line scan
+- ~80% accuracy is acceptable for identifying refactoring candidates
+- Easy to extend to new languages (add a langSpec struct)
+- Composite metric balances length and branching: 50 lines = 1 point, 1 branch = 1 point
+
+**Cons:**
+- Cannot handle all edge cases (string literals containing keywords, complex nesting)
+- No true cyclomatic complexity — heuristic approximation
+- Function boundary detection imperfect for languages with unusual syntax
+
+### Option C: External tool integration (complexity-report, radon, etc.)
+
+Shell out to existing complexity analysis tools per language.
+
+**Pros:**
+- Leverages battle-tested tools
+- Accurate per-language metrics
+
+**Cons:**
+- Requires tools to be installed
+- Different output formats per tool
+- Doesn't match stringer's self-contained approach
+- Maintenance burden scales with language count
+
+## Recommendation
+
+**Option B: Regex-based function detection with composite scoring.**
+
+For archaeological signal detection, ~80% accuracy is sufficient. The composite score (lines/50 + branches) balances file length with control flow complexity — a 200-line function with no branches scores 4.0, while a 50-line function with 10 branches scores 11.0. Both are meaningful signals, but the branching-heavy function is correctly ranked higher.
+
+### Composite metric
+
+`score = lines/50 + branches`
+
+Where:
+- `lines` = non-blank lines in the function body
+- `branches` = count of control flow keywords (`if`, `else if`, `elif`, `for`, `while`, `switch`, `case`, `catch`, `except`, `guard`, `when`, `unless`) plus `&&`/`||` operators
+- Comment lines are excluded from branch counting
+
+### Confidence bands
+
+| Score range | Confidence |
+|------------|------------|
+| >= 15 | 0.8 |
+| 8–15 | 0.6–0.8 (linear interpolation) |
+| 6–8 | 0.5–0.6 (linear interpolation) |
+| < 6 | Not emitted |
+
+### Collector architecture
+
+Independent collector running in parallel with all others. The hotspot cross-reference (complexity × churn) lives in the report layer, which reads both `complexity` and `gitlog` metrics post-scan.
+
+### Language coverage (phase 1)
+
+Go, Python, JS/TS, Java, Rust, Ruby — top 6 languages already supported by the patterns collector.
+
+### Files affected
+
+- New: `internal/collectors/complexity.go`, `internal/report/complexity.go`, `internal/report/hotspots.go`
+- Modified: `internal/signal/signal.go`, `internal/config/config.go`, `internal/config/merge.go`, `cmd/stringer/collectors.go`
+
+## Decision
+
+Option B accepted. Regex-based function detection with composite scoring. Hotspot cross-reference in report layer.

--- a/internal/collectors/complexity.go
+++ b/internal/collectors/complexity.go
@@ -1,0 +1,535 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
+package collectors
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/davetashner/stringer/internal/collector"
+	"github.com/davetashner/stringer/internal/signal"
+)
+
+// defaultMinComplexityScore is the minimum composite score to emit a signal.
+const defaultMinComplexityScore = 6.0
+
+// defaultMinFunctionLines is the minimum function body lines to analyze.
+const defaultMinFunctionLines = 5
+
+func init() {
+	collector.Register(&ComplexityCollector{})
+}
+
+// FunctionComplexity holds complexity metrics for a single detected function.
+type FunctionComplexity struct {
+	FilePath  string
+	FuncName  string
+	StartLine int
+	Lines     int
+	Branches  int
+	Score     float64 // lines/50 + branches
+}
+
+// ComplexityMetrics holds structured metrics from the complexity scan.
+type ComplexityMetrics struct {
+	Functions      []FunctionComplexity // sorted by score desc
+	FilesAnalyzed  int
+	FunctionsFound int
+}
+
+// ComplexityCollector detects complex functions using regex-based function
+// detection and control flow keyword counting. Produces scored signals for
+// functions exceeding a configurable complexity threshold.
+type ComplexityCollector struct {
+	metrics *ComplexityMetrics
+}
+
+// Name returns the collector name used for registration and filtering.
+func (c *ComplexityCollector) Name() string { return "complexity" }
+
+// langSpec describes how to detect functions and their boundaries in a language.
+type langSpec struct {
+	extensions []string
+	funcStart  *regexp.Regexp
+	endMode    endDetection
+}
+
+type endDetection int
+
+const (
+	endBraceDepth endDetection = iota
+	endDedent
+	endKeyword // Ruby's "end"
+)
+
+// branchPattern matches control flow keywords across all supported languages.
+// Matches whole words only to avoid false positives (e.g., "notify" matching "if").
+var branchPattern = regexp.MustCompile(
+	`\b(?:if|else\s+if|elif|elsif|for|while|switch|case|catch|except|guard|when|unless)\b`)
+
+// logicalOpPattern matches && and || operators for branch counting.
+var logicalOpPattern = regexp.MustCompile(`&&|\|\|`)
+
+// commentLinePattern matches lines that are purely comments.
+var commentLinePattern = regexp.MustCompile(
+	`^\s*(?://|#|/\*|\*\s|\*/|--)\s*`)
+
+// langSpecs defines function detection patterns per language.
+var langSpecs = []langSpec{
+	{
+		extensions: []string{".go"},
+		funcStart:  regexp.MustCompile(`^\s*func\s+(?:\([^)]*\)\s+)?(\w+)\s*\(`),
+		endMode:    endBraceDepth,
+	},
+	{
+		extensions: []string{".py"},
+		funcStart:  regexp.MustCompile(`^\s*def\s+(\w+)\s*\(`),
+		endMode:    endDedent,
+	},
+	{
+		extensions: []string{".js", ".ts", ".jsx", ".tsx"},
+		funcStart: regexp.MustCompile(
+			`(?:^\s*(?:export\s+)?(?:async\s+)?function\s+(\w+)\s*\()` +
+				`|(?:^\s*(?:export\s+)?(?:const|let|var)\s+(\w+)\s*=\s*(?:async\s+)?(?:\([^)]*\)|[^=])\s*=>)` +
+				`|(?:^\s*(?:async\s+)?(\w+)\s*\([^)]*\)\s*\{)`),
+		endMode: endBraceDepth,
+	},
+	{
+		extensions: []string{".java"},
+		funcStart: regexp.MustCompile(
+			`^\s*(?:(?:public|private|protected|static|final|abstract|synchronized|native)\s+)*\w[\w<>\[\],\s]*\s+(\w+)\s*\(`),
+		endMode: endBraceDepth,
+	},
+	{
+		extensions: []string{".rs"},
+		funcStart:  regexp.MustCompile(`^\s*(?:pub(?:\([^)]*\))?\s+)?(?:async\s+)?fn\s+(\w+)`),
+		endMode:    endBraceDepth,
+	},
+	{
+		extensions: []string{".rb"},
+		funcStart:  regexp.MustCompile(`^\s*def\s+(\w+[?!]?)`),
+		endMode:    endKeyword,
+	},
+}
+
+// extToSpec maps file extensions to their language spec for fast lookup.
+var extToSpec map[string]*langSpec
+
+func init() {
+	extToSpec = make(map[string]*langSpec)
+	for i := range langSpecs {
+		for _, ext := range langSpecs[i].extensions {
+			extToSpec[ext] = &langSpecs[i]
+		}
+	}
+}
+
+// Collect walks source files in repoPath, detects complex functions, and
+// returns them as raw signals.
+func (c *ComplexityCollector) Collect(ctx context.Context, repoPath string, opts signal.CollectorOpts) ([]signal.RawSignal, error) {
+	excludes := mergeExcludes(opts.ExcludePatterns)
+
+	minScore := defaultMinComplexityScore
+	if opts.MinComplexityScore > 0 {
+		minScore = opts.MinComplexityScore
+	}
+	minLines := defaultMinFunctionLines
+	if opts.MinFunctionLines > 0 {
+		minLines = opts.MinFunctionLines
+	}
+
+	var allFunctions []FunctionComplexity
+	var fileCount int
+
+	err := FS.WalkDir(repoPath, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return nil
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		relPath, relErr := filepath.Rel(repoPath, path)
+		if relErr != nil {
+			return nil
+		}
+
+		if d.IsDir() {
+			if shouldExclude(relPath, excludes) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if shouldExclude(relPath, excludes) {
+			return nil
+		}
+
+		// Skip symlinks outside repo tree.
+		if d.Type()&os.ModeSymlink != 0 {
+			resolved, resolveErr := FS.EvalSymlinks(path)
+			if resolveErr != nil {
+				return nil
+			}
+			if !strings.HasPrefix(resolved, repoPath+string(filepath.Separator)) && resolved != repoPath {
+				return nil
+			}
+		}
+
+		if len(opts.IncludePatterns) > 0 && !matchesAny(relPath, opts.IncludePatterns) {
+			return nil
+		}
+
+		ext := filepath.Ext(path)
+		spec := extToSpec[ext]
+		if spec == nil {
+			return nil
+		}
+
+		if isBinaryFile(path) {
+			return nil
+		}
+
+		if isGeneratedFile(path) {
+			return nil
+		}
+
+		funcs, analyzeErr := analyzeFile(path, relPath, spec, minLines)
+		if analyzeErr != nil {
+			return nil
+		}
+
+		allFunctions = append(allFunctions, funcs...)
+		fileCount++
+
+		if opts.ProgressFunc != nil && fileCount%500 == 0 {
+			opts.ProgressFunc(fmt.Sprintf("complexity: scanned %d files", fileCount))
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("walking repo: %w", err)
+	}
+
+	// Sort by score descending.
+	sort.Slice(allFunctions, func(i, j int) bool {
+		return allFunctions[i].Score > allFunctions[j].Score
+	})
+
+	// Build signals for functions above threshold.
+	var signals []signal.RawSignal
+	for _, fc := range allFunctions {
+		if fc.Score < minScore {
+			continue
+		}
+		conf := complexityConfidence(fc.Score)
+		signals = append(signals, signal.RawSignal{
+			Source:     "complexity",
+			Kind:       "complex-function",
+			FilePath:   fc.FilePath,
+			Line:       fc.StartLine,
+			Title:      fmt.Sprintf("Complex function: %s (score %.1f, %d lines, %d branches)", fc.FuncName, fc.Score, fc.Lines, fc.Branches),
+			Confidence: conf,
+			Tags:       []string{"complexity", "refactor-candidate"},
+		})
+	}
+
+	c.metrics = &ComplexityMetrics{
+		Functions:      allFunctions,
+		FilesAnalyzed:  fileCount,
+		FunctionsFound: len(allFunctions),
+	}
+
+	// Enrich signals with timestamps from git log.
+	gitRoot := opts.GitRoot
+	if gitRoot == "" {
+		gitRoot = repoPath
+	}
+	enrichTimestamps(ctx, gitRoot, signals)
+
+	return signals, nil
+}
+
+// analyzeFile detects functions in a file and computes complexity metrics.
+func analyzeFile(absPath, relPath string, spec *langSpec, minLines int) ([]FunctionComplexity, error) {
+	f, err := FS.Open(absPath)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close() //nolint:errcheck // read-only file
+
+	var lines []string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return extractFunctions(lines, relPath, spec, minLines), nil
+}
+
+// extractFunctions finds functions in lines and computes their complexity.
+func extractFunctions(lines []string, relPath string, spec *langSpec, minLines int) []FunctionComplexity {
+	var results []FunctionComplexity
+	i := 0
+
+	for i < len(lines) {
+		funcName, startLine := matchFuncStart(lines[i], spec, i+1)
+		if funcName == "" {
+			i++
+			continue
+		}
+
+		// Determine function body boundaries.
+		var bodyLines []string
+		var endIdx int
+
+		switch spec.endMode {
+		case endBraceDepth:
+			bodyLines, endIdx = extractBraceBody(lines, i)
+		case endDedent:
+			bodyLines, endIdx = extractDedentBody(lines, i)
+		case endKeyword:
+			bodyLines, endIdx = extractKeywordBody(lines, i)
+		}
+
+		if len(bodyLines) >= minLines {
+			branches := countBranches(bodyLines)
+			nonBlank := countNonBlank(bodyLines)
+			score := float64(nonBlank)/50.0 + float64(branches)
+
+			results = append(results, FunctionComplexity{
+				FilePath:  relPath,
+				FuncName:  funcName,
+				StartLine: startLine,
+				Lines:     nonBlank,
+				Branches:  branches,
+				Score:     score,
+			})
+		}
+
+		if endIdx > i {
+			i = endIdx + 1
+		} else {
+			i++
+		}
+	}
+
+	return results
+}
+
+// matchFuncStart checks if a line matches the function start pattern for the
+// given language spec. Returns the function name and 1-based line number.
+func matchFuncStart(line string, spec *langSpec, lineNo int) (string, int) {
+	matches := spec.funcStart.FindStringSubmatch(line)
+	if matches == nil {
+		return "", 0
+	}
+
+	// Return the first non-empty capture group.
+	for _, m := range matches[1:] {
+		if m != "" {
+			return m, lineNo
+		}
+	}
+	return "", 0
+}
+
+// extractBraceBody extracts the function body using brace depth tracking.
+// startIdx is the index of the line containing the function signature.
+func extractBraceBody(lines []string, startIdx int) ([]string, int) {
+	depth := 0
+	started := false
+
+	for i := startIdx; i < len(lines); i++ {
+		line := lines[i]
+		for _, ch := range line {
+			switch ch {
+			case '{':
+				depth++
+				started = true
+			case '}':
+				depth--
+			}
+		}
+		if started && depth <= 0 {
+			// Body is from line after the opening brace to this line.
+			bodyStart := startIdx + 1
+			if bodyStart > i {
+				return nil, i
+			}
+			return lines[bodyStart:i], i
+		}
+	}
+
+	// No closing brace found — return what we have.
+	if startIdx+1 < len(lines) {
+		return lines[startIdx+1:], len(lines) - 1
+	}
+	return nil, startIdx
+}
+
+// extractDedentBody extracts a Python function body based on indentation.
+func extractDedentBody(lines []string, startIdx int) ([]string, int) {
+	// Find the indentation of the def line.
+	defLine := lines[startIdx]
+	defIndent := leadingSpaces(defLine)
+
+	// The body starts on the next line and must be indented more than the def.
+	bodyStart := startIdx + 1
+	if bodyStart >= len(lines) {
+		return nil, startIdx
+	}
+
+	// Find the first non-blank line to determine body indentation.
+	bodyIndent := -1
+	for i := bodyStart; i < len(lines); i++ {
+		trimmed := strings.TrimSpace(lines[i])
+		if trimmed == "" || trimmed == "#" {
+			continue
+		}
+		bodyIndent = leadingSpaces(lines[i])
+		break
+	}
+
+	if bodyIndent <= defIndent {
+		return nil, startIdx
+	}
+
+	// Collect lines until dedent.
+	var body []string
+	endIdx := startIdx
+	for i := bodyStart; i < len(lines); i++ {
+		trimmed := strings.TrimSpace(lines[i])
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			body = append(body, lines[i])
+			endIdx = i
+			continue
+		}
+		indent := leadingSpaces(lines[i])
+		if indent <= defIndent {
+			break
+		}
+		body = append(body, lines[i])
+		endIdx = i
+	}
+
+	return body, endIdx
+}
+
+// extractKeywordBody extracts a Ruby function body using end keyword matching.
+func extractKeywordBody(lines []string, startIdx int) ([]string, int) {
+	depth := 1 // the def itself opens a block
+	bodyStart := startIdx + 1
+
+	// Ruby block-opening keywords.
+	blockOpen := regexp.MustCompile(`\b(?:def|class|module|do|if|unless|while|until|for|case|begin)\b`)
+	blockEnd := regexp.MustCompile(`\bend\b`)
+
+	for i := bodyStart; i < len(lines); i++ {
+		trimmed := strings.TrimSpace(lines[i])
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+
+		// Count block openers and closers on this line.
+		depth += len(blockOpen.FindAllString(lines[i], -1))
+		depth -= len(blockEnd.FindAllString(lines[i], -1))
+
+		if depth <= 0 {
+			if bodyStart > i {
+				return nil, i
+			}
+			return lines[bodyStart:i], i
+		}
+	}
+
+	if bodyStart < len(lines) {
+		return lines[bodyStart:], len(lines) - 1
+	}
+	return nil, startIdx
+}
+
+// leadingSpaces returns the number of leading space characters in a line.
+// Tabs count as 4 spaces (consistent with Python's typical indent).
+func leadingSpaces(line string) int {
+	count := 0
+	for _, ch := range line {
+		switch ch {
+		case ' ':
+			count++
+		case '\t':
+			count += 4
+		default:
+			return count
+		}
+	}
+	return count
+}
+
+// countBranches counts control flow keywords and logical operators in lines,
+// skipping comment-only lines.
+func countBranches(lines []string) int {
+	count := 0
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		if commentLinePattern.MatchString(line) {
+			continue
+		}
+		count += len(branchPattern.FindAllString(line, -1))
+		count += len(logicalOpPattern.FindAllString(line, -1))
+	}
+	return count
+}
+
+// countNonBlank counts non-blank lines.
+func countNonBlank(lines []string) int {
+	count := 0
+	for _, line := range lines {
+		if strings.TrimSpace(line) != "" {
+			count++
+		}
+	}
+	return count
+}
+
+// complexityConfidence maps a complexity score to a confidence value per DR-013:
+//   - score >= 15: 0.8
+//   - score 8–15: linear interpolation 0.6–0.8
+//   - score 6–8: linear interpolation 0.5–0.6
+//   - score < 6: not emitted (handled by caller)
+func complexityConfidence(score float64) float64 {
+	switch {
+	case score >= 15:
+		return 0.8
+	case score >= 8:
+		// Linear from 0.6 at 8 to 0.8 at 15.
+		return 0.6 + 0.2*(score-8)/(15-8)
+	case score >= 6:
+		// Linear from 0.5 at 6 to 0.6 at 8.
+		return 0.5 + 0.1*(score-6)/(8-6)
+	default:
+		return 0.5
+	}
+}
+
+// Metrics returns structured metrics from the complexity scan.
+func (c *ComplexityCollector) Metrics() any { return c.metrics }
+
+// Compile-time interface checks.
+var _ collector.Collector = (*ComplexityCollector)(nil)
+var _ collector.MetricsProvider = (*ComplexityCollector)(nil)

--- a/internal/collectors/complexity_test.go
+++ b/internal/collectors/complexity_test.go
@@ -1,0 +1,667 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
+package collectors
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/davetashner/stringer/internal/signal"
+)
+
+func TestComplexityCollector_Name(t *testing.T) {
+	c := &ComplexityCollector{}
+	assert.Equal(t, "complexity", c.Name())
+}
+
+func TestMatchFuncStart_Go(t *testing.T) {
+	spec := extToSpec[".go"]
+	tests := []struct {
+		line string
+		want string
+	}{
+		{"func main() {", "main"},
+		{"func (s *Server) Handle(w http.ResponseWriter, r *http.Request) {", "Handle"},
+		{"func processFile(path string) error {", "processFile"},
+		{"// func commented() {", ""},
+		{"var x = 5", ""},
+	}
+	for _, tt := range tests {
+		name, _ := matchFuncStart(tt.line, spec, 1)
+		assert.Equal(t, tt.want, name, "line: %s", tt.line)
+	}
+}
+
+func TestMatchFuncStart_Python(t *testing.T) {
+	spec := extToSpec[".py"]
+	tests := []struct {
+		line string
+		want string
+	}{
+		{"def process_file(path):", "process_file"},
+		{"    def inner(x):", "inner"},
+		{"class Foo:", ""},
+	}
+	for _, tt := range tests {
+		name, _ := matchFuncStart(tt.line, spec, 1)
+		assert.Equal(t, tt.want, name, "line: %s", tt.line)
+	}
+}
+
+func TestMatchFuncStart_JavaScript(t *testing.T) {
+	spec := extToSpec[".js"]
+	tests := []struct {
+		line string
+		want string
+	}{
+		{"function processFile(path) {", "processFile"},
+		{"async function fetchData() {", "fetchData"},
+		{"const handler = (req, res) => {", "handler"},
+		{"export function render() {", "render"},
+	}
+	for _, tt := range tests {
+		name, _ := matchFuncStart(tt.line, spec, 1)
+		assert.Equal(t, tt.want, name, "line: %s", tt.line)
+	}
+}
+
+func TestMatchFuncStart_Java(t *testing.T) {
+	spec := extToSpec[".java"]
+	tests := []struct {
+		line string
+		want string
+	}{
+		{"    public void processFile(String path) {", "processFile"},
+		{"    private static int calculate(int x) {", "calculate"},
+		{"    protected List<String> getItems() {", "getItems"},
+	}
+	for _, tt := range tests {
+		name, _ := matchFuncStart(tt.line, spec, 1)
+		assert.Equal(t, tt.want, name, "line: %s", tt.line)
+	}
+}
+
+func TestMatchFuncStart_Rust(t *testing.T) {
+	spec := extToSpec[".rs"]
+	tests := []struct {
+		line string
+		want string
+	}{
+		{"fn process_file(path: &str) -> Result<()> {", "process_file"},
+		{"pub fn new() -> Self {", "new"},
+		{"pub(crate) async fn handle(req: Request) -> Response {", "handle"},
+	}
+	for _, tt := range tests {
+		name, _ := matchFuncStart(tt.line, spec, 1)
+		assert.Equal(t, tt.want, name, "line: %s", tt.line)
+	}
+}
+
+func TestMatchFuncStart_Ruby(t *testing.T) {
+	spec := extToSpec[".rb"]
+	tests := []struct {
+		line string
+		want string
+	}{
+		{"  def process_file(path)", "process_file"},
+		{"  def valid?", "valid?"},
+		{"  def save!", "save!"},
+	}
+	for _, tt := range tests {
+		name, _ := matchFuncStart(tt.line, spec, 1)
+		assert.Equal(t, tt.want, name, "line: %s", tt.line)
+	}
+}
+
+func TestExtractBraceBody(t *testing.T) {
+	lines := strings.Split(`func foo() {
+	if x > 0 {
+		return x
+	}
+	for i := 0; i < 10; i++ {
+		sum += i
+	}
+	return sum
+}`, "\n")
+
+	body, endIdx := extractBraceBody(lines, 0)
+	assert.Equal(t, 7, len(body), "expected 7 body lines")
+	assert.Equal(t, 8, endIdx)
+}
+
+func TestExtractDedentBody(t *testing.T) {
+	lines := strings.Split(`def process(data):
+    if data is None:
+        return
+    for item in data:
+        result.append(item)
+    return result
+
+def other():`, "\n")
+
+	body, endIdx := extractDedentBody(lines, 0)
+	// Body includes the blank line between functions (before dedent).
+	assert.Equal(t, 6, len(body), "expected 6 body lines including trailing blank")
+	assert.Equal(t, 6, endIdx)
+}
+
+func TestExtractKeywordBody(t *testing.T) {
+	lines := strings.Split(`def process(data)
+  if data.nil?
+    return
+  end
+  data.each do |item|
+    result << item
+  end
+  result
+end`, "\n")
+
+	body, endIdx := extractKeywordBody(lines, 0)
+	assert.Equal(t, 7, len(body), "expected 7 body lines")
+	assert.Equal(t, 8, endIdx)
+}
+
+func TestCountBranches(t *testing.T) {
+	lines := []string{
+		"	if x > 0 {",
+		"		// if this is a comment",
+		"		for i := range items {",
+		"			if y > 0 || z > 0 {",
+		"				switch mode {",
+		"				case 1:",
+		"				case 2:",
+		"			}",
+		"		}",
+		"	}",
+	}
+	count := countBranches(lines)
+	// if + for + if + || + switch + case + case = 7
+	assert.Equal(t, 7, count)
+}
+
+func TestCountBranches_SkipsComments(t *testing.T) {
+	lines := []string{
+		"// if this is commented",
+		"# elif this too",
+		"  if real_code:",
+	}
+	count := countBranches(lines)
+	assert.Equal(t, 1, count)
+}
+
+func TestComplexityConfidence(t *testing.T) {
+	tests := []struct {
+		score float64
+		want  float64
+	}{
+		{20.0, 0.8},
+		{15.0, 0.8},
+		{8.0, 0.6},
+		{11.5, 0.7},
+		{6.0, 0.5},
+		{7.0, 0.55},
+		{5.0, 0.5},
+	}
+	for _, tt := range tests {
+		got := complexityConfidence(tt.score)
+		assert.InDelta(t, tt.want, got, 0.01, "score=%.1f", tt.score)
+	}
+}
+
+func TestCompositeScore(t *testing.T) {
+	// 200 lines, 15 branches → 200/50 + 15 = 4.0 + 15 = 19.0
+	score := float64(200)/50.0 + float64(15)
+	assert.InDelta(t, 19.0, score, 0.01)
+
+	// 50 lines, 0 branches → 1.0
+	score = float64(50)/50.0 + float64(0)
+	assert.InDelta(t, 1.0, score, 0.01)
+
+	// 50 lines, 10 branches → 11.0
+	score = float64(50)/50.0 + float64(10)
+	assert.InDelta(t, 11.0, score, 0.01)
+}
+
+func TestComplexityCollector_EndToEnd(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a Go file with a complex function.
+	goCode := `package main
+
+func simpleFunc() {
+	return
+}
+
+func complexFunc(items []int) int {
+	sum := 0
+	for _, item := range items {
+		if item > 0 {
+			sum += item
+		} else if item < -10 {
+			sum -= item
+		}
+		switch {
+		case item == 0:
+			continue
+		case item > 100:
+			break
+		}
+		if sum > 1000 || sum < -1000 {
+			return sum
+		}
+	}
+	for i := 0; i < len(items); i++ {
+		if items[i] > sum && items[i] < sum*2 {
+			sum = items[i]
+		}
+	}
+	return sum
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.go"), []byte(goCode), 0o600))
+
+	c := &ComplexityCollector{}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{
+		MinComplexityScore: 3.0, // Lower threshold for test
+	})
+	require.NoError(t, err)
+
+	// Should detect complexFunc but not simpleFunc.
+	complexSigs := filterByKind(signals, "complex-function")
+	require.NotEmpty(t, complexSigs, "expected at least one complex-function signal")
+
+	found := false
+	for _, sig := range complexSigs {
+		if strings.Contains(sig.Title, "complexFunc") {
+			found = true
+			assert.Equal(t, "complexity", sig.Source)
+			assert.Contains(t, sig.Tags, "complexity")
+			assert.Contains(t, sig.Tags, "refactor-candidate")
+			assert.True(t, sig.Confidence >= 0.5)
+			break
+		}
+	}
+	assert.True(t, found, "expected complexFunc signal")
+
+	// simpleFunc should not appear.
+	for _, sig := range complexSigs {
+		assert.NotContains(t, sig.Title, "simpleFunc")
+	}
+
+	// Metrics should be populated.
+	assert.NotNil(t, c.Metrics())
+	m := c.Metrics().(*ComplexityMetrics)
+	assert.Equal(t, 1, m.FilesAnalyzed)
+	assert.GreaterOrEqual(t, m.FunctionsFound, 1)
+}
+
+func TestComplexityCollector_Python(t *testing.T) {
+	dir := t.TempDir()
+
+	pyCode := `def simple():
+    return 1
+
+def complex_function(data):
+    result = []
+    for item in data:
+        if item > 0:
+            result.append(item)
+        elif item < -10:
+            result.append(-item)
+        else:
+            pass
+        for sub in item.children:
+            if sub.valid and sub.active:
+                result.append(sub)
+            elif sub.pending or sub.deferred:
+                pass
+        while len(result) > 100:
+            result.pop()
+    return result
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "app.py"), []byte(pyCode), 0o600))
+
+	c := &ComplexityCollector{}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{
+		MinComplexityScore: 3.0,
+	})
+	require.NoError(t, err)
+
+	complexSigs := filterByKind(signals, "complex-function")
+	found := false
+	for _, sig := range complexSigs {
+		if strings.Contains(sig.Title, "complex_function") {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected complex_function signal")
+}
+
+func TestComplexityCollector_MultipleFunctionsInFile(t *testing.T) {
+	dir := t.TempDir()
+
+	goCode := `package main
+
+func funcA(x int) int {
+	if x > 0 {
+		for i := 0; i < x; i++ {
+			if i%2 == 0 || i%3 == 0 {
+				x += i
+			}
+			switch i {
+			case 1:
+				x++
+			case 2:
+				x--
+			}
+		}
+	}
+	return x
+}
+
+func funcB(items []string) []string {
+	var result []string
+	for _, item := range items {
+		if len(item) > 0 && item[0] != '#' {
+			result = append(result, item)
+		}
+		if len(item) > 100 || strings.Contains(item, "special") {
+			continue
+		}
+		for _, ch := range item {
+			if ch == '\n' {
+				break
+			}
+		}
+		switch len(item) {
+		case 0:
+			continue
+		case 1:
+			result = append(result, item+item)
+		}
+	}
+	return result
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "multi.go"), []byte(goCode), 0o600))
+
+	c := &ComplexityCollector{}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{
+		MinComplexityScore: 3.0,
+	})
+	require.NoError(t, err)
+
+	complexSigs := filterByKind(signals, "complex-function")
+	assert.GreaterOrEqual(t, len(complexSigs), 2, "expected at least 2 complex function signals")
+}
+
+func TestComplexityCollector_ExcludePatterns(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a file in a vendor directory.
+	vendorDir := filepath.Join(dir, "vendor")
+	require.NoError(t, os.MkdirAll(vendorDir, 0o750))
+
+	goCode := `package vendor
+func complexVendor(x int) int {
+	if x > 0 {
+		for i := 0; i < 10; i++ {
+			if i > 5 {
+				switch i {
+				case 6:
+				case 7:
+				case 8:
+				}
+			}
+		}
+	}
+	return x
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(vendorDir, "lib.go"), []byte(goCode), 0o600))
+
+	c := &ComplexityCollector{}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{
+		MinComplexityScore: 1.0,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, signals, "vendor files should be excluded")
+}
+
+func TestComplexityCollector_ContextCancellation(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main\nfunc main() {}\n"), 0o600))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately.
+
+	c := &ComplexityCollector{}
+	_, err := c.Collect(ctx, dir, signal.CollectorOpts{})
+	assert.Error(t, err)
+}
+
+func TestComplexityCollector_EmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "empty.go"), []byte(""), 0o600))
+
+	c := &ComplexityCollector{}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{})
+	require.NoError(t, err)
+	assert.Empty(t, signals)
+}
+
+func TestComplexityCollector_BinaryFileSkipped(t *testing.T) {
+	dir := t.TempDir()
+	// Write a binary file with null bytes.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "binary.go"), []byte("package main\x00\x00\x00"), 0o600))
+
+	c := &ComplexityCollector{}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{})
+	require.NoError(t, err)
+	assert.Empty(t, signals)
+}
+
+func TestComplexityCollector_GeneratedFileSkipped(t *testing.T) {
+	dir := t.TempDir()
+	goCode := "// Code generated by stringer; DO NOT EDIT.\npackage main\nfunc big() {\n"
+	for i := 0; i < 100; i++ {
+		goCode += "\tif true { }\n"
+	}
+	goCode += "}\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "gen.go"), []byte(goCode), 0o600))
+
+	c := &ComplexityCollector{}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{
+		MinComplexityScore: 1.0,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, signals, "generated files should be skipped")
+}
+
+func TestComplexityCollector_Rust(t *testing.T) {
+	dir := t.TempDir()
+
+	rsCode := `pub fn process(data: &[i32]) -> Vec<i32> {
+    let mut result = Vec::new();
+    for item in data {
+        if *item > 0 {
+            result.push(*item);
+        } else if *item < -10 {
+            result.push(-*item);
+        }
+        match *item {
+            0 => continue,
+            1..=10 => result.push(*item * 2),
+            _ => {}
+        }
+        while result.len() > 100 {
+            result.pop();
+        }
+    }
+    result
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "lib.rs"), []byte(rsCode), 0o600))
+
+	c := &ComplexityCollector{}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{
+		MinComplexityScore: 3.0,
+	})
+	require.NoError(t, err)
+
+	complexSigs := filterByKind(signals, "complex-function")
+	found := false
+	for _, sig := range complexSigs {
+		if strings.Contains(sig.Title, "process") {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected process function signal from Rust file")
+}
+
+func TestComplexityCollector_Ruby(t *testing.T) {
+	dir := t.TempDir()
+
+	rbCode := `def process(data)
+  result = []
+  data.each do |item|
+    if item > 0
+      result << item
+    elsif item < -10
+      result << -item
+    end
+    case item
+    when 0
+      next
+    when 1..10
+      result << item * 2
+    end
+    while result.length > 100
+      result.pop
+    end
+  end
+  result
+end
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "app.rb"), []byte(rbCode), 0o600))
+
+	c := &ComplexityCollector{}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{
+		MinComplexityScore: 3.0,
+	})
+	require.NoError(t, err)
+
+	complexSigs := filterByKind(signals, "complex-function")
+	found := false
+	for _, sig := range complexSigs {
+		if strings.Contains(sig.Title, "process") {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected process function signal from Ruby file")
+}
+
+func TestComplexityCollector_MinFunctionLines(t *testing.T) {
+	dir := t.TempDir()
+
+	// A short function with branches — should be skipped with high minLines.
+	goCode := `package main
+
+func tiny(x int) int {
+	if x > 0 {
+		return x
+	}
+	return -x
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "tiny.go"), []byte(goCode), 0o600))
+
+	c := &ComplexityCollector{}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{
+		MinFunctionLines:   100, // Very high threshold.
+		MinComplexityScore: 0.1,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, signals, "tiny functions should be skipped with high minLines")
+}
+
+func TestCountNonBlank(t *testing.T) {
+	lines := []string{
+		"	x := 1",
+		"",
+		"	y := 2",
+		"",
+		"",
+		"	return x + y",
+	}
+	assert.Equal(t, 3, countNonBlank(lines))
+}
+
+func TestLeadingSpaces(t *testing.T) {
+	assert.Equal(t, 0, leadingSpaces("hello"))
+	assert.Equal(t, 4, leadingSpaces("    hello"))
+	assert.Equal(t, 4, leadingSpaces("\thello"))
+	assert.Equal(t, 8, leadingSpaces("\t\thello"))
+}
+
+func TestExtractFunctions_JavaScriptArrow(t *testing.T) {
+	spec := extToSpec[".js"]
+	lines := strings.Split(`const handler = (req, res) => {
+  if (req.method === 'GET') {
+    for (const item of items) {
+      if (item.valid && item.active) {
+        res.send(item);
+      }
+    }
+  } else if (req.method === 'POST') {
+    switch (req.body.type) {
+    case 'create':
+      break;
+    case 'update':
+      break;
+    }
+  }
+};`, "\n")
+
+	funcs := extractFunctions(lines, "handler.js", spec, 1)
+	require.NotEmpty(t, funcs)
+	assert.Equal(t, "handler", funcs[0].FuncName)
+	assert.True(t, funcs[0].Branches > 0)
+}
+
+func TestExtractFunctions_JavaMethod(t *testing.T) {
+	spec := extToSpec[".java"]
+	lines := strings.Split(`    public List<String> process(List<String> items) {
+        List<String> result = new ArrayList<>();
+        for (String item : items) {
+            if (item != null && !item.isEmpty()) {
+                result.add(item);
+            } else if (item == null) {
+                continue;
+            }
+            switch (item.length()) {
+            case 0:
+                break;
+            case 1:
+                result.add(item + item);
+                break;
+            }
+        }
+        return result;
+    }`, "\n")
+
+	funcs := extractFunctions(lines, "Processor.java", spec, 1)
+	require.NotEmpty(t, funcs)
+	assert.Equal(t, "process", funcs[0].FuncName)
+	assert.True(t, funcs[0].Branches > 0)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -55,6 +55,10 @@ type CollectorConfig struct {
 
 	// Timeout is the per-collector timeout (e.g. "60s", "2m").
 	Timeout string `yaml:"timeout,omitempty"`
+
+	// Complexity collector settings.
+	MinFunctionLines   int     `yaml:"min_function_lines,omitempty"`
+	MinComplexityScore float64 `yaml:"min_complexity_score,omitempty"`
 }
 
 // FileName is the expected config file name in a repository root.

--- a/internal/config/merge.go
+++ b/internal/config/merge.go
@@ -77,6 +77,12 @@ func Merge(fileCfg *Config, cliCfg signal.ScanConfig) signal.ScanConfig {
 					co.Timeout = d
 				}
 			}
+			if co.MinFunctionLines == 0 && fc.MinFunctionLines > 0 {
+				co.MinFunctionLines = fc.MinFunctionLines
+			}
+			if co.MinComplexityScore == 0 && fc.MinComplexityScore > 0 {
+				co.MinComplexityScore = fc.MinComplexityScore
+			}
 			result.CollectorOpts[name] = co
 		}
 	}

--- a/internal/report/complexity.go
+++ b/internal/report/complexity.go
@@ -1,0 +1,103 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
+package report
+
+import (
+	"fmt"
+	"io"
+	"sort"
+
+	"github.com/davetashner/stringer/internal/collectors"
+	"github.com/davetashner/stringer/internal/signal"
+)
+
+const complexityTopN = 20
+
+func init() {
+	Register(&complexitySection{})
+}
+
+// complexitySection reports the most complex functions found during scanning.
+type complexitySection struct {
+	functions []collectors.FunctionComplexity
+}
+
+func (s *complexitySection) Name() string        { return "complexity" }
+func (s *complexitySection) Description() string { return "Function complexity analysis" }
+
+func (s *complexitySection) Analyze(result *signal.ScanResult) error {
+	raw, ok := result.Metrics["complexity"]
+	if !ok {
+		return fmt.Errorf("complexity: %w", ErrMetricsNotAvailable)
+	}
+	m, ok := raw.(*collectors.ComplexityMetrics)
+	if !ok || m == nil {
+		return fmt.Errorf("complexity: %w", ErrMetricsNotAvailable)
+	}
+
+	// Copy and sort by score descending.
+	s.functions = make([]collectors.FunctionComplexity, len(m.Functions))
+	copy(s.functions, m.Functions)
+	sort.Slice(s.functions, func(i, j int) bool {
+		return s.functions[i].Score > s.functions[j].Score
+	})
+
+	// Cap at top N.
+	if len(s.functions) > complexityTopN {
+		s.functions = s.functions[:complexityTopN]
+	}
+
+	return nil
+}
+
+func (s *complexitySection) Render(w io.Writer) error {
+	_, _ = fmt.Fprintf(w, "%s\n", SectionTitle("Function Complexity"))
+	_, _ = fmt.Fprintf(w, "-------------------\n")
+
+	if len(s.functions) == 0 {
+		_, _ = fmt.Fprintf(w, "  No complex functions detected.\n\n")
+		return nil
+	}
+
+	tbl := NewTable(
+		Column{Header: "Function"},
+		Column{Header: "File"},
+		Column{Header: "Lines", Align: AlignRight},
+		Column{Header: "Branches", Align: AlignRight},
+		Column{Header: "Score", Align: AlignRight, Color: ColorComplexity},
+	)
+
+	for _, fc := range s.functions {
+		tbl.AddRow(
+			fc.FuncName,
+			fc.FilePath,
+			fmt.Sprintf("%d", fc.Lines),
+			fmt.Sprintf("%d", fc.Branches),
+			fmt.Sprintf("%.1f", fc.Score),
+		)
+	}
+
+	if err := tbl.Render(w); err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(w, "\n")
+	return nil
+}
+
+// ColorComplexity colors complexity score labels.
+func ColorComplexity(val string) string {
+	// Parse the score to determine color.
+	var score float64
+	if _, err := fmt.Sscanf(val, "%f", &score); err != nil {
+		return val
+	}
+	switch {
+	case score >= 15:
+		return colorRed.Sprint(val)
+	case score >= 8:
+		return colorYellow.Sprint(val)
+	default:
+		return val
+	}
+}

--- a/internal/report/complexity_test.go
+++ b/internal/report/complexity_test.go
@@ -1,0 +1,123 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
+package report
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/davetashner/stringer/internal/collectors"
+	"github.com/davetashner/stringer/internal/signal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestComplexity_Registered(t *testing.T) {
+	s := Get("complexity")
+	require.NotNil(t, s)
+	assert.Equal(t, "complexity", s.Name())
+	assert.NotEmpty(t, s.Description())
+}
+
+func TestComplexity_Analyze_MissingMetrics(t *testing.T) {
+	s := &complexitySection{}
+	err := s.Analyze(&signal.ScanResult{Metrics: map[string]any{}})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrMetricsNotAvailable))
+}
+
+func TestComplexity_Analyze_NilMetrics(t *testing.T) {
+	s := &complexitySection{}
+	err := s.Analyze(&signal.ScanResult{
+		Metrics: map[string]any{"complexity": (*collectors.ComplexityMetrics)(nil)},
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrMetricsNotAvailable))
+}
+
+func TestComplexity_AnalyzeAndRender(t *testing.T) {
+	s := &complexitySection{}
+	result := &signal.ScanResult{
+		Metrics: map[string]any{
+			"complexity": &collectors.ComplexityMetrics{
+				Functions: []collectors.FunctionComplexity{
+					{FilePath: "main.go", FuncName: "simple", StartLine: 1, Lines: 10, Branches: 1, Score: 1.2},
+					{FilePath: "handler.go", FuncName: "processRequest", StartLine: 15, Lines: 200, Branches: 20, Score: 24.0},
+					{FilePath: "parser.go", FuncName: "parse", StartLine: 30, Lines: 100, Branches: 10, Score: 12.0},
+				},
+				FilesAnalyzed:  3,
+				FunctionsFound: 3,
+			},
+		},
+	}
+
+	require.NoError(t, s.Analyze(result))
+
+	var buf bytes.Buffer
+	require.NoError(t, s.Render(&buf))
+
+	out := buf.String()
+	assert.Contains(t, out, "Function Complexity")
+	assert.Contains(t, out, "processRequest")
+	assert.Contains(t, out, "parse")
+	assert.Contains(t, out, "simple")
+
+	// Should be sorted by score descending.
+	processIdx := bytes.Index(buf.Bytes(), []byte("processRequest"))
+	parseIdx := bytes.Index(buf.Bytes(), []byte("parse"))
+	assert.True(t, processIdx < parseIdx, "processRequest (24.0) before parse (12.0)")
+}
+
+func TestComplexity_TopN_Cap(t *testing.T) {
+	funcs := make([]collectors.FunctionComplexity, 30)
+	for i := range funcs {
+		funcs[i] = collectors.FunctionComplexity{
+			FilePath:  fmt.Sprintf("file%d.go", i),
+			FuncName:  fmt.Sprintf("func%d", i),
+			StartLine: i + 1,
+			Lines:     100 + i,
+			Branches:  20 - i,
+			Score:     float64(30 - i),
+		}
+	}
+
+	s := &complexitySection{}
+	result := &signal.ScanResult{
+		Metrics: map[string]any{
+			"complexity": &collectors.ComplexityMetrics{Functions: funcs},
+		},
+	}
+
+	require.NoError(t, s.Analyze(result))
+	assert.Len(t, s.functions, complexityTopN)
+	assert.Equal(t, float64(30), s.functions[0].Score)
+}
+
+func TestComplexity_Render_Empty(t *testing.T) {
+	s := &complexitySection{}
+	s.functions = nil
+
+	var buf bytes.Buffer
+	require.NoError(t, s.Render(&buf))
+	assert.Contains(t, buf.String(), "No complex functions detected")
+}
+
+func TestColorComplexity(t *testing.T) {
+	// High score — should contain original text.
+	high := ColorComplexity("20.0")
+	assert.Contains(t, high, "20.0")
+
+	// Medium score — should contain original text.
+	med := ColorComplexity("10.0")
+	assert.Contains(t, med, "10.0")
+
+	// Low score returned as-is.
+	low := ColorComplexity("5.0")
+	assert.Equal(t, "5.0", low)
+
+	// Non-numeric returned as-is.
+	assert.Equal(t, "n/a", ColorComplexity("n/a"))
+}

--- a/internal/report/hotspots.go
+++ b/internal/report/hotspots.go
@@ -1,0 +1,154 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
+package report
+
+import (
+	"fmt"
+	"io"
+	"math"
+	"sort"
+
+	"github.com/davetashner/stringer/internal/collectors"
+	"github.com/davetashner/stringer/internal/signal"
+)
+
+const hotspotsTopN = 15
+
+// minHotspotComplexity is the minimum complexity score for hotspot inclusion.
+const minHotspotComplexity = 6.0
+
+// minHotspotChurn is the minimum change count for hotspot inclusion.
+const minHotspotChurn = 5
+
+func init() {
+	Register(&hotspotsSection{})
+}
+
+// hotspot represents a file at the intersection of high complexity and high churn.
+type hotspot struct {
+	FilePath     string
+	FuncName     string
+	Complexity   float64
+	ChangeCount  int
+	HotspotScore float64 // complexity_score * log2(change_count + 1)
+}
+
+// hotspotsSection cross-references complexity and churn data to find toxic hotspots.
+type hotspotsSection struct {
+	hotspots []hotspot
+}
+
+func (s *hotspotsSection) Name() string        { return "hotspots" }
+func (s *hotspotsSection) Description() string { return "Toxic hotspots (complexity x churn)" }
+
+func (s *hotspotsSection) Analyze(result *signal.ScanResult) error {
+	// Read complexity metrics.
+	rawC, okC := result.Metrics["complexity"]
+	if !okC {
+		return fmt.Errorf("complexity: %w", ErrMetricsNotAvailable)
+	}
+	cm, okCM := rawC.(*collectors.ComplexityMetrics)
+	if !okCM || cm == nil {
+		return fmt.Errorf("complexity: %w", ErrMetricsNotAvailable)
+	}
+
+	// Read gitlog metrics.
+	rawG, okG := result.Metrics["gitlog"]
+	if !okG {
+		return fmt.Errorf("gitlog: %w", ErrMetricsNotAvailable)
+	}
+	gm, okGM := rawG.(*collectors.GitlogMetrics)
+	if !okGM || gm == nil {
+		return fmt.Errorf("gitlog: %w", ErrMetricsNotAvailable)
+	}
+
+	// Build churn lookup by file path.
+	churnMap := make(map[string]int, len(gm.FileChurns))
+	for _, fc := range gm.FileChurns {
+		churnMap[fc.Path] = fc.ChangeCount
+	}
+
+	// Cross-reference: for each complex function, check if its file has high churn.
+	var spots []hotspot
+	for _, fc := range cm.Functions {
+		if fc.Score < minHotspotComplexity {
+			continue
+		}
+		changes, ok := churnMap[fc.FilePath]
+		if !ok || changes < minHotspotChurn {
+			continue
+		}
+		spots = append(spots, hotspot{
+			FilePath:     fc.FilePath,
+			FuncName:     fc.FuncName,
+			Complexity:   fc.Score,
+			ChangeCount:  changes,
+			HotspotScore: fc.Score * math.Log2(float64(changes+1)),
+		})
+	}
+
+	// Sort by hotspot score descending.
+	sort.Slice(spots, func(i, j int) bool {
+		return spots[i].HotspotScore > spots[j].HotspotScore
+	})
+
+	if len(spots) > hotspotsTopN {
+		spots = spots[:hotspotsTopN]
+	}
+
+	s.hotspots = spots
+	return nil
+}
+
+func (s *hotspotsSection) Render(w io.Writer) error {
+	_, _ = fmt.Fprintf(w, "%s\n", SectionTitle("Toxic Hotspots"))
+	_, _ = fmt.Fprintf(w, "--------------\n")
+
+	if len(s.hotspots) == 0 {
+		_, _ = fmt.Fprintf(w, "  No toxic hotspots detected (complex functions in high-churn files).\n\n")
+		return nil
+	}
+
+	_, _ = fmt.Fprintf(w, "  Complex functions in frequently-changed files — highest-value refactoring targets.\n\n")
+
+	tbl := NewTable(
+		Column{Header: "Function"},
+		Column{Header: "File"},
+		Column{Header: "Complexity", Align: AlignRight},
+		Column{Header: "Changes", Align: AlignRight},
+		Column{Header: "Hotspot", Align: AlignRight, Color: colorHotspot},
+	)
+
+	for _, hs := range s.hotspots {
+		tbl.AddRow(
+			hs.FuncName,
+			hs.FilePath,
+			fmt.Sprintf("%.1f", hs.Complexity),
+			fmt.Sprintf("%d", hs.ChangeCount),
+			fmt.Sprintf("%.1f", hs.HotspotScore),
+		)
+	}
+
+	if err := tbl.Render(w); err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintf(w, "\n")
+	return nil
+}
+
+// colorHotspot colors hotspot scores.
+func colorHotspot(val string) string {
+	var score float64
+	if _, err := fmt.Sscanf(val, "%f", &score); err != nil {
+		return val
+	}
+	switch {
+	case score >= 50:
+		return colorRed.Sprint(val)
+	case score >= 25:
+		return colorYellow.Sprint(val)
+	default:
+		return val
+	}
+}

--- a/internal/report/hotspots_test.go
+++ b/internal/report/hotspots_test.go
@@ -1,0 +1,164 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
+package report
+
+import (
+	"bytes"
+	"errors"
+	"math"
+	"testing"
+
+	"github.com/davetashner/stringer/internal/collectors"
+	"github.com/davetashner/stringer/internal/signal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHotspots_Registered(t *testing.T) {
+	s := Get("hotspots")
+	require.NotNil(t, s)
+	assert.Equal(t, "hotspots", s.Name())
+	assert.NotEmpty(t, s.Description())
+}
+
+func TestHotspots_Analyze_MissingComplexity(t *testing.T) {
+	s := &hotspotsSection{}
+	err := s.Analyze(&signal.ScanResult{
+		Metrics: map[string]any{
+			"gitlog": &collectors.GitlogMetrics{},
+		},
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrMetricsNotAvailable))
+}
+
+func TestHotspots_Analyze_MissingGitlog(t *testing.T) {
+	s := &hotspotsSection{}
+	err := s.Analyze(&signal.ScanResult{
+		Metrics: map[string]any{
+			"complexity": &collectors.ComplexityMetrics{},
+		},
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrMetricsNotAvailable))
+}
+
+func TestHotspots_Analyze_NilComplexity(t *testing.T) {
+	s := &hotspotsSection{}
+	err := s.Analyze(&signal.ScanResult{
+		Metrics: map[string]any{
+			"complexity": (*collectors.ComplexityMetrics)(nil),
+			"gitlog":     &collectors.GitlogMetrics{},
+		},
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrMetricsNotAvailable))
+}
+
+func TestHotspots_AnalyzeAndRender(t *testing.T) {
+	s := &hotspotsSection{}
+	result := &signal.ScanResult{
+		Metrics: map[string]any{
+			"complexity": &collectors.ComplexityMetrics{
+				Functions: []collectors.FunctionComplexity{
+					{FilePath: "hot.go", FuncName: "processAll", Lines: 200, Branches: 20, Score: 24.0},
+					{FilePath: "stable.go", FuncName: "simple", Lines: 20, Branches: 1, Score: 1.4},
+					{FilePath: "complex_only.go", FuncName: "bigFunc", Lines: 150, Branches: 12, Score: 15.0},
+				},
+			},
+			"gitlog": &collectors.GitlogMetrics{
+				FileChurns: []collectors.FileChurn{
+					{Path: "hot.go", ChangeCount: 30, AuthorCount: 5},
+					{Path: "stable.go", ChangeCount: 1, AuthorCount: 1},
+					{Path: "churn_only.go", ChangeCount: 50, AuthorCount: 3},
+				},
+			},
+		},
+	}
+
+	require.NoError(t, s.Analyze(result))
+
+	// hot.go: score 24.0, 30 changes → hotspot score = 24.0 * log2(31)
+	// stable.go: score 1.4, 1 change → excluded (score < 6)
+	// complex_only.go: score 15.0, 0 changes → excluded (no churn)
+	require.Len(t, s.hotspots, 1)
+	assert.Equal(t, "hot.go", s.hotspots[0].FilePath)
+	assert.Equal(t, "processAll", s.hotspots[0].FuncName)
+	expectedScore := 24.0 * math.Log2(31)
+	assert.InDelta(t, expectedScore, s.hotspots[0].HotspotScore, 0.1)
+
+	var buf bytes.Buffer
+	require.NoError(t, s.Render(&buf))
+
+	out := buf.String()
+	assert.Contains(t, out, "Toxic Hotspots")
+	assert.Contains(t, out, "processAll")
+	assert.Contains(t, out, "hot.go")
+	assert.NotContains(t, out, "stable.go")
+	assert.NotContains(t, out, "complex_only.go")
+}
+
+func TestHotspots_Render_Empty(t *testing.T) {
+	s := &hotspotsSection{}
+	s.hotspots = nil
+
+	var buf bytes.Buffer
+	require.NoError(t, s.Render(&buf))
+	assert.Contains(t, buf.String(), "No toxic hotspots detected")
+}
+
+func TestHotspots_MinThresholds(t *testing.T) {
+	s := &hotspotsSection{}
+	result := &signal.ScanResult{
+		Metrics: map[string]any{
+			"complexity": &collectors.ComplexityMetrics{
+				Functions: []collectors.FunctionComplexity{
+					// Below complexity threshold (< 6.0).
+					{FilePath: "a.go", FuncName: "low", Score: 5.9},
+					// Above complexity but below churn threshold.
+					{FilePath: "b.go", FuncName: "complex_no_churn", Score: 10.0},
+				},
+			},
+			"gitlog": &collectors.GitlogMetrics{
+				FileChurns: []collectors.FileChurn{
+					{Path: "a.go", ChangeCount: 100},
+					{Path: "b.go", ChangeCount: 4}, // Below minHotspotChurn (5).
+				},
+			},
+		},
+	}
+
+	require.NoError(t, s.Analyze(result))
+	assert.Empty(t, s.hotspots)
+}
+
+func TestHotspots_SortAndCap(t *testing.T) {
+	funcs := make([]collectors.FunctionComplexity, 20)
+	churns := make([]collectors.FileChurn, 20)
+	for i := range funcs {
+		path := "file" + string(rune('a'+i)) + ".go"
+		funcs[i] = collectors.FunctionComplexity{
+			FilePath: path,
+			FuncName: "func" + string(rune('A'+i)),
+			Score:    float64(10 + i),
+		}
+		churns[i] = collectors.FileChurn{
+			Path:        path,
+			ChangeCount: 10 + i,
+		}
+	}
+
+	s := &hotspotsSection{}
+	result := &signal.ScanResult{
+		Metrics: map[string]any{
+			"complexity": &collectors.ComplexityMetrics{Functions: funcs},
+			"gitlog":     &collectors.GitlogMetrics{FileChurns: churns},
+		},
+	}
+
+	require.NoError(t, s.Analyze(result))
+	assert.Len(t, s.hotspots, hotspotsTopN)
+	// First should have highest hotspot score.
+	assert.True(t, s.hotspots[0].HotspotScore >= s.hotspots[1].HotspotScore)
+}

--- a/internal/signal/signal.go
+++ b/internal/signal/signal.go
@@ -95,6 +95,14 @@ type CollectorOpts struct {
 	// dependency health checks (e.g., "2y", "18m"). If empty, the default
 	// (2 years) is used.
 	StalenessThreshold string
+
+	// MinFunctionLines is the minimum function body lines to analyze for
+	// complexity. Functions shorter than this are skipped. 0 uses default (5).
+	MinFunctionLines int
+
+	// MinComplexityScore is the minimum composite complexity score to emit a
+	// signal. 0 uses default (6.0).
+	MinComplexityScore float64
 }
 
 // ScanConfig holds the overall configuration for a scan operation.


### PR DESCRIPTION
## Summary

- Adds C9 Complexity Hotspot Detector (`stringer-b9u`) — a new collector that detects complex functions using regex-based function detection across 6 languages (Go, Python, JS/TS, Java, Rust, Ruby) with a composite scoring formula (`lines/50 + branches`)
- Adds two new report sections: **Function Complexity** (top-20 complex functions table) and **Toxic Hotspots** (complexity × churn cross-reference for highest-value refactoring targets)
- Adds recommendation analysis for complexity and hotspots
- Includes DR-013 decision record documenting the design choices
- Config plumbing for `min_function_lines` and `min_complexity_score` settings

### New files
| File | Description |
|------|-------------|
| `internal/collectors/complexity.go` | Core collector: per-language function detection, control flow counting, composite scoring |
| `internal/collectors/complexity_test.go` | Comprehensive tests for all 6 languages, edge cases, and end-to-end |
| `internal/report/complexity.go` | Report section: top-20 functions by score |
| `internal/report/complexity_test.go` | Report section tests |
| `internal/report/hotspots.go` | Cross-reference section: complexity × churn |
| `internal/report/hotspots_test.go` | Hotspot section tests |
| `docs/decisions/013-complexity-hotspot-design.md` | Decision record |

### Modified files
| File | Change |
|------|--------|
| `internal/signal/signal.go` | Add `MinFunctionLines`, `MinComplexityScore` to `CollectorOpts` |
| `internal/config/config.go` | Add fields to `CollectorConfig` |
| `internal/config/merge.go` | Merge logic for new fields |
| `cmd/stringer/collectors.go` | Register `complexity` in `knownCollectors` |
| `internal/report/recommendations.go` | Add `analyzeComplexity()` and `analyzeHotspots()` |

## Test plan

- [x] Per-language function detection tests (Go, Python, JS, Java, Rust, Ruby)
- [x] Brace/indent/keyword end detection tests
- [x] Control flow counting + comment skipping tests
- [x] Composite score and confidence band tests
- [x] End-to-end collector tests (signal generation, exclude patterns, binary/generated skip)
- [x] Report section tests (complexity + hotspots)
- [x] Context cancellation, empty file, min threshold tests
- [x] Full test suite passes: `go test -race ./...`
- [x] Dogfood: `./stringer scan .` finds complexity signals, `./stringer report .` shows both new sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)