### PR TITLE
feat: add git hygiene detector collector (C13)

### DIFF
--- a/cmd/stringer/collectors.go
+++ b/cmd/stringer/collectors.go
@@ -74,6 +74,11 @@ var knownCollectors = map[string]collectorMeta{
 		SignalKinds:  []string{"unused-function", "unused-type"},
 		ConfigFields: []string{},
 	},
+	"githygiene": {
+		Description:  "Detects large binaries, merge conflict markers, committed secrets, and mixed line endings",
+		SignalKinds:  []string{"large-binary", "merge-conflict-marker", "committed-secret", "mixed-line-endings"},
+		ConfigFields: []string{},
+	},
 }
 
 // Common config fields that apply to every collector.

--- a/docs/decisions/015-git-hygiene-detector-design.md
+++ b/docs/decisions/015-git-hygiene-detector-design.md
@@ -1,0 +1,76 @@
+# 015: Git Hygiene Detector Design
+
+**Status:** Accepted
+**Date:** 2026-02-21
+**Context:** stringer-38h (C13: Git Hygiene Detector). Adding repository-level hygiene checks as a new signal source.
+
+## Problem
+
+Stringer detects code-level issues (TODOs, dead code, complexity) but misses repository-level hygiene problems that are trivially detectable and always actionable. Common git mistakes — large committed binaries, forgotten merge conflict markers, accidentally committed secrets, and mixed line endings — are high-signal, low-false-positive findings.
+
+Key questions:
+1. Which hygiene checks have the best signal-to-noise ratio?
+2. How do we avoid flagging LFS-tracked binaries?
+3. What confidence levels are appropriate for each check type?
+
+## Options
+
+### Option A: Shell out to external tools
+
+Use `gitleaks` for secrets, custom scripts for binaries and conflicts.
+
+**Pros:**
+- Battle-tested secret detection
+
+**Cons:**
+- Requires external tool installation
+- Different output formats to normalize
+- Doesn't match stringer's self-contained approach
+
+### Option B: Regex-based single-pass file scanner
+
+Walk all files once, applying four checks per file: binary size, conflict markers, secret patterns, and line ending consistency.
+
+**Pros:**
+- Zero external dependencies
+- Single walk pass for efficiency
+- Reuses existing helpers (`isBinaryFile`, `shouldExclude`, `mergeExcludes`)
+- Conservative secret patterns minimize false positives
+
+**Cons:**
+- Secret detection is not as comprehensive as gitleaks
+- Line ending detection requires reading entire files
+
+## Recommendation
+
+**Option B: Regex-based single-pass file scanner.**
+
+This is not a replacement for gitleaks — it's a lightweight early warning system that catches the most common patterns. Stringer already runs gitleaks as a pre-commit hook, so this collector catches secrets that slipped through or were committed before the hook was set up.
+
+### Signal types
+
+| Kind | Detection | Confidence |
+|------|-----------|------------|
+| `large-binary` | Binary file > 1 MB not tracked by LFS | 0.8 |
+| `merge-conflict-marker` | `<<<<<<<`, `=======`, `>>>>>>>` in text files | 0.9 |
+| `committed-secret` | AWS keys, GitHub tokens, generic key=value patterns | 0.6–0.7 |
+| `mixed-line-endings` | File has both CRLF and LF (≥2 of each) | 0.7 |
+
+### LFS handling
+
+Parse `.gitattributes` for `filter=lfs` entries and skip matching files in the large-binary check. This avoids false positives for intentionally tracked large files.
+
+### Secret patterns
+
+Conservative set — not a full gitleaks replacement:
+- AWS access key: `AKIA[0-9A-Z]{16}` (confidence 0.7)
+- GitHub token: `gh[ps]_[A-Za-z0-9_]{36,}` (confidence 0.7)
+- Generic: `(?i)(api[_-]?key|secret[_-]?key|password)\s*[:=]\s*["'][^"']{8,}` (confidence 0.6)
+
+### Efficiency
+
+Single `WalkDir` pass handles all four checks. Binary files are checked for size only (text checks skipped). Text files are read once with all pattern checks applied during the same scan.
+
+## Decision
+
+Option B accepted. Single-pass regex scanner with four high-confidence signal types.

