### PR TITLE
fix: suppress coverage false positives for non-source dirs and warn on shallow clones

### DIFF
--- a/cmd/stringer/collectors.go
+++ b/cmd/stringer/collectors.go
@@ -50,7 +50,7 @@ var knownCollectors = map[string]collectorMeta{
 		ConfigFields: []string{"include_prs", "comment_depth", "max_issues_per_collector", "include_closed", "history_depth"},
 	},
 	"lotteryrisk": {
-		Description:  "Analyzes git blame and commit history to find single-author risk areas",
+		Description:  "Analyzes git blame and commit history to find single-author risk areas (accuracy improves with full git history; shallow clones may underreport)",
 		SignalKinds:  []string{"low-lottery-risk", "review-concentration"},
 		ConfigFields: []string{"lottery_risk_threshold", "directory_depth", "max_blame_files"},
 	},

--- a/internal/collectors/lotteryrisk.go
+++ b/internal/collectors/lotteryrisk.go
@@ -416,6 +416,7 @@ func walkCommitsForOwnership(ctx context.Context, gitDir string, ownership map[s
 			strings.Contains(errMsg, "bad default revision") ||
 			strings.Contains(errMsg, "object not found") ||
 			strings.Contains(errMsg, "exit status 128") {
+			slog.Warn("lottery risk: limited git history detected, ownership data may be incomplete (shallow clone?)", "error", err)
 			return nil
 		}
 		return fmt.Errorf("git log --numstat: %w", err)

--- a/internal/collectors/patterns.go
+++ b/internal/collectors/patterns.go
@@ -264,8 +264,9 @@ func (c *PatternsCollector) Collect(ctx context.Context, repoPath string, opts s
 			return nil, err
 		}
 
-		// Build metrics for every directory with source files.
-		if stats.sourceFiles > 0 {
+		// Build metrics for every directory with source files,
+		// excluding non-source/demo directories.
+		if stats.sourceFiles > 0 && (opts.IncludeDemoPaths || !isDemoPath(dir)) {
 			ratio := float64(stats.testFiles) / float64(stats.sourceFiles)
 			dirRatios = append(dirRatios, DirectoryTestRatio{
 				Path:        dir,

--- a/internal/collectors/todos.go
+++ b/internal/collectors/todos.go
@@ -86,6 +86,19 @@ var defaultDemoPatterns = []string{
 	"samples/**",
 	"sample/**",
 	"_examples/**",
+	// Non-source directories where tests are not expected.
+	"docs/**",
+	"doc/**",
+	"extras/**",
+	"packaging/**",
+	"scripts/**",
+	"tools/**",
+	"contrib/**",
+	"misc/**",
+	"build/**",
+	"deploy/**",
+	".github/**",
+	".ci/**",
 }
 
 // isDemoPath returns true if relPath falls under a demo/example/tutorial directory.

--- a/internal/collectors/todos_test.go
+++ b/internal/collectors/todos_test.go
@@ -1086,6 +1086,19 @@ func TestIsDemoPath(t *testing.T) {
 		{name: "filename_example_no_match", relPath: "example.go", want: false},
 		{name: "filename_examples_no_match", relPath: "examples.go", want: false},
 		{name: "sub_example_no_match", relPath: "pkg/example.go", want: false},
+		// Non-source directories (docs, tooling, etc.)
+		{name: "docs_nested", relPath: "docs/design.md", want: true},
+		{name: "doc_nested", relPath: "doc/api/overview.go", want: true},
+		{name: "scripts_nested", relPath: "scripts/deploy.py", want: true},
+		{name: "tools_nested", relPath: "tools/gen/main.go", want: true},
+		{name: "build_nested", relPath: "build/output/main.go", want: true},
+		{name: "deploy_nested", relPath: "deploy/k8s/app.yaml", want: true},
+		{name: "extras_nested", relPath: "extras/playground.go", want: true},
+		{name: "packaging_nested", relPath: "packaging/deb/control", want: true},
+		{name: "contrib_nested", relPath: "contrib/plugin/main.go", want: true},
+		{name: "misc_nested", relPath: "misc/notes.txt", want: true},
+		{name: "dotgithub_nested", relPath: ".github/workflows/ci.yml", want: true},
+		{name: "dotci_nested", relPath: ".ci/pipeline.yml", want: true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- **stringer-89b**: Add `docs/`, `scripts/`, `tools/`, `build/`, `deploy/`, `packaging/`, `contrib/`, `misc/`, `.github/`, `.ci/` to `defaultDemoPatterns` so the patterns collector no longer flags non-source directories as missing tests. Also exclude these directories from `dirRatios` metrics.
- **stringer-8qi**: Update lotteryrisk collector description to note shallow clone impact and add `slog.Warn` when limited git history is detected during commit walk.

## Test plan
- [x] `TestIsDemoPath` extended with 12 new cases for non-source dirs — all pass
- [x] Existing `TestPatterns*` tests pass (no regressions)
- [x] `./stringer collectors info lotteryrisk` shows shallow clone caveat
- [x] Full `go test -race ./...` passes (integration test failure is pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)