### PR TITLE
feat: add dead code detector collector

### DIFF
--- a/cmd/stringer/collectors.go
+++ b/cmd/stringer/collectors.go
@@ -69,6 +69,11 @@ var knownCollectors = map[string]collectorMeta{
 		SignalKinds:  []string{"complex-function"},
 		ConfigFields: []string{"min_function_lines", "min_complexity_score"},
 	},
+	"deadcode": {
+		Description:  "Detects unused functions and types via regex heuristic and reference search",
+		SignalKinds:  []string{"unused-function", "unused-type"},
+		ConfigFields: []string{},
+	},
 }
 
 // Common config fields that apply to every collector.

--- a/docs/decisions/014-dead-code-detector-design.md
+++ b/docs/decisions/014-dead-code-detector-design.md
@@ -1,0 +1,103 @@
+# 014: Dead Code Detector Design
+
+**Status:** Accepted
+**Date:** 2026-02-21
+**Context:** stringer-7el (C8: Dead Code Detector). Adding dead code detection as a new signal source to identify unused functions and types.
+
+## Problem
+
+Stringer detects complexity hotspots and churn patterns but does not identify code that is never referenced — dead code. Unused functions and types are maintenance debt: they confuse readers, increase build times, and rot over time. Detecting dead code provides actionable cleanup signals.
+
+Key questions:
+1. How should we detect unused symbols without AST parsing?
+2. What confidence levels are appropriate given false-positive risk?
+3. How do we handle exported symbols that may be used by external consumers?
+
+## Options
+
+### Option A: AST-based dead code analysis
+
+Use `go/ast`, tree-sitter, or language-specific tools for precise symbol resolution and usage tracking.
+
+**Pros:**
+- Accurate symbol resolution including imports and qualified references
+- Handles shadowing, overloading, and namespaces correctly
+
+**Cons:**
+- Requires AST parser per language — massive dependency surface
+- Overkill for archaeological signals where ~80% accuracy suffices
+- Doesn't match stringer's zero-external-tooling philosophy
+
+### Option B: Regex heuristic + in-memory reference search
+
+Two-pass algorithm: extract symbol definitions via regex, then search all cached file contents for word-boundary references.
+
+**Pros:**
+- Zero external dependencies
+- Reuses existing `langSpecs`/`extToSpec` from complexity collector for function detection
+- ~80% accuracy is acceptable for identifying cleanup candidates
+- Fast with `strings.Contains` pre-filter before regex matching
+- Easy to extend to new languages
+
+**Cons:**
+- Cannot resolve imports or qualified references precisely
+- May miss references in string interpolation, reflection, or codegen
+- False positives for exported symbols used by external packages
+
+### Option C: External tool integration (deadcode, vulture, etc.)
+
+Shell out to language-specific dead code tools.
+
+**Pros:**
+- Leverages battle-tested, accurate tools
+
+**Cons:**
+- Requires tools to be installed
+- Different output formats per tool
+- Doesn't match stringer's self-contained approach
+
+## Recommendation
+
+**Option B: Regex heuristic + in-memory reference search.**
+
+Consistent with DR-013's philosophy — ~80% accuracy is sufficient for archaeological signals. Lower confidence for exported symbols mitigates false-positive risk.
+
+### Algorithm
+
+1. **Extract** — Walk source files, use regex to build a symbol index (name, file, line, visibility)
+2. **Search** — For each symbol, scan all cached file contents for word-boundary matches. If count==1 in def file and 0 elsewhere, it's dead code. If only referenced in test files, flag with lower confidence.
+
+### Signal kinds
+
+- `unused-function` — function/method defined but never referenced elsewhere
+- `unused-type` — type/class/struct defined but never referenced elsewhere
+
+### Skip list
+
+Never flag: `main`, `init`, `Test*`, `Benchmark*`, `Example*`, dunder methods, framework lifecycle methods (`constructor`, `render`, `componentDidMount`, etc.), names <= 2 chars, symbols in test files, generated/binary files.
+
+### Confidence tiers
+
+| Context | Confidence |
+|---------|-----------|
+| Go unexported, zero refs | 0.7 |
+| Go exported in `internal/` | 0.6 |
+| Rust non-pub | 0.6 |
+| Other unexported | 0.5 |
+| Other exported | 0.4 |
+| Only referenced in test files | 0.3 |
+| Go exported in public pkg | 0.3 |
+
+### Performance guards
+
+- File count cap: 10,000 (skip with warning if exceeded)
+- `strings.Contains` fast pre-filter before regex match
+- Context cancellation checks in both walk and search loops
+
+### Languages
+
+Go, Python, JS/TS, Java, Rust, Ruby — same as complexity collector.
+
+## Decision
+
+Option B accepted. Regex heuristic with in-memory reference search, conservative confidence tiers for exported symbols.

