### PR TITLE
fix: update bd init flags in integration test

### DIFF
--- a/test/integration/scan_test.go
+++ b/test/integration/scan_test.go
@@ -342,7 +342,7 @@ func TestScan_BdImportRoundTrip(t *testing.T) {
 
 	// Step 3: Init a temp bd repo and import.
 	bdDir := t.TempDir()
-	initCmd := exec.Command(bdPath, "init", "--no-db", "--prefix", "str") //nolint:gosec // test helper
+	initCmd := exec.Command(bdPath, "init", "--prefix", "str", "--skip-hooks", "-q") //nolint:gosec // test helper
 	initCmd.Dir = bdDir
 	initOut, err := initCmd.CombinedOutput()
 	require.NoError(t, err, "bd init failed:\n%s", initOut)


### PR DESCRIPTION
## Summary
- Remove obsolete `--no-db` flag from `TestScan_BdImportRoundTrip` — it was removed when bd migrated from SQLite to Dolt backend (#219)
- Add `--skip-hooks -q` for clean test execution

Beads: `stringer-14e`

## Test plan
- [x] `go test -race ./test/integration/ -run TestScan_BdImportRoundTrip -v` — passes
- [x] One-line change, no functional impact beyond fixing the test

🤖 Generated with [Claude Code](https://claude.com/claude-code)