--- a/internal/collectors/githygiene.go
+++ b/internal/collectors/githygiene.go
@@ -1,0 +1,353 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
+package collectors
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/davetashner/stringer/internal/collector"
+	"github.com/davetashner/stringer/internal/signal"
+)
+
+// defaultLargeBinaryThreshold is the minimum file size in bytes to flag a
+// binary file as large. Default 1 MB.
+const defaultLargeBinaryThreshold = 1_000_000
+
+func init() {
+	collector.Register(&GitHygieneCollector{})
+}
+
+// GitHygieneMetrics holds structured metrics from the git hygiene scan.
+type GitHygieneMetrics struct {
+	FilesScanned         int
+	LargeBinaries        int
+	MergeConflictMarkers int
+	CommittedSecrets     int
+	MixedLineEndings     int
+}
+
+// GitHygieneCollector detects repository-level hygiene problems:
+// large committed binaries, merge conflict markers, committed secrets,
+// and mixed line endings.
+type GitHygieneCollector struct {
+	metrics *GitHygieneMetrics
+}
+
+// Name returns the collector name used for registration and filtering.
+func (c *GitHygieneCollector) Name() string { return "githygiene" }
+
+// mergeConflictPattern matches git merge conflict markers.
+var mergeConflictPattern = regexp.MustCompile(`^(<{7}|={7}|>{7})\s`)
+
+// secretPatterns maps pattern names to their regex and confidence scores.
+var secretPatterns = []struct {
+	name       string
+	pattern    *regexp.Regexp
+	confidence float64
+}{
+	{
+		name:       "AWS access key",
+		pattern:    regexp.MustCompile(`AKIA[0-9A-Z]{16}`),
+		confidence: 0.7,
+	},
+	{
+		name:       "GitHub token",
+		pattern:    regexp.MustCompile(`gh[ps]_[A-Za-z0-9_]{36,}`),
+		confidence: 0.7,
+	},
+	{
+		name:       "generic secret",
+		pattern:    regexp.MustCompile(`(?i)(api[_-]?key|secret[_-]?key|password)\s*[:=]\s*["'][^"']{8,}`),
+		confidence: 0.6,
+	},
+}
+
+// Collect walks the repository, performing four hygiene checks per file
+// in a single pass: large binaries, merge conflict markers, committed
+// secrets, and mixed line endings.
+func (c *GitHygieneCollector) Collect(ctx context.Context, repoPath string, opts signal.CollectorOpts) ([]signal.RawSignal, error) {
+	excludes := mergeExcludes(opts.ExcludePatterns)
+
+	// Parse .gitattributes for LFS-tracked patterns.
+	lfsPatterns := parseLFSPatterns(repoPath)
+
+	var signals []signal.RawSignal
+	metrics := &GitHygieneMetrics{}
+
+	err := FS.WalkDir(repoPath, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return nil
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		relPath, relErr := filepath.Rel(repoPath, path)
+		if relErr != nil {
+			return nil
+		}
+
+		if d.IsDir() {
+			if shouldExclude(relPath, excludes) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		if shouldExclude(relPath, excludes) {
+			return nil
+		}
+
+		// Skip symlinks outside repo tree.
+		if d.Type()&os.ModeSymlink != 0 {
+			resolved, resolveErr := FS.EvalSymlinks(path)
+			if resolveErr != nil {
+				return nil
+			}
+			if !strings.HasPrefix(resolved, repoPath+string(filepath.Separator)) && resolved != repoPath {
+				return nil
+			}
+		}
+
+		if len(opts.IncludePatterns) > 0 && !matchesAny(relPath, opts.IncludePatterns) {
+			return nil
+		}
+
+		metrics.FilesScanned++
+
+		binary := isBinaryFile(path)
+
+		// Check 1: Large binary detection.
+		if binary {
+			if !isLFSTracked(relPath, lfsPatterns) {
+				info, statErr := FS.Stat(path)
+				if statErr == nil && info.Size() >= defaultLargeBinaryThreshold {
+					conf := 0.8
+					if conf >= opts.MinConfidence {
+						signals = append(signals, signal.RawSignal{
+							Source:     "githygiene",
+							Kind:       "large-binary",
+							FilePath:   relPath,
+							Title:      fmt.Sprintf("Large binary file: %s (%s)", relPath, humanSize(info.Size())),
+							Confidence: conf,
+							Tags:       []string{"git-hygiene", "large-binary"},
+						})
+						metrics.LargeBinaries++
+					}
+				}
+			}
+			// Skip text checks for binary files.
+			return nil
+		}
+
+		if isGeneratedFile(path) {
+			return nil
+		}
+
+		// Read file content for text-based checks.
+		fileSignals := scanTextFileHygiene(path, relPath, opts.MinConfidence)
+		for i := range fileSignals {
+			switch fileSignals[i].Kind {
+			case "merge-conflict-marker":
+				metrics.MergeConflictMarkers++
+			case "committed-secret":
+				metrics.CommittedSecrets++
+			case "mixed-line-endings":
+				metrics.MixedLineEndings++
+			}
+		}
+		signals = append(signals, fileSignals...)
+
+		if opts.ProgressFunc != nil && metrics.FilesScanned%500 == 0 {
+			opts.ProgressFunc(fmt.Sprintf("githygiene: scanned %d files", metrics.FilesScanned))
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("walking repo: %w", err)
+	}
+
+	c.metrics = metrics
+
+	// Enrich signals with timestamps from git log.
+	gitRoot := opts.GitRoot
+	if gitRoot == "" {
+		gitRoot = repoPath
+	}
+	enrichTimestamps(ctx, gitRoot, signals)
+
+	return signals, nil
+}
+
+// scanTextFileHygiene reads a text file and checks for merge conflict
+// markers, committed secrets, and mixed line endings in a single pass.
+func scanTextFileHygiene(path, relPath string, minConfidence float64) []signal.RawSignal {
+	f, err := FS.Open(path)
+	if err != nil {
+		return nil
+	}
+	defer f.Close() //nolint:errcheck // read-only file
+
+	// Read raw bytes to detect line endings before scanner normalizes them.
+	var rawBytes []byte
+	buf := make([]byte, 32*1024)
+	for {
+		n, readErr := f.Read(buf)
+		if n > 0 {
+			rawBytes = append(rawBytes, buf[:n]...)
+		}
+		if readErr != nil {
+			break
+		}
+		// Cap at 1 MB to avoid excessive memory usage.
+		if len(rawBytes) > 1024*1024 {
+			break
+		}
+	}
+
+	// Count line endings from raw bytes.
+	crlfCount := strings.Count(string(rawBytes), "\r\n")
+	// Total \n minus CRLF gives bare LF count.
+	totalLF := strings.Count(string(rawBytes), "\n")
+	lfCount := totalLF - crlfCount
+
+	var signals []signal.RawSignal
+
+	// Split into lines for pattern matching.
+	lines := strings.Split(string(rawBytes), "\n")
+	conflictReported := false
+
+	for lineNo, rawLine := range lines {
+		// Trim trailing \r from CRLF lines for consistent matching.
+		line := strings.TrimRight(rawLine, "\r")
+
+		// Check for merge conflict markers (report only first occurrence).
+		if !conflictReported && mergeConflictPattern.MatchString(line) {
+			conf := 0.9
+			if conf >= minConfidence {
+				signals = append(signals, signal.RawSignal{
+					Source:     "githygiene",
+					Kind:       "merge-conflict-marker",
+					FilePath:   relPath,
+					Line:       lineNo + 1,
+					Title:      fmt.Sprintf("Merge conflict marker in %s:%d", relPath, lineNo+1),
+					Confidence: conf,
+					Tags:       []string{"git-hygiene", "merge-conflict"},
+				})
+				conflictReported = true
+			}
+		}
+
+		// Check for committed secrets.
+		for _, sp := range secretPatterns {
+			if sp.confidence < minConfidence {
+				continue
+			}
+			if sp.pattern.MatchString(line) {
+				signals = append(signals, signal.RawSignal{
+					Source:     "githygiene",
+					Kind:       "committed-secret",
+					FilePath:   relPath,
+					Line:       lineNo + 1,
+					Title:      fmt.Sprintf("Possible %s in %s:%d", sp.name, relPath, lineNo+1),
+					Confidence: sp.confidence,
+					Tags:       []string{"git-hygiene", "security", "secret"},
+				})
+				break // one secret signal per line
+			}
+		}
+	}
+
+	// Check for mixed line endings (need both types present, with at least
+	// 2 lines of each to avoid false positives from single-line anomalies).
+	if crlfCount >= 2 && lfCount >= 2 {
+		conf := 0.7
+		if conf >= minConfidence {
+			signals = append(signals, signal.RawSignal{
+				Source:     "githygiene",
+				Kind:       "mixed-line-endings",
+				FilePath:   relPath,
+				Title:      fmt.Sprintf("Mixed line endings in %s (%d CRLF, %d LF)", relPath, crlfCount, lfCount),
+				Confidence: conf,
+				Tags:       []string{"git-hygiene", "line-endings"},
+			})
+		}
+	}
+
+	return signals
+}
+
+// parseLFSPatterns reads .gitattributes and returns glob patterns for
+// files tracked by Git LFS.
+func parseLFSPatterns(repoPath string) []string {
+	path := filepath.Join(repoPath, ".gitattributes")
+	f, err := FS.Open(path)
+	if err != nil {
+		return nil
+	}
+	defer f.Close() //nolint:errcheck // read-only file
+
+	var patterns []string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if strings.Contains(line, "filter=lfs") {
+			// Pattern is the first field before any whitespace.
+			fields := strings.Fields(line)
+			if len(fields) > 0 {
+				patterns = append(patterns, fields[0])
+			}
+		}
+	}
+	return patterns
+}
+
+// isLFSTracked returns true if the given relative path matches any of the
+// LFS glob patterns from .gitattributes.
+func isLFSTracked(relPath string, lfsPatterns []string) bool {
+	for _, pattern := range lfsPatterns {
+		matched, err := filepath.Match(pattern, filepath.Base(relPath))
+		if err == nil && matched {
+			return true
+		}
+		// Also try full path match.
+		matched, err = filepath.Match(pattern, relPath)
+		if err == nil && matched {
+			return true
+		}
+	}
+	return false
+}
+
+// humanSize formats a byte count as a human-readable string.
+func humanSize(bytes int64) string {
+	switch {
+	case bytes >= 1_000_000_000:
+		return fmt.Sprintf("%.1f GB", float64(bytes)/1_000_000_000)
+	case bytes >= 1_000_000:
+		return fmt.Sprintf("%.1f MB", float64(bytes)/1_000_000)
+	case bytes >= 1_000:
+		return fmt.Sprintf("%.1f KB", float64(bytes)/1_000)
+	default:
+		return fmt.Sprintf("%d B", bytes)
+	}
+}
+
+// Metrics returns structured metrics from the git hygiene scan.
+func (c *GitHygieneCollector) Metrics() any { return c.metrics }
+
+// Compile-time interface checks.
+var _ collector.Collector = (*GitHygieneCollector)(nil)
+var _ collector.MetricsProvider = (*GitHygieneCollector)(nil)

--- a/internal/collectors/githygiene_test.go
+++ b/internal/collectors/githygiene_test.go
@@ -1,0 +1,296 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
+package collectors
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/davetashner/stringer/internal/signal"
+)
+
+func TestGitHygieneCollector_Name(t *testing.T) {
+	c := &GitHygieneCollector{}
+	assert.Equal(t, "githygiene", c.Name())
+}
+
+func TestGitHygieneCollector_LargeBinary(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a binary file over the threshold (1 MB).
+	data := make([]byte, defaultLargeBinaryThreshold+100)
+	data[0] = 0 // null byte makes it binary
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "big.bin"), data, 0o600))
+
+	// Create a small binary file (under threshold).
+	smallData := []byte{0, 1, 2, 3}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "small.bin"), smallData, 0o600))
+
+	c := &GitHygieneCollector{}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{})
+	require.NoError(t, err)
+
+	largeBinaries := filterByKind(signals, "large-binary")
+	assert.Len(t, largeBinaries, 1)
+	assert.Contains(t, largeBinaries[0].Title, "big.bin")
+	assert.Contains(t, largeBinaries[0].Title, "MB")
+	assert.Equal(t, 0.8, largeBinaries[0].Confidence)
+	assert.Equal(t, "githygiene", largeBinaries[0].Source)
+}
+
+func TestGitHygieneCollector_LargeBinary_LFSTracked(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create .gitattributes with LFS pattern.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".gitattributes"),
+		[]byte("*.bin filter=lfs diff=lfs merge=lfs -text\n"), 0o600))
+
+	// Create a large binary that matches the LFS pattern.
+	data := make([]byte, defaultLargeBinaryThreshold+100)
+	data[0] = 0
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "tracked.bin"), data, 0o600))
+
+	c := &GitHygieneCollector{}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{})
+	require.NoError(t, err)
+
+	largeBinaries := filterByKind(signals, "large-binary")
+	assert.Empty(t, largeBinaries, "LFS-tracked binaries should not be flagged")
+}
+
+func TestGitHygieneCollector_MergeConflictMarkers(t *testing.T) {
+	dir := t.TempDir()
+
+	content := "line 1\n<<<<<<< HEAD\nour change\n=======\ntheir change\n>>>>>>> branch\nline 7\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "conflict.go"), []byte(content), 0o600))
+
+	c := &GitHygieneCollector{}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{})
+	require.NoError(t, err)
+
+	conflicts := filterByKind(signals, "merge-conflict-marker")
+	assert.Len(t, conflicts, 1, "should report only one conflict signal per file")
+	assert.Equal(t, 2, conflicts[0].Line)
+	assert.Equal(t, 0.9, conflicts[0].Confidence)
+}
+
+func TestGitHygieneCollector_CommittedSecrets_AWSKey(t *testing.T) {
+	dir := t.TempDir()
+
+	content := `package main
+const awsKey = "AKIAIOSFODNN7EXAMPLE"
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "config.go"), []byte(content), 0o600))
+
+	c := &GitHygieneCollector{}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{})
+	require.NoError(t, err)
+
+	secrets := filterByKind(signals, "committed-secret")
+	require.Len(t, secrets, 1)
+	assert.Contains(t, secrets[0].Title, "AWS access key")
+	assert.Equal(t, 0.7, secrets[0].Confidence)
+}
+
+func TestGitHygieneCollector_CommittedSecrets_GitHubToken(t *testing.T) {
+	dir := t.TempDir()
+
+	// Generate a fake token of sufficient length (36+ chars).
+	token := "ghp_" + strings.Repeat("A", 36)
+	content := "TOKEN=" + token + "\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "env.sh"), []byte(content), 0o600))
+
+	c := &GitHygieneCollector{}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{})
+	require.NoError(t, err)
+
+	secrets := filterByKind(signals, "committed-secret")
+	require.Len(t, secrets, 1)
+	assert.Contains(t, secrets[0].Title, "GitHub token")
+}
+
+func TestGitHygieneCollector_CommittedSecrets_GenericKey(t *testing.T) {
+	dir := t.TempDir()
+
+	content := `api_key = "supersecretvalue123456"` + "\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(content), 0o600))
+
+	c := &GitHygieneCollector{}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{})
+	require.NoError(t, err)
+
+	secrets := filterByKind(signals, "committed-secret")
+	require.Len(t, secrets, 1)
+	assert.Contains(t, secrets[0].Title, "generic secret")
+	assert.Equal(t, 0.6, secrets[0].Confidence)
+}
+
+func TestGitHygieneCollector_MixedLineEndings(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a file with mixed line endings: some CRLF, some LF.
+	// bufio.Scanner strips \n but leaves \r on CRLF lines.
+	content := "line1\r\nline2\r\nline3\r\nline4\nline5\nline6\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "mixed.txt"), []byte(content), 0o600))
+
+	c := &GitHygieneCollector{}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{})
+	require.NoError(t, err)
+
+	mixed := filterByKind(signals, "mixed-line-endings")
+	require.Len(t, mixed, 1)
+	assert.Contains(t, mixed[0].Title, "CRLF")
+	assert.Contains(t, mixed[0].Title, "LF")
+	assert.Equal(t, 0.7, mixed[0].Confidence)
+}
+
+func TestGitHygieneCollector_NoMixedEndings_AllLF(t *testing.T) {
+	dir := t.TempDir()
+
+	content := "line1\nline2\nline3\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "clean.txt"), []byte(content), 0o600))
+
+	c := &GitHygieneCollector{}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{})
+	require.NoError(t, err)
+
+	mixed := filterByKind(signals, "mixed-line-endings")
+	assert.Empty(t, mixed)
+}
+
+func TestGitHygieneCollector_MinConfidenceFilter(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a generic secret (confidence 0.6) — should be filtered at 0.7.
+	content := `api_key = "supersecretvalue123456"` + "\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(content), 0o600))
+
+	c := &GitHygieneCollector{}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{
+		MinConfidence: 0.7,
+	})
+	require.NoError(t, err)
+
+	secrets := filterByKind(signals, "committed-secret")
+	assert.Empty(t, secrets, "generic secrets should be filtered at min_confidence 0.7")
+}
+
+func TestGitHygieneCollector_ContextCancellation(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "file.go"), []byte("package main\n"), 0o600))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	c := &GitHygieneCollector{}
+	_, err := c.Collect(ctx, dir, signal.CollectorOpts{})
+	assert.Error(t, err)
+}
+
+func TestGitHygieneCollector_ExcludePatterns(t *testing.T) {
+	dir := t.TempDir()
+
+	// Put a conflict marker in a vendor file (should be excluded).
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "vendor"), 0o750))
+	content := "<<<<<<< HEAD\nours\n=======\ntheirs\n>>>>>>> branch\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "vendor", "lib.go"), []byte(content), 0o600))
+
+	c := &GitHygieneCollector{}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{})
+	require.NoError(t, err)
+
+	conflicts := filterByKind(signals, "merge-conflict-marker")
+	assert.Empty(t, conflicts, "vendor files should be excluded by default")
+}
+
+func TestGitHygieneCollector_Metrics(t *testing.T) {
+	dir := t.TempDir()
+
+	// Set up files that trigger each signal type.
+	content := "<<<<<<< HEAD\nours\n=======\ntheirs\n>>>>>>> branch\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "conflict.go"), []byte(content), 0o600))
+
+	c := &GitHygieneCollector{}
+	_, err := c.Collect(context.Background(), dir, signal.CollectorOpts{})
+	require.NoError(t, err)
+
+	m, ok := c.Metrics().(*GitHygieneMetrics)
+	require.True(t, ok)
+	assert.Greater(t, m.FilesScanned, 0)
+	assert.Equal(t, 1, m.MergeConflictMarkers)
+}
+
+func TestParseLFSPatterns(t *testing.T) {
+	dir := t.TempDir()
+
+	attrs := `# Git LFS
+*.bin filter=lfs diff=lfs merge=lfs -text
+*.png filter=lfs diff=lfs merge=lfs -text
+
+# Not LFS
+*.go text=auto
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".gitattributes"), []byte(attrs), 0o600))
+
+	patterns := parseLFSPatterns(dir)
+	assert.Equal(t, []string{"*.bin", "*.png"}, patterns)
+}
+
+func TestParseLFSPatterns_NoFile(t *testing.T) {
+	dir := t.TempDir()
+	patterns := parseLFSPatterns(dir)
+	assert.Nil(t, patterns)
+}
+
+func TestIsLFSTracked(t *testing.T) {
+	patterns := []string{"*.bin", "*.png", "assets/*.psd"}
+
+	assert.True(t, isLFSTracked("foo.bin", patterns))
+	assert.True(t, isLFSTracked("dir/bar.png", patterns))
+	assert.False(t, isLFSTracked("main.go", patterns))
+}
+
+func TestHumanSize(t *testing.T) {
+	assert.Equal(t, "500 B", humanSize(500))
+	assert.Equal(t, "1.5 KB", humanSize(1500))
+	assert.Equal(t, "2.5 MB", humanSize(2_500_000))
+	assert.Equal(t, "1.0 GB", humanSize(1_000_000_000))
+}
+
+func TestGitHygieneCollector_BinarySkipsTextChecks(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a binary file with conflict markers in it — should NOT trigger
+	// merge-conflict-marker since it's binary.
+	data := []byte("<<<<<<< HEAD\n\x00binary content\n>>>>>>> branch\n")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "binary.dat"), data, 0o600))
+
+	c := &GitHygieneCollector{}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{})
+	require.NoError(t, err)
+
+	conflicts := filterByKind(signals, "merge-conflict-marker")
+	assert.Empty(t, conflicts, "binary files should not be checked for text patterns")
+}
+
+func TestGitHygieneCollector_OneSecretPerLine(t *testing.T) {
+	dir := t.TempDir()
+
+	// A line that matches both AWS key and generic secret patterns.
+	content := `api_key = "AKIAIOSFODNN7EXAMPLE"` + "\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "both.go"), []byte(content), 0o600))
+
+	c := &GitHygieneCollector{}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{})
+	require.NoError(t, err)
+
+	secrets := filterByKind(signals, "committed-secret")
+	assert.Len(t, secrets, 1, "should only report one secret per line")
+}