--- a/internal/collectors/deadcode.go
+++ b/internal/collectors/deadcode.go
@@ -1,0 +1,484 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
+package collectors
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/davetashner/stringer/internal/collector"
+	"github.com/davetashner/stringer/internal/signal"
+)
+
+// defaultFileCountCap is the maximum number of source files to analyze.
+// Repositories exceeding this are skipped with a warning.
+const defaultFileCountCap = 10_000
+
+func init() {
+	collector.Register(&DeadCodeCollector{})
+}
+
+// symbolDef represents a symbol extracted from source code.
+type symbolDef struct {
+	Name       string
+	FilePath   string // relative path
+	Line       int
+	Kind       string // "unused-function" or "unused-type"
+	Exported   bool
+	Language   string // file extension (e.g., ".go")
+	InInternal bool   // Go: inside internal/ directory
+}
+
+// DeadCodeMetrics holds structured metrics from the dead code scan.
+type DeadCodeMetrics struct {
+	FilesAnalyzed      int
+	SymbolsFound       int
+	DeadSymbols        int
+	SkippedCapExceeded bool
+}
+
+// DeadCodeCollector detects unused functions and types using regex-based
+// symbol extraction and in-memory reference searching. Follows the
+// regex-over-AST philosophy from DR-013/DR-014.
+type DeadCodeCollector struct {
+	metrics *DeadCodeMetrics
+}
+
+// Name returns the collector name used for registration and filtering.
+func (c *DeadCodeCollector) Name() string { return "deadcode" }
+
+// typePatterns maps file extensions to regex patterns for type/class/struct
+// definitions. Each regex has one capture group for the type name.
+var typePatterns = map[string]*regexp.Regexp{
+	".go":   regexp.MustCompile(`^\s*type\s+(\w+)\s+(?:struct|interface)\s*\{`),
+	".py":   regexp.MustCompile(`^\s*class\s+(\w+)`),
+	".js":   regexp.MustCompile(`^\s*(?:export\s+)?class\s+(\w+)`),
+	".ts":   regexp.MustCompile(`^\s*(?:export\s+)?(?:class|interface|type)\s+(\w+)`),
+	".tsx":  regexp.MustCompile(`^\s*(?:export\s+)?(?:class|interface|type)\s+(\w+)`),
+	".jsx":  regexp.MustCompile(`^\s*(?:export\s+)?class\s+(\w+)`),
+	".java": regexp.MustCompile(`^\s*(?:(?:public|private|protected|abstract|final|static)\s+)*(?:class|interface|enum)\s+(\w+)`),
+	".rs":   regexp.MustCompile(`^\s*(?:pub(?:\([^)]*\))?\s+)?(?:struct|enum|trait)\s+(\w+)`),
+	".rb":   regexp.MustCompile(`^\s*class\s+(\w+)`),
+}
+
+// skipNames are symbol names that should never be flagged as dead code.
+var skipNames = map[string]bool{
+	"main": true, "init": true, "setup": true, "teardown": true,
+	"constructor": true, "render": true, "componentDidMount": true,
+	"componentDidUpdate": true, "componentWillUnmount": true,
+	"setUp": true, "tearDown": true, "run": true,
+	"__init__": true, "__str__": true, "__repr__": true,
+	"__enter__": true, "__exit__": true, "__call__": true,
+	"__len__": true, "__getitem__": true, "__setitem__": true,
+	"__delitem__": true, "__iter__": true, "__next__": true,
+	"__eq__": true, "__hash__": true, "__lt__": true,
+	"__le__": true, "__gt__": true, "__ge__": true,
+	"__add__": true, "__sub__": true, "__mul__": true,
+	"__contains__": true, "__bool__": true, "__new__": true,
+	"initialize": true, // Ruby
+}
+
+// skipPrefixes are symbol name prefixes that indicate test/benchmark functions.
+var skipPrefixes = []string{"Test", "Benchmark", "Example", "test_", "test"}
+
+// wordBoundary builds a regex to match a symbol name at word boundaries.
+func wordBoundary(name string) *regexp.Regexp {
+	return regexp.MustCompile(`\b` + regexp.QuoteMeta(name) + `\b`)
+}
+
+// shouldSkipSymbol returns true if the symbol name should never be flagged.
+func shouldSkipSymbol(name string) bool {
+	if len(name) <= 2 {
+		return true
+	}
+	if skipNames[name] {
+		return true
+	}
+	for _, prefix := range skipPrefixes {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+	// Skip dunder methods.
+	if strings.HasPrefix(name, "__") && strings.HasSuffix(name, "__") {
+		return true
+	}
+	return false
+}
+
+// isExported determines if a symbol is exported/public for the given language.
+func isExported(name, ext string) bool {
+	switch ext {
+	case ".go":
+		if len(name) == 0 {
+			return false
+		}
+		return name[0] >= 'A' && name[0] <= 'Z'
+	case ".rs":
+		// Handled by the pub keyword detection in extractSymbols.
+		// Default to exported; the caller sets this from regex context.
+		return true
+	case ".py", ".rb":
+		// Python/Ruby: underscore prefix = private convention.
+		return !strings.HasPrefix(name, "_")
+	case ".java":
+		// Java: assume public unless lowercase first char (unusual).
+		if len(name) == 0 {
+			return false
+		}
+		return name[0] >= 'A' && name[0] <= 'Z'
+	default:
+		// JS/TS: export keyword handled by extractSymbols. Default to exported.
+		return true
+	}
+}
+
+// fileContents caches file content for the reference search pass.
+type fileContents struct {
+	relPath string
+	content string
+	isTest  bool
+}
+
+// Collect walks source files, extracts symbol definitions, then searches for
+// references to determine which symbols are dead code.
+func (c *DeadCodeCollector) Collect(ctx context.Context, repoPath string, opts signal.CollectorOpts) ([]signal.RawSignal, error) {
+	excludes := mergeExcludes(opts.ExcludePatterns)
+
+	// Pass 1: Walk files, extract symbols, cache content.
+	var symbols []symbolDef
+	var files []fileContents
+	var fileCount int
+
+	err := FS.WalkDir(repoPath, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return nil
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		relPath, relErr := filepath.Rel(repoPath, path)
+		if relErr != nil {
+			return nil
+		}
+
+		if d.IsDir() {
+			if shouldExclude(relPath, excludes) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if shouldExclude(relPath, excludes) {
+			return nil
+		}
+
+		// Skip symlinks outside repo tree.
+		if d.Type()&os.ModeSymlink != 0 {
+			resolved, resolveErr := FS.EvalSymlinks(path)
+			if resolveErr != nil {
+				return nil
+			}
+			if !strings.HasPrefix(resolved, repoPath+string(filepath.Separator)) && resolved != repoPath {
+				return nil
+			}
+		}
+
+		if len(opts.IncludePatterns) > 0 && !matchesAny(relPath, opts.IncludePatterns) {
+			return nil
+		}
+
+		ext := filepath.Ext(path)
+		// Must be a supported language (has either function or type patterns).
+		if extToSpec[ext] == nil && typePatterns[ext] == nil {
+			return nil
+		}
+
+		if isBinaryFile(path) {
+			return nil
+		}
+
+		if isGeneratedFile(path) {
+			return nil
+		}
+
+		fileCount++
+		if fileCount > defaultFileCountCap {
+			return fmt.Errorf("file count exceeds cap (%d)", defaultFileCountCap)
+		}
+
+		// Read file content.
+		content, readErr := readFileContent(path)
+		if readErr != nil {
+			return nil
+		}
+
+		testFile := isTestFile(relPath)
+		files = append(files, fileContents{
+			relPath: relPath,
+			content: content,
+			isTest:  testFile,
+		})
+
+		// Don't extract symbols from test files.
+		if testFile {
+			return nil
+		}
+
+		// Extract symbols.
+		syms := extractSymbols(content, relPath, ext)
+		symbols = append(symbols, syms...)
+
+		if opts.ProgressFunc != nil && fileCount%500 == 0 {
+			opts.ProgressFunc(fmt.Sprintf("deadcode: scanned %d files", fileCount))
+		}
+
+		return nil
+	})
+
+	capExceeded := false
+	if err != nil {
+		if strings.Contains(err.Error(), "file count exceeds cap") {
+			capExceeded = true
+		} else {
+			return nil, fmt.Errorf("walking repo: %w", err)
+		}
+	}
+
+	// Pass 2: Search for references to each symbol.
+	var signals []signal.RawSignal
+	deadCount := 0
+
+	for i := range symbols {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		sym := &symbols[i]
+		if shouldSkipSymbol(sym.Name) {
+			continue
+		}
+
+		dead, testOnly := isDeadSymbol(sym, files)
+		if !dead && !testOnly {
+			continue
+		}
+
+		conf := deadCodeConfidence(sym, testOnly)
+		if conf < opts.MinConfidence {
+			continue
+		}
+
+		title := fmt.Sprintf("Unused %s: %s",
+			strings.TrimPrefix(sym.Kind, "unused-"), sym.Name)
+
+		tags := []string{"dead-code", "cleanup-candidate"}
+		if testOnly {
+			tags = append(tags, "test-only-reference")
+		}
+
+		signals = append(signals, signal.RawSignal{
+			Source:     "deadcode",
+			Kind:       sym.Kind,
+			FilePath:   sym.FilePath,
+			Line:       sym.Line,
+			Title:      title,
+			Confidence: conf,
+			Tags:       tags,
+		})
+		deadCount++
+	}
+
+	c.metrics = &DeadCodeMetrics{
+		FilesAnalyzed:      fileCount,
+		SymbolsFound:       len(symbols),
+		DeadSymbols:        deadCount,
+		SkippedCapExceeded: capExceeded,
+	}
+
+	// Enrich signals with timestamps from git log.
+	gitRoot := opts.GitRoot
+	if gitRoot == "" {
+		gitRoot = repoPath
+	}
+	enrichTimestamps(ctx, gitRoot, signals)
+
+	return signals, nil
+}
+
+// readFileContent reads a file and returns its content as a string.
+func readFileContent(path string) (string, error) {
+	f, err := FS.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close() //nolint:errcheck // read-only file
+
+	var sb strings.Builder
+	scanner := bufio.NewScanner(f)
+	// Increase buffer for large files.
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		sb.WriteString(scanner.Text())
+		sb.WriteByte('\n')
+	}
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+	return sb.String(), nil
+}
+
+// extractSymbols finds function and type definitions in file content.
+func extractSymbols(content, relPath, ext string) []symbolDef {
+	var syms []symbolDef
+	lines := strings.Split(content, "\n")
+	inInternal := strings.Contains(relPath, "internal/") || strings.HasPrefix(relPath, "internal/")
+
+	// Extract functions using existing langSpecs.
+	spec := extToSpec[ext]
+	if spec != nil {
+		for i, line := range lines {
+			name, _ := matchFuncStart(line, spec, i+1)
+			if name == "" {
+				continue
+			}
+			exported := isExported(name, ext)
+			// Rust: check if line has "pub" keyword.
+			if ext == ".rs" {
+				exported = strings.Contains(line, "pub ")
+			}
+			syms = append(syms, symbolDef{
+				Name:       name,
+				FilePath:   relPath,
+				Line:       i + 1,
+				Kind:       "unused-function",
+				Exported:   exported,
+				Language:   ext,
+				InInternal: inInternal,
+			})
+		}
+	}
+
+	// Extract types.
+	typePat := typePatterns[ext]
+	if typePat != nil {
+		for i, line := range lines {
+			matches := typePat.FindStringSubmatch(line)
+			if matches == nil {
+				continue
+			}
+			name := matches[1]
+			if name == "" {
+				continue
+			}
+			exported := isExported(name, ext)
+			if ext == ".rs" {
+				exported = strings.Contains(line, "pub ")
+			}
+			syms = append(syms, symbolDef{
+				Name:       name,
+				FilePath:   relPath,
+				Line:       i + 1,
+				Kind:       "unused-type",
+				Exported:   exported,
+				Language:   ext,
+				InInternal: inInternal,
+			})
+		}
+	}
+
+	return syms
+}
+
+// isDeadSymbol checks if a symbol has no references outside its definition.
+// Returns (dead, testOnly) where testOnly means the only external references
+// are in test files.
+func isDeadSymbol(sym *symbolDef, files []fileContents) (dead bool, testOnly bool) {
+	// Fast pre-filter: check if the name appears in any other file.
+	pat := wordBoundary(sym.Name)
+	foundInNonTest := false
+	foundInTest := false
+
+	for i := range files {
+		fc := &files[i]
+
+		// Fast pre-filter.
+		if !strings.Contains(fc.content, sym.Name) {
+			continue
+		}
+
+		if fc.relPath == sym.FilePath {
+			// Same file: count occurrences. If >1, it's used locally.
+			count := len(pat.FindAllStringIndex(fc.content, -1))
+			if count > 1 {
+				return false, false
+			}
+			continue
+		}
+
+		// Different file: any match means it's referenced.
+		if pat.MatchString(fc.content) {
+			if fc.isTest {
+				foundInTest = true
+			} else {
+				foundInNonTest = true
+			}
+		}
+	}
+
+	if foundInNonTest {
+		return false, false
+	}
+	if foundInTest {
+		return false, true
+	}
+	return true, false
+}
+
+// deadCodeConfidence returns the confidence score for a dead code signal
+// based on the symbol's visibility and language context.
+func deadCodeConfidence(sym *symbolDef, testOnly bool) float64 {
+	if testOnly {
+		return 0.3
+	}
+
+	switch sym.Language {
+	case ".go":
+		if !sym.Exported {
+			return 0.7
+		}
+		if sym.InInternal {
+			return 0.6
+		}
+		return 0.3 // public package export
+	case ".rs":
+		if !sym.Exported {
+			return 0.6
+		}
+		return 0.4
+	case ".py", ".rb":
+		if !sym.Exported {
+			return 0.5
+		}
+		return 0.4
+	default: // JS/TS, Java
+		if !sym.Exported {
+			return 0.5
+		}
+		return 0.4
+	}
+}
+
+// Metrics returns structured metrics from the dead code scan.
+func (c *DeadCodeCollector) Metrics() any { return c.metrics }
+
+// Compile-time interface checks.
+var _ collector.Collector = (*DeadCodeCollector)(nil)
+var _ collector.MetricsProvider = (*DeadCodeCollector)(nil)