--- a/internal/report/githygiene.go
+++ b/internal/report/githygiene.go
@@ -1,0 +1,82 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
+package report
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/davetashner/stringer/internal/collectors"
+	"github.com/davetashner/stringer/internal/signal"
+)
+
+func init() {
+	Register(&gitHygieneSection{})
+}
+
+// gitHygieneSection reports git hygiene issues found during scanning.
+type gitHygieneSection struct {
+	metrics *collectors.GitHygieneMetrics
+}
+
+func (s *gitHygieneSection) Name() string        { return "git-hygiene" }
+func (s *gitHygieneSection) Description() string { return "Git repository hygiene analysis" }
+
+func (s *gitHygieneSection) Analyze(result *signal.ScanResult) error {
+	raw, ok := result.Metrics["githygiene"]
+	if !ok {
+		return fmt.Errorf("git-hygiene: %w", ErrMetricsNotAvailable)
+	}
+	m, ok := raw.(*collectors.GitHygieneMetrics)
+	if !ok || m == nil {
+		return fmt.Errorf("git-hygiene: %w", ErrMetricsNotAvailable)
+	}
+	s.metrics = m
+	return nil
+}
+
+func (s *gitHygieneSection) Render(w io.Writer) error {
+	_, _ = fmt.Fprintf(w, "%s\n", SectionTitle("Git Hygiene"))
+	_, _ = fmt.Fprintf(w, "-------------------\n")
+
+	if s.metrics == nil {
+		_, _ = fmt.Fprintf(w, "  No git hygiene data available.\n\n")
+		return nil
+	}
+
+	total := s.metrics.LargeBinaries + s.metrics.MergeConflictMarkers +
+		s.metrics.CommittedSecrets + s.metrics.MixedLineEndings
+
+	if total == 0 {
+		_, _ = fmt.Fprintf(w, "  No git hygiene issues detected (%d files scanned).\n\n",
+			s.metrics.FilesScanned)
+		return nil
+	}
+
+	tbl := NewTable(
+		Column{Header: "Issue Type"},
+		Column{Header: "Count", Align: AlignRight, Color: colorHygieneCount},
+	)
+
+	tbl.AddRow("Large binaries", fmt.Sprintf("%d", s.metrics.LargeBinaries))
+	tbl.AddRow("Merge conflict markers", fmt.Sprintf("%d", s.metrics.MergeConflictMarkers))
+	tbl.AddRow("Committed secrets", fmt.Sprintf("%d", s.metrics.CommittedSecrets))
+	tbl.AddRow("Mixed line endings", fmt.Sprintf("%d", s.metrics.MixedLineEndings))
+
+	if err := tbl.Render(w); err != nil {
+		return err
+	}
+
+	_, _ = fmt.Fprintf(w, "\n  %d files scanned, %d issues found.\n\n",
+		s.metrics.FilesScanned, total)
+	return nil
+}
+
+// colorHygieneCount colors issue counts: 0 is green, >0 is yellow/red.
+func colorHygieneCount(val string) string {
+	if val == "0" {
+		return colorGreen.Sprint(val)
+	}
+	return colorYellow.Sprint(val)
+}