--- a/internal/collectors/deadcode_test.go
+++ b/internal/collectors/deadcode_test.go
@@ -1,0 +1,881 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
+package collectors
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/davetashner/stringer/internal/signal"
+)
+
+func TestDeadCodeCollector_Name(t *testing.T) {
+	c := &DeadCodeCollector{}
+	assert.Equal(t, "deadcode", c.Name())
+}
+
+func TestDeadCode_UnusedGoFunc(t *testing.T) {
+	dir := t.TempDir()
+
+	goCode := `package main
+
+func usedFunc() int {
+	return 42
+}
+
+func unusedHelper() string {
+	return "never called"
+}
+
+func main() {
+	usedFunc()
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.go"), []byte(goCode), 0o600))
+
+	c := &DeadCodeCollector{}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{})
+	require.NoError(t, err)
+
+	// unusedHelper should be detected.
+	found := false
+	for _, sig := range signals {
+		if strings.Contains(sig.Title, "unusedHelper") {
+			found = true
+			assert.Equal(t, "deadcode", sig.Source)
+			assert.Equal(t, "unused-function", sig.Kind)
+			assert.Contains(t, sig.Tags, "dead-code")
+			assert.Contains(t, sig.Tags, "cleanup-candidate")
+			// Unexported Go func → 0.7 confidence.
+			assert.InDelta(t, 0.7, sig.Confidence, 0.01)
+			break
+		}
+	}
+	assert.True(t, found, "expected unusedHelper to be detected as dead code")
+
+	// usedFunc should NOT be detected (referenced in main).
+	for _, sig := range signals {
+		assert.NotContains(t, sig.Title, "usedFunc")
+	}
+}
+
+func TestDeadCode_UsedFunc_NotFlagged(t *testing.T) {
+	dir := t.TempDir()
+
+	// Two files: one defines, the other uses.
+	lib := `package mylib
+
+func ProcessData(items []int) int {
+	sum := 0
+	for _, i := range items {
+		sum += i
+	}
+	return sum
+}
+`
+	caller := `package mylib
+
+func DoWork() {
+	ProcessData([]int{1, 2, 3})
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "lib.go"), []byte(lib), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "caller.go"), []byte(caller), 0o600))
+
+	c := &DeadCodeCollector{}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{})
+	require.NoError(t, err)
+
+	for _, sig := range signals {
+		assert.NotContains(t, sig.Title, "ProcessData",
+			"ProcessData is used in caller.go and should not be flagged")
+	}
+}
+
+func TestDeadCode_SameFileReference(t *testing.T) {
+	dir := t.TempDir()
+
+	// helper is called within the same file.
+	goCode := `package main
+
+func helper() int {
+	return 42
+}
+
+func caller() int {
+	return helper()
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.go"), []byte(goCode), 0o600))
+
+	c := &DeadCodeCollector{}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{})
+	require.NoError(t, err)
+
+	for _, sig := range signals {
+		assert.NotContains(t, sig.Title, "helper",
+			"helper is referenced in the same file and should not be flagged")
+	}
+}
+
+func TestDeadCode_TestOnlyReference(t *testing.T) {
+	dir := t.TempDir()
+
+	lib := `package mylib
+
+func InternalHelper() string {
+	return "test only"
+}
+`
+	testFile := `package mylib
+
+import "testing"
+
+func TestInternalHelper(t *testing.T) {
+	InternalHelper()
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "lib.go"), []byte(lib), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "lib_test.go"), []byte(testFile), 0o600))
+
+	c := &DeadCodeCollector{}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{})
+	require.NoError(t, err)
+
+	found := false
+	for _, sig := range signals {
+		if strings.Contains(sig.Title, "InternalHelper") {
+			found = true
+			assert.Contains(t, sig.Tags, "test-only-reference")
+			assert.InDelta(t, 0.3, sig.Confidence, 0.01)
+			break
+		}
+	}
+	assert.True(t, found, "expected InternalHelper to be flagged as test-only reference")
+}
+
+func TestDeadCode_TypeDetection(t *testing.T) {
+	dir := t.TempDir()
+
+	goCode := `package main
+
+type UsedStruct struct {
+	Name string
+}
+
+type unusedConfig struct {
+	Value int
+}
+
+func main() {
+	_ = UsedStruct{Name: "test"}
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "types.go"), []byte(goCode), 0o600))
+
+	c := &DeadCodeCollector{}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{})
+	require.NoError(t, err)
+
+	foundUnused := false
+	for _, sig := range signals {
+		if strings.Contains(sig.Title, "unusedConfig") {
+			foundUnused = true
+			assert.Equal(t, "unused-type", sig.Kind)
+			break
+		}
+	}
+	assert.True(t, foundUnused, "expected unusedConfig to be detected")
+
+	// UsedStruct should NOT be flagged (referenced in main).
+	for _, sig := range signals {
+		assert.NotContains(t, sig.Title, "UsedStruct")
+	}
+}
+
+func TestDeadCode_TypeDetection_Python(t *testing.T) {
+	dir := t.TempDir()
+
+	pyCode := `class UsedClass:
+    pass
+
+class _UnusedHelper:
+    pass
+
+def main():
+    obj = UsedClass()
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "app.py"), []byte(pyCode), 0o600))
+
+	c := &DeadCodeCollector{}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{})
+	require.NoError(t, err)
+
+	foundUnused := false
+	for _, sig := range signals {
+		if strings.Contains(sig.Title, "_UnusedHelper") {
+			foundUnused = true
+			assert.Equal(t, "unused-type", sig.Kind)
+			break
+		}
+	}
+	assert.True(t, foundUnused, "expected _UnusedHelper to be detected")
+}
+
+func TestDeadCode_TypeDetection_Java(t *testing.T) {
+	dir := t.TempDir()
+
+	javaCode := `public class UsedClass {
+    public void doWork() {}
+}
+
+class UnusedInternalClass {
+    void helper() {}
+}
+`
+	caller := `public class Main {
+    public static void main(String[] args) {
+        UsedClass uc = new UsedClass();
+    }
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "UsedClass.java"), []byte(javaCode), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "Main.java"), []byte(caller), 0o600))
+
+	c := &DeadCodeCollector{}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{})
+	require.NoError(t, err)
+
+	foundUnused := false
+	for _, sig := range signals {
+		if strings.Contains(sig.Title, "UnusedInternalClass") {
+			foundUnused = true
+			assert.Equal(t, "unused-type", sig.Kind)
+			break
+		}
+	}
+	assert.True(t, foundUnused, "expected UnusedInternalClass to be detected")
+}
+
+func TestDeadCode_TypeDetection_Rust(t *testing.T) {
+	dir := t.TempDir()
+
+	rsCode := `pub struct UsedStruct {
+    pub name: String,
+}
+
+struct UnusedConfig {
+    value: i32,
+}
+
+fn main() {
+    let _s = UsedStruct { name: "test".to_string() };
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.rs"), []byte(rsCode), 0o600))
+
+	c := &DeadCodeCollector{}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{})
+	require.NoError(t, err)
+
+	foundUnused := false
+	for _, sig := range signals {
+		if strings.Contains(sig.Title, "UnusedConfig") {
+			foundUnused = true
+			assert.Equal(t, "unused-type", sig.Kind)
+			// Non-pub Rust → 0.6 confidence.
+			assert.InDelta(t, 0.6, sig.Confidence, 0.01)
+			break
+		}
+	}
+	assert.True(t, foundUnused, "expected UnusedConfig to be detected")
+}
+
+func TestDeadCode_SkipList(t *testing.T) {
+	dir := t.TempDir()
+
+	goCode := `package main
+
+func main() {}
+func init() {}
+func TestSomething() {}
+func BenchmarkFoo() {}
+func ExampleBar() {}
+
+func ab() int { return 1 }
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.go"), []byte(goCode), 0o600))
+
+	c := &DeadCodeCollector{}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{})
+	require.NoError(t, err)
+
+	// None of these should be flagged.
+	for _, sig := range signals {
+		assert.NotContains(t, sig.Title, "main")
+		assert.NotContains(t, sig.Title, "init")
+		assert.NotContains(t, sig.Title, "TestSomething")
+		assert.NotContains(t, sig.Title, "BenchmarkFoo")
+		assert.NotContains(t, sig.Title, "ExampleBar")
+		assert.NotContains(t, sig.Title, "ab") // len <= 2
+	}
+}
+
+func TestDeadCode_SkipDunderMethods(t *testing.T) {
+	dir := t.TempDir()
+
+	pyCode := `class MyClass:
+    def __init__(self):
+        pass
+
+    def __str__(self):
+        return "MyClass"
+
+    def unused_method(self):
+        pass
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "app.py"), []byte(pyCode), 0o600))
+
+	c := &DeadCodeCollector{}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{})
+	require.NoError(t, err)
+
+	for _, sig := range signals {
+		assert.NotContains(t, sig.Title, "__init__")
+		assert.NotContains(t, sig.Title, "__str__")
+	}
+}
+
+func TestDeadCode_MultiLanguage(t *testing.T) {
+	dir := t.TempDir()
+
+	goCode := `package main
+
+func unusedGoFunc() {}
+`
+	pyCode := `def unused_python_func():
+    pass
+`
+	jsCode := `function unusedJsFunc() {
+    return 42;
+}
+`
+	rsCode := `fn unused_rust_func() -> i32 {
+    42
+}
+`
+	rbCode := `def unused_ruby_func
+  42
+end
+`
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.go"), []byte(goCode), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "app.py"), []byte(pyCode), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "app.js"), []byte(jsCode), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "lib.rs"), []byte(rsCode), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "app.rb"), []byte(rbCode), 0o600))
+
+	c := &DeadCodeCollector{}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{})
+	require.NoError(t, err)
+
+	names := make(map[string]bool)
+	for _, sig := range signals {
+		// Extract function name from title "Unused function: <name>".
+		parts := strings.SplitN(sig.Title, ": ", 2)
+		if len(parts) == 2 {
+			names[parts[1]] = true
+		}
+	}
+
+	assert.True(t, names["unusedGoFunc"], "expected Go unused func")
+	assert.True(t, names["unused_python_func"], "expected Python unused func")
+	assert.True(t, names["unusedJsFunc"], "expected JS unused func")
+	assert.True(t, names["unused_rust_func"], "expected Rust unused func")
+	assert.True(t, names["unused_ruby_func"], "expected Ruby unused func")
+}
+
+func TestDeadCode_ContextCancellation(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.go"),
+		[]byte("package main\nfunc main() {}\n"), 0o600))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately.
+
+	c := &DeadCodeCollector{}
+	_, err := c.Collect(ctx, dir, signal.CollectorOpts{})
+	assert.Error(t, err)
+}
+
+func TestDeadCode_ExcludePatterns(t *testing.T) {
+	dir := t.TempDir()
+
+	vendorDir := filepath.Join(dir, "vendor")
+	require.NoError(t, os.MkdirAll(vendorDir, 0o750))
+
+	goCode := `package vendor
+func unusedVendorFunc() {}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(vendorDir, "lib.go"), []byte(goCode), 0o600))
+
+	c := &DeadCodeCollector{}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{})
+	require.NoError(t, err)
+	assert.Empty(t, signals, "vendor files should be excluded")
+}
+
+func TestDeadCode_Metrics(t *testing.T) {
+	dir := t.TempDir()
+
+	goCode := `package main
+
+func usedFunc() int { return 42 }
+func unusedFunc() int { return 0 }
+
+func main() { usedFunc() }
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.go"), []byte(goCode), 0o600))
+
+	c := &DeadCodeCollector{}
+	_, err := c.Collect(context.Background(), dir, signal.CollectorOpts{})
+	require.NoError(t, err)
+
+	assert.NotNil(t, c.Metrics())
+	m := c.Metrics().(*DeadCodeMetrics)
+	assert.Equal(t, 1, m.FilesAnalyzed)
+	assert.GreaterOrEqual(t, m.SymbolsFound, 2) // at least usedFunc + unusedFunc (main skipped)
+	assert.GreaterOrEqual(t, m.DeadSymbols, 1)
+	assert.False(t, m.SkippedCapExceeded)
+}
+
+func TestDeadCode_ExportedGoInInternal(t *testing.T) {
+	dir := t.TempDir()
+
+	internalDir := filepath.Join(dir, "internal", "pkg")
+	require.NoError(t, os.MkdirAll(internalDir, 0o750))
+
+	goCode := `package pkg
+
+func UnusedExported() {}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(internalDir, "lib.go"), []byte(goCode), 0o600))
+
+	c := &DeadCodeCollector{}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{})
+	require.NoError(t, err)
+
+	found := false
+	for _, sig := range signals {
+		if strings.Contains(sig.Title, "UnusedExported") {
+			found = true
+			// Exported in internal/ → 0.6 confidence.
+			assert.InDelta(t, 0.6, sig.Confidence, 0.01)
+			break
+		}
+	}
+	assert.True(t, found, "expected UnusedExported to be detected in internal/")
+}
+
+func TestDeadCode_ExportedGoPublicPackage(t *testing.T) {
+	dir := t.TempDir()
+
+	pkgDir := filepath.Join(dir, "pkg")
+	require.NoError(t, os.MkdirAll(pkgDir, 0o750))
+
+	goCode := `package pkg
+
+func UnusedPublicExport() {}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(pkgDir, "lib.go"), []byte(goCode), 0o600))
+
+	c := &DeadCodeCollector{}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{})
+	require.NoError(t, err)
+
+	found := false
+	for _, sig := range signals {
+		if strings.Contains(sig.Title, "UnusedPublicExport") {
+			found = true
+			// Exported in public package → 0.3 confidence.
+			assert.InDelta(t, 0.3, sig.Confidence, 0.01)
+			break
+		}
+	}
+	assert.True(t, found, "expected UnusedPublicExport to be detected")
+}
+
+func TestDeadCode_GeneratedFileSkipped(t *testing.T) {
+	dir := t.TempDir()
+
+	goCode := "// Code generated by stringer; DO NOT EDIT.\npackage main\nfunc unusedGen() {}\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "gen.go"), []byte(goCode), 0o600))
+
+	c := &DeadCodeCollector{}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{})
+	require.NoError(t, err)
+	assert.Empty(t, signals, "generated files should be skipped")
+}
+
+func TestDeadCode_BinaryFileSkipped(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "binary.go"),
+		[]byte("package main\x00\x00\x00\nfunc unused() {}\n"), 0o600))
+
+	c := &DeadCodeCollector{}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{})
+	require.NoError(t, err)
+	assert.Empty(t, signals)
+}
+
+func TestDeadCode_EmptyDir(t *testing.T) {
+	dir := t.TempDir()
+
+	c := &DeadCodeCollector{}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{})
+	require.NoError(t, err)
+	assert.Empty(t, signals)
+}
+
+func TestDeadCode_MinConfidenceFilter(t *testing.T) {
+	dir := t.TempDir()
+
+	// Public package exported func has confidence 0.3.
+	goCode := `package pkg
+
+func UnusedPublic() {}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "lib.go"), []byte(goCode), 0o600))
+
+	c := &DeadCodeCollector{}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{
+		MinConfidence: 0.5, // Should filter out 0.3 confidence signals.
+	})
+	require.NoError(t, err)
+
+	for _, sig := range signals {
+		assert.NotContains(t, sig.Title, "UnusedPublic",
+			"low confidence signals should be filtered by MinConfidence")
+	}
+}
+
+func TestDeadCode_TestFilesNotScanned(t *testing.T) {
+	dir := t.TempDir()
+
+	// Symbols defined in test files should not be extracted.
+	testCode := `package main
+
+func helperForTests() int {
+	return 42
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main_test.go"), []byte(testCode), 0o600))
+
+	c := &DeadCodeCollector{}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{})
+	require.NoError(t, err)
+
+	for _, sig := range signals {
+		assert.NotContains(t, sig.Title, "helperForTests",
+			"symbols from test files should not be extracted")
+	}
+}
+
+func TestDeadCode_TypeScript(t *testing.T) {
+	dir := t.TempDir()
+
+	tsCode := `export class UsedClass {
+    constructor() {}
+}
+
+interface UnusedInterface {
+    name: string;
+}
+
+type UnusedType = {
+    value: number;
+};
+
+const x = new UsedClass();
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "app.ts"), []byte(tsCode), 0o600))
+
+	c := &DeadCodeCollector{}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{})
+	require.NoError(t, err)
+
+	foundInterface := false
+	foundType := false
+	for _, sig := range signals {
+		if strings.Contains(sig.Title, "UnusedInterface") {
+			foundInterface = true
+		}
+		if strings.Contains(sig.Title, "UnusedType") {
+			foundType = true
+		}
+		assert.NotContains(t, sig.Title, "UsedClass")
+	}
+	assert.True(t, foundInterface, "expected UnusedInterface to be detected")
+	assert.True(t, foundType, "expected UnusedType to be detected")
+}
+
+func TestShouldSkipSymbol(t *testing.T) {
+	tests := []struct {
+		name string
+		skip bool
+	}{
+		{"main", true},
+		{"init", true},
+		{"TestFoo", true},
+		{"BenchmarkBar", true},
+		{"ExampleBaz", true},
+		{"ab", true},       // len <= 2
+		{"x", true},        // len <= 2
+		{"__init__", true}, // dunder
+		{"__str__", true},  // dunder
+		{"constructor", true},
+		{"render", true},
+		{"processData", false},
+		{"HandleRequest", false},
+		{"calculate", false},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.skip, shouldSkipSymbol(tt.name), "name=%s", tt.name)
+	}
+}
+
+func TestDeadCode_IsTestFile(t *testing.T) {
+	tests := []struct {
+		path   string
+		isTest bool
+	}{
+		{"foo_test.go", true},
+		{"foo.test.js", true},
+		{"foo.spec.ts", true},
+		{"foo.test.tsx", true},
+		{"test_foo.py", true},
+		{"__tests__/foo.test.js", true},
+		{"tests/test_foo.py", true}, // test_ prefix on .py
+		{"foo.go", false},
+		{"foo.js", false},
+		{"app.py", false},
+		{"testing.go", false},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.isTest, isTestFile(tt.path), "path=%s", tt.path)
+	}
+}
+
+func TestIsExported(t *testing.T) {
+	tests := []struct {
+		name     string
+		ext      string
+		exported bool
+	}{
+		{"ProcessData", ".go", true},
+		{"processData", ".go", false},
+		{"_private", ".py", false},
+		{"public_func", ".py", true},
+		{"MyClass", ".java", true},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.exported, isExported(tt.name, tt.ext),
+			"name=%s ext=%s", tt.name, tt.ext)
+	}
+}
+
+func TestDeadCode_IncludePatterns(t *testing.T) {
+	dir := t.TempDir()
+
+	subDir := filepath.Join(dir, "src")
+	require.NoError(t, os.MkdirAll(subDir, 0o750))
+
+	// File in src/ should be analyzed.
+	require.NoError(t, os.WriteFile(filepath.Join(subDir, "lib.go"),
+		[]byte("package lib\nfunc unusedInSrc() {}\n"), 0o600))
+	// File outside src/ should be excluded.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "other.go"),
+		[]byte("package other\nfunc unusedOutside() {}\n"), 0o600))
+
+	c := &DeadCodeCollector{}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{
+		IncludePatterns: []string{"src/**"},
+	})
+	require.NoError(t, err)
+
+	foundInSrc := false
+	for _, sig := range signals {
+		if strings.Contains(sig.Title, "unusedInSrc") {
+			foundInSrc = true
+		}
+		assert.NotContains(t, sig.Title, "unusedOutside")
+	}
+	assert.True(t, foundInSrc, "expected signal from src/")
+}
+
+func TestDeadCode_RustVisibility(t *testing.T) {
+	dir := t.TempDir()
+
+	rsCode := `pub fn public_unused() -> i32 {
+    42
+}
+
+fn private_unused() -> i32 {
+    0
+}
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "lib.rs"), []byte(rsCode), 0o600))
+
+	c := &DeadCodeCollector{}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{})
+	require.NoError(t, err)
+
+	for _, sig := range signals {
+		if strings.Contains(sig.Title, "public_unused") {
+			assert.InDelta(t, 0.4, sig.Confidence, 0.01, "pub Rust func should have 0.4 confidence")
+		}
+		if strings.Contains(sig.Title, "private_unused") {
+			assert.InDelta(t, 0.6, sig.Confidence, 0.01, "non-pub Rust func should have 0.6 confidence")
+		}
+	}
+}
+
+func TestDeadCode_ContextCancellationInSearchPhase(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create enough files to get past the walk phase before cancellation
+	// affects the search phase.
+	for i := 0; i < 5; i++ {
+		code := "package main\nfunc unused" + string(rune('A'+i)) + "Func() {}\n"
+		require.NoError(t, os.WriteFile(
+			filepath.Join(dir, "file"+string(rune('0'+i))+".go"),
+			[]byte(code), 0o600))
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	c := &DeadCodeCollector{}
+	// Cancel after walk completes (we can't easily time this, so we just
+	// verify the collector handles cancellation gracefully).
+	cancel()
+	_, err := c.Collect(ctx, dir, signal.CollectorOpts{})
+	// Should error due to cancellation.
+	assert.Error(t, err)
+}
+
+func TestExtractSymbols_GoTypes(t *testing.T) {
+	content := `package main
+
+type MyStruct struct {
+	Name string
+}
+
+type MyInterface interface {
+	Method()
+}
+
+type myPrivate struct {
+	x int
+}
+`
+	syms := extractSymbols(content, "types.go", ".go")
+
+	names := make(map[string]bool)
+	for _, s := range syms {
+		names[s.Name] = true
+	}
+	assert.True(t, names["MyStruct"], "expected MyStruct")
+	assert.True(t, names["MyInterface"], "expected MyInterface")
+	assert.True(t, names["myPrivate"], "expected myPrivate")
+}
+
+func TestExtractSymbols_GoFunctions(t *testing.T) {
+	content := `package main
+
+func publicFunc() {}
+
+func (s *Server) method() {}
+
+func privateFunc() {}
+`
+	syms := extractSymbols(content, "funcs.go", ".go")
+
+	names := make(map[string]bool)
+	for _, s := range syms {
+		names[s.Name] = true
+	}
+	assert.True(t, names["publicFunc"])
+	assert.True(t, names["method"])
+	assert.True(t, names["privateFunc"])
+}
+
+func TestExtractSymbols_RustTypes(t *testing.T) {
+	content := `pub struct PublicStruct {
+    name: String,
+}
+
+struct PrivateStruct {
+    value: i32,
+}
+
+pub enum PublicEnum {
+    A,
+    B,
+}
+
+trait MyTrait {
+    fn method(&self);
+}
+`
+	syms := extractSymbols(content, "lib.rs", ".rs")
+
+	symMap := make(map[string]symbolDef)
+	for _, s := range syms {
+		symMap[s.Name] = s
+	}
+	assert.True(t, symMap["PublicStruct"].Exported)
+	assert.False(t, symMap["PrivateStruct"].Exported)
+	assert.True(t, symMap["PublicEnum"].Exported)
+	assert.False(t, symMap["MyTrait"].Exported) // no pub keyword
+}
+
+func TestDeadCode_RubyClass(t *testing.T) {
+	dir := t.TempDir()
+
+	rbCode := `class UsedClass
+  def work
+    42
+  end
+end
+
+class UnusedClass
+  def helper
+    0
+  end
+end
+
+obj = UsedClass.new
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "app.rb"), []byte(rbCode), 0o600))
+
+	c := &DeadCodeCollector{}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{})
+	require.NoError(t, err)
+
+	foundUnused := false
+	for _, sig := range signals {
+		if strings.Contains(sig.Title, "UnusedClass") {
+			foundUnused = true
+			assert.Equal(t, "unused-type", sig.Kind)
+		}
+		assert.NotContains(t, sig.Title, "UsedClass")
+	}
+	assert.True(t, foundUnused, "expected UnusedClass to be detected")
+}


### PR DESCRIPTION
## Summary
- Add C8 dead code detector collector (`stringer-7el`) — two-pass regex heuristic that extracts function/type definitions, then searches all cached file contents for word-boundary references
- Supports Go, Python, JS/TS, Java, Rust, and Ruby with conservative confidence tiers based on visibility and language context
- Includes decision record (`docs/decisions/014-dead-code-detector-design.md`)
- Registers collector in `collectors.go` metadata map

## Test plan
- [x] Unit tests covering all supported languages (881 lines in `deadcode_test.go`)
- [ ] CI passes (lint, race tests, coverage gate)
- [ ] Manual: `go build -o stringer ./cmd/stringer && ./stringer collectors list` shows dead-code entry

Closes stringer-7el

🤖 Generated with [Claude Code](https://claude.com/claude-code)