--- a/internal/report/githygiene_test.go
+++ b/internal/report/githygiene_test.go
@@ -1,0 +1,95 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
+package report
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/davetashner/stringer/internal/collectors"
+	"github.com/davetashner/stringer/internal/signal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGitHygiene_Registered(t *testing.T) {
+	s := Get("git-hygiene")
+	require.NotNil(t, s)
+	assert.Equal(t, "git-hygiene", s.Name())
+	assert.NotEmpty(t, s.Description())
+}
+
+func TestGitHygiene_Analyze_MissingMetrics(t *testing.T) {
+	s := &gitHygieneSection{}
+	err := s.Analyze(&signal.ScanResult{Metrics: map[string]any{}})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrMetricsNotAvailable))
+}
+
+func TestGitHygiene_Analyze_NilMetrics(t *testing.T) {
+	s := &gitHygieneSection{}
+	err := s.Analyze(&signal.ScanResult{
+		Metrics: map[string]any{"githygiene": (*collectors.GitHygieneMetrics)(nil)},
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrMetricsNotAvailable))
+}
+
+func TestGitHygiene_AnalyzeAndRender(t *testing.T) {
+	s := &gitHygieneSection{}
+	result := &signal.ScanResult{
+		Metrics: map[string]any{
+			"githygiene": &collectors.GitHygieneMetrics{
+				FilesScanned:         100,
+				LargeBinaries:        2,
+				MergeConflictMarkers: 1,
+				CommittedSecrets:     3,
+				MixedLineEndings:     0,
+			},
+		},
+	}
+
+	require.NoError(t, s.Analyze(result))
+
+	var buf bytes.Buffer
+	require.NoError(t, s.Render(&buf))
+
+	out := buf.String()
+	assert.Contains(t, out, "Git Hygiene")
+	assert.Contains(t, out, "Large binaries")
+	assert.Contains(t, out, "Merge conflict markers")
+	assert.Contains(t, out, "Committed secrets")
+	assert.Contains(t, out, "Mixed line endings")
+	assert.Contains(t, out, "6 issues found")
+}
+
+func TestGitHygiene_Render_NoIssues(t *testing.T) {
+	s := &gitHygieneSection{
+		metrics: &collectors.GitHygieneMetrics{
+			FilesScanned: 50,
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, s.Render(&buf))
+	assert.Contains(t, buf.String(), "No git hygiene issues detected")
+	assert.Contains(t, buf.String(), "50 files scanned")
+}
+
+func TestGitHygiene_Render_NilMetrics(t *testing.T) {
+	s := &gitHygieneSection{}
+
+	var buf bytes.Buffer
+	require.NoError(t, s.Render(&buf))
+	assert.Contains(t, buf.String(), "No git hygiene data available")
+}
+
+func TestColorHygieneCount(t *testing.T) {
+	zero := colorHygieneCount("0")
+	assert.Contains(t, zero, "0")
+
+	nonzero := colorHygieneCount("5")
+	assert.Contains(t, nonzero, "5")
+}


### PR DESCRIPTION
## Summary
- Add `githygiene` collector that detects four high-confidence repository hygiene signals in a single `WalkDir` pass: large committed binaries (>1MB, LFS-aware), merge conflict markers, committed secrets (AWS keys, GitHub tokens, generic key=value), and mixed line endings
- Add `git-hygiene` report section with summary table showing issue counts by type
- Add DR-015 documenting the design decision (regex-based single-pass scanner)
- Register collector in `knownCollectors` map for `stringer collectors list/info`

Closes `stringer-38h`

## Test plan
- [x] `go build -o stringer ./cmd/stringer`
- [x] `go test -race ./internal/collectors/ -run TestGitHygiene` — 15 tests pass
- [x] `go test -race ./internal/report/ -run TestGitHygiene` — 6 tests pass
- [x] `go test -race ./...` — all pass (integration test failure is pre-existing)
- [x] `./stringer collectors list` — shows `githygiene` as enabled
- [x] `./stringer collectors info githygiene` — shows all 4 signal types

🤖 Generated with [Claude Code](https://claude.com/claude-code)