### PR TITLE
feat: add SARIF v2.1.0 output formatter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,7 @@ stringer/
 │   │   ├── beads.go            # Beads JSONL writer (primary)
 │   │   ├── json.go             # JSON with metadata envelope
 │   │   ├── markdown.go         # Human-readable markdown summary
+│   │   ├── sarif.go            # SARIF v2.1.0 static analysis output
 │   │   ├── tasks.go            # Claude Code task format
 │   │   └── signalid.go         # Shared deterministic signal ID generation
 │   ├── pipeline/           # Scan orchestration

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ stringer scan [path] [flags]
 
 **Available collectors:** `todos`, `gitlog`, `patterns`, `lotteryrisk`, `github`, `dephealth`, `vuln`, `complexity`, `deadcode`, `githygiene`, `docstale`, `configdrift`, `apidrift`
 
-**Available formats:** `beads`, `json`, `markdown`, `tasks`
+**Available formats:** `beads`, `json`, `markdown`, `sarif`, `tasks`
 
 ## Configuration File
 

--- a/cmd/stringer/scan.go
+++ b/cmd/stringer/scan.go
@@ -70,7 +70,7 @@ For a human-readable health dashboard, use 'stringer report' instead.`,
 
 func init() {
 	scanCmd.Flags().StringVarP(&scanCollectors, "collectors", "c", "", "comma-separated list of collectors to run")
-	scanCmd.Flags().StringVarP(&scanFormat, "format", "f", "beads", "output format (beads, html, html-dir, json, markdown, tasks)")
+	scanCmd.Flags().StringVarP(&scanFormat, "format", "f", "beads", "output format (beads, html, html-dir, json, markdown, sarif, tasks)")
 	scanCmd.Flags().StringVarP(&scanOutput, "output", "o", "", "output file path (default: stdout)")
 	scanCmd.Flags().BoolVar(&scanDryRun, "dry-run", false, "show signal count without producing output")
 	scanCmd.Flags().BoolVar(&scanDelta, "delta", false, "only output new signals since last scan")

--- a/internal/output/formatter_test.go
+++ b/internal/output/formatter_test.go
@@ -41,6 +41,7 @@ func restoreFormatters() {
 	RegisterFormatter(NewHTMLDirFormatter())
 	RegisterFormatter(NewJSONFormatter())
 	RegisterFormatter(NewMarkdownFormatter())
+	RegisterFormatter(NewSARIFFormatter())
 	RegisterFormatter(NewTasksFormatter())
 }
 

--- a/internal/output/sarif.go
+++ b/internal/output/sarif.go
@@ -1,0 +1,347 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
+package output
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"slices"
+
+	"github.com/davetashner/stringer/internal/signal"
+)
+
+func init() {
+	RegisterFormatter(NewSARIFFormatter())
+}
+
+// SARIFFormatter writes signals as a SARIF v2.1.0 JSON document.
+type SARIFFormatter struct {
+	// Version is the stringer version to embed in the SARIF tool component.
+	// If empty, "dev" is used.
+	Version string
+}
+
+// Compile-time interface check.
+var _ Formatter = (*SARIFFormatter)(nil)
+
+// NewSARIFFormatter returns a new SARIFFormatter with default settings.
+func NewSARIFFormatter() *SARIFFormatter {
+	return &SARIFFormatter{}
+}
+
+// Name returns the format name.
+func (f *SARIFFormatter) Name() string { return "sarif" }
+
+// Format writes all signals as a SARIF v2.1.0 document to w.
+func (f *SARIFFormatter) Format(signals []signal.RawSignal, w io.Writer) error {
+	if signals == nil {
+		signals = []signal.RawSignal{}
+	}
+
+	doc := f.buildDocument(signals)
+
+	data, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal sarif: %w", err)
+	}
+	if _, err := w.Write(data); err != nil {
+		return fmt.Errorf("write sarif: %w", err)
+	}
+	_, err = w.Write([]byte("\n"))
+	if err != nil {
+		return fmt.Errorf("write sarif trailing newline: %w", err)
+	}
+	return nil
+}
+
+// SARIF document types — only exported for JSON marshaling.
+
+type sarifDocument struct {
+	Schema  string     `json:"$schema"`
+	Version string     `json:"version"`
+	Runs    []sarifRun `json:"runs"`
+}
+
+type sarifRun struct {
+	Tool    sarifTool     `json:"tool"`
+	Results []sarifResult `json:"results"`
+}
+
+type sarifTool struct {
+	Driver sarifDriver `json:"driver"`
+}
+
+type sarifDriver struct {
+	Name           string      `json:"name"`
+	Version        string      `json:"version,omitempty"`
+	InformationURI string      `json:"informationUri,omitempty"`
+	Rules          []sarifRule `json:"rules"`
+}
+
+type sarifRule struct {
+	ID               string                     `json:"id"`
+	ShortDescription sarifMultiformatMessage    `json:"shortDescription"`
+	DefaultConfig    *sarifReportingConfig      `json:"defaultConfiguration,omitempty"`
+	Properties       map[string]json.RawMessage `json:"properties,omitempty"`
+}
+
+type sarifMultiformatMessage struct {
+	Text string `json:"text"`
+}
+
+type sarifReportingConfig struct {
+	Level string `json:"level"`
+}
+
+type sarifResult struct {
+	RuleID              string                     `json:"ruleId"`
+	RuleIndex           int                        `json:"ruleIndex"`
+	Level               string                     `json:"level"`
+	Rank                float64                    `json:"rank"`
+	Message             sarifMultiformatMessage    `json:"message"`
+	Locations           []sarifLocation            `json:"locations,omitempty"`
+	PartialFingerprints map[string]string          `json:"partialFingerprints,omitempty"`
+	Properties          map[string]json.RawMessage `json:"properties,omitempty"`
+}
+
+type sarifLocation struct {
+	PhysicalLocation sarifPhysicalLocation `json:"physicalLocation"`
+}
+
+type sarifPhysicalLocation struct {
+	ArtifactLocation sarifArtifactLocation `json:"artifactLocation"`
+	Region           *sarifRegion          `json:"region,omitempty"`
+}
+
+type sarifArtifactLocation struct {
+	URI       string `json:"uri"`
+	URIBaseID string `json:"uriBaseId,omitempty"`
+}
+
+type sarifRegion struct {
+	StartLine int `json:"startLine"`
+}
+
+func (f *SARIFFormatter) buildDocument(signals []signal.RawSignal) sarifDocument {
+	rules, ruleIndex := f.buildRules(signals)
+	results := f.buildResults(signals, ruleIndex)
+
+	version := f.Version
+	if version == "" {
+		version = "dev"
+	}
+
+	return sarifDocument{
+		Schema:  "https://json.schemastore.org/sarif-2.1.0.json",
+		Version: "2.1.0",
+		Runs: []sarifRun{
+			{
+				Tool: sarifTool{
+					Driver: sarifDriver{
+						Name:           "stringer",
+						Version:        version,
+						InformationURI: "https://github.com/davetashner/stringer",
+						Rules:          rules,
+					},
+				},
+				Results: results,
+			},
+		},
+	}
+}
+
+// buildRules collects unique signal kinds into SARIF rule objects.
+// Returns the rules and a map from kind to rule index.
+func (f *SARIFFormatter) buildRules(signals []signal.RawSignal) ([]sarifRule, map[string]int) {
+	ruleIndex := make(map[string]int)
+	var rules []sarifRule
+
+	// Collect unique kinds in stable order.
+	var kinds []string
+	for _, sig := range signals {
+		if _, exists := ruleIndex[sig.Kind]; !exists {
+			ruleIndex[sig.Kind] = -1 // placeholder
+			kinds = append(kinds, sig.Kind)
+		}
+	}
+	slices.Sort(kinds)
+
+	// Build rules in sorted order and update index.
+	for i, kind := range kinds {
+		ruleIndex[kind] = i
+		rules = append(rules, sarifRule{
+			ID: kind,
+			ShortDescription: sarifMultiformatMessage{
+				Text: ruleDescription(kind),
+			},
+			DefaultConfig: &sarifReportingConfig{
+				Level: "warning",
+			},
+			Properties: ruleProperties(kind),
+		})
+	}
+
+	return rules, ruleIndex
+}
+
+func (f *SARIFFormatter) buildResults(signals []signal.RawSignal, ruleIndex map[string]int) []sarifResult {
+	results := make([]sarifResult, 0, len(signals))
+
+	for _, sig := range signals {
+		priority := mapConfidenceToPriority(sig.Confidence)
+		if sig.Priority != nil {
+			priority = *sig.Priority
+		}
+
+		result := sarifResult{
+			RuleID:    sig.Kind,
+			RuleIndex: ruleIndex[sig.Kind],
+			Level:     priorityToSARIFLevel(priority),
+			Rank:      sig.Confidence * 100.0,
+			Message: sarifMultiformatMessage{
+				Text: sig.Title,
+			},
+			PartialFingerprints: map[string]string{
+				"stringer/v1": SignalID(sig, ""),
+			},
+		}
+
+		if sig.FilePath != "" {
+			loc := sarifLocation{
+				PhysicalLocation: sarifPhysicalLocation{
+					ArtifactLocation: sarifArtifactLocation{
+						URI:       sig.FilePath,
+						URIBaseID: "%SRCROOT%",
+					},
+				},
+			}
+			if sig.Line > 0 {
+				loc.PhysicalLocation.Region = &sarifRegion{
+					StartLine: sig.Line,
+				}
+			}
+			result.Locations = []sarifLocation{loc}
+		}
+
+		props := make(map[string]json.RawMessage)
+		if sig.Source != "" {
+			props["collector"] = mustMarshal(sig.Source)
+		}
+		if sig.Author != "" {
+			props["author"] = mustMarshal(sig.Author)
+		}
+		if len(sig.Tags) > 0 {
+			props["tags"] = mustMarshal(sig.Tags)
+		}
+		if len(props) > 0 {
+			result.Properties = props
+		}
+
+		results = append(results, result)
+	}
+
+	return results
+}
+
+// priorityToSARIFLevel maps P1-P4 to SARIF level values.
+func priorityToSARIFLevel(priority int) string {
+	switch priority {
+	case 1:
+		return "error"
+	case 2:
+		return "warning"
+	case 3:
+		return "note"
+	default:
+		return "none"
+	}
+}
+
+// ruleDescription returns a human-readable description for a signal kind.
+func ruleDescription(kind string) string {
+	descriptions := map[string]string{
+		"todo":                  "Unresolved TODO comment in source code",
+		"fixme":                 "FIXME comment indicating a known issue",
+		"hack":                  "HACK comment indicating a workaround",
+		"xxx":                   "XXX comment flagging problematic code",
+		"optimize":              "OPTIMIZE comment suggesting performance improvement",
+		"bug":                   "BUG comment marking a known defect",
+		"revert":                "Git revert commit detected",
+		"churn":                 "High file churn detected in recent history",
+		"stale-branch":          "Stale branch with no recent activity",
+		"large-file":            "Source file exceeds size threshold",
+		"missing-tests":         "Source file has no corresponding test file",
+		"low-test-ratio":        "Directory has low test-to-source file ratio",
+		"low-lottery-risk":      "File has concentrated code ownership",
+		"review-concentration":  "Code reviews concentrated among few reviewers",
+		"vuln":                  "Known vulnerability in dependency",
+		"complexity":            "High cyclomatic complexity detected",
+		"deadcode":              "Potentially unused code detected",
+		"merge-conflict-marker": "Unresolved merge conflict marker in file",
+		"committed-secret":      "Potential secret committed to repository",
+		"large-binary":          "Large binary file committed to repository",
+		"mixed-line-endings":    "File has inconsistent line endings",
+		"stale-doc":             "Documentation may be outdated",
+		"undocumented-route":    "API route without documentation",
+		"unimplemented-route":   "Documented API route without implementation",
+		"stale-api-version":     "API version with no recent changes",
+		"env-var-drift":         "Environment variable referenced but not documented",
+		"dead-config-key":       "Configuration key defined but not referenced",
+		"inconsistent-defaults": "Configuration defaults differ across locations",
+		"deprecated-dependency": "Dependency is deprecated by its maintainer",
+		"archived-dependency":   "Dependency repository is archived",
+		"stale-dependency":      "Dependency has not been updated recently",
+		"yanked-dependency":     "Dependency version has been yanked",
+		"local-replace":         "Go module uses a local replace directive",
+		"retracted-version":     "Go module uses a retracted version",
+	}
+	if desc, ok := descriptions[kind]; ok {
+		return desc
+	}
+	return fmt.Sprintf("Signal of kind %q detected", kind)
+}
+
+// ruleProperties returns SARIF properties for a rule, mapping kinds to collectors.
+func ruleProperties(kind string) map[string]json.RawMessage {
+	collector := kindToCollector(kind)
+	if collector == "" {
+		return nil
+	}
+	return map[string]json.RawMessage{
+		"collector": mustMarshal(collector),
+	}
+}
+
+func kindToCollector(kind string) string {
+	collectorMap := map[string]string{
+		"todo": "todos", "fixme": "todos", "hack": "todos",
+		"xxx": "todos", "optimize": "todos", "bug": "todos",
+		"revert": "gitlog", "churn": "gitlog", "stale-branch": "gitlog",
+		"large-file": "patterns", "missing-tests": "patterns", "low-test-ratio": "patterns",
+		"low-lottery-risk": "lotteryrisk", "review-concentration": "lotteryrisk",
+		"vuln":                  "vuln",
+		"complexity":            "complexity",
+		"deadcode":              "deadcode",
+		"merge-conflict-marker": "githygiene", "committed-secret": "githygiene",
+		"large-binary": "githygiene", "mixed-line-endings": "githygiene",
+		"stale-doc":          "docstale",
+		"undocumented-route": "apidrift", "unimplemented-route": "apidrift",
+		"stale-api-version": "apidrift",
+		"env-var-drift":     "configdrift", "dead-config-key": "configdrift",
+		"inconsistent-defaults": "configdrift",
+		"deprecated-dependency": "dephealth", "archived-dependency": "dephealth",
+		"stale-dependency": "dephealth", "yanked-dependency": "dephealth",
+		"local-replace": "dephealth", "retracted-version": "dephealth",
+	}
+	return collectorMap[kind]
+}
+
+func mustMarshal(v any) json.RawMessage {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(fmt.Sprintf("mustMarshal: %v", err))
+	}
+	return data
+}

--- a/internal/output/sarif_test.go
+++ b/internal/output/sarif_test.go
@@ -1,0 +1,346 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/davetashner/stringer/internal/signal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSARIFFormatter_Name(t *testing.T) {
+	f := NewSARIFFormatter()
+	assert.Equal(t, "sarif", f.Name())
+}
+
+func TestSARIFFormatter_EmptySignals(t *testing.T) {
+	f := NewSARIFFormatter()
+	var buf bytes.Buffer
+	require.NoError(t, f.Format(nil, &buf))
+
+	var doc sarifDocument
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &doc))
+
+	assert.Equal(t, "2.1.0", doc.Version)
+	assert.Equal(t, "https://json.schemastore.org/sarif-2.1.0.json", doc.Schema)
+	require.Len(t, doc.Runs, 1)
+	assert.Equal(t, "stringer", doc.Runs[0].Tool.Driver.Name)
+	assert.Empty(t, doc.Runs[0].Results)
+	assert.Empty(t, doc.Runs[0].Tool.Driver.Rules)
+}
+
+func TestSARIFFormatter_BasicSignal(t *testing.T) {
+	f := NewSARIFFormatter()
+	f.Version = "1.0.1"
+
+	signals := []signal.RawSignal{
+		{
+			Source:     "todos",
+			Kind:       "todo",
+			FilePath:   "internal/foo.go",
+			Line:       42,
+			Title:      "TODO: fix this",
+			Confidence: 0.5,
+			Author:     "alice",
+			Tags:       []string{"debt"},
+			Timestamp:  time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, f.Format(signals, &buf))
+
+	var doc sarifDocument
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &doc))
+
+	run := doc.Runs[0]
+
+	// Tool info
+	assert.Equal(t, "1.0.1", run.Tool.Driver.Version)
+	assert.Equal(t, "https://github.com/davetashner/stringer", run.Tool.Driver.InformationURI)
+
+	// Rules
+	require.Len(t, run.Tool.Driver.Rules, 1)
+	rule := run.Tool.Driver.Rules[0]
+	assert.Equal(t, "todo", rule.ID)
+	assert.Equal(t, "Unresolved TODO comment in source code", rule.ShortDescription.Text)
+	require.NotNil(t, rule.DefaultConfig)
+	assert.Equal(t, "warning", rule.DefaultConfig.Level)
+
+	// Results
+	require.Len(t, run.Results, 1)
+	result := run.Results[0]
+	assert.Equal(t, "todo", result.RuleID)
+	assert.Equal(t, 0, result.RuleIndex)
+	assert.Equal(t, "note", result.Level) // 0.5 confidence -> P3 -> note
+	assert.InDelta(t, 50.0, result.Rank, 0.01)
+	assert.Equal(t, "TODO: fix this", result.Message.Text)
+
+	// Location
+	require.Len(t, result.Locations, 1)
+	loc := result.Locations[0].PhysicalLocation
+	assert.Equal(t, "internal/foo.go", loc.ArtifactLocation.URI)
+	assert.Equal(t, "%SRCROOT%", loc.ArtifactLocation.URIBaseID)
+	require.NotNil(t, loc.Region)
+	assert.Equal(t, 42, loc.Region.StartLine)
+
+	// Fingerprint
+	assert.NotEmpty(t, result.PartialFingerprints["stringer/v1"])
+
+	// Properties
+	assert.NotNil(t, result.Properties)
+}
+
+func TestSARIFFormatter_NoLineOmitsRegion(t *testing.T) {
+	f := NewSARIFFormatter()
+	signals := []signal.RawSignal{
+		{
+			Source:     "gitlog",
+			Kind:       "stale-branch",
+			Title:      "Branch feature/old is stale",
+			Confidence: 0.3,
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, f.Format(signals, &buf))
+
+	var doc sarifDocument
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &doc))
+
+	result := doc.Runs[0].Results[0]
+	// No file path -> no locations
+	assert.Empty(t, result.Locations)
+}
+
+func TestSARIFFormatter_NoFilePathOmitsLocations(t *testing.T) {
+	f := NewSARIFFormatter()
+	signals := []signal.RawSignal{
+		{
+			Source:     "gitlog",
+			Kind:       "stale-branch",
+			FilePath:   "some/path.go",
+			Line:       0,
+			Title:      "Stale branch",
+			Confidence: 0.4,
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, f.Format(signals, &buf))
+
+	var doc sarifDocument
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &doc))
+
+	result := doc.Runs[0].Results[0]
+	require.Len(t, result.Locations, 1)
+	assert.Nil(t, result.Locations[0].PhysicalLocation.Region)
+}
+
+func TestSARIFFormatter_PriorityMapping(t *testing.T) {
+	tests := []struct {
+		confidence float64
+		priority   *int
+		wantLevel  string
+		wantRank   float64
+	}{
+		{0.9, nil, "error", 90.0},   // P1
+		{0.7, nil, "warning", 70.0}, // P2
+		{0.5, nil, "note", 50.0},    // P3
+		{0.2, nil, "none", 20.0},    // P4
+	}
+
+	for _, tt := range tests {
+		f := NewSARIFFormatter()
+		signals := []signal.RawSignal{
+			{Kind: "todo", Title: "test", Confidence: tt.confidence},
+		}
+		if tt.priority != nil {
+			signals[0].Priority = tt.priority
+		}
+
+		var buf bytes.Buffer
+		require.NoError(t, f.Format(signals, &buf))
+
+		var doc sarifDocument
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &doc))
+
+		result := doc.Runs[0].Results[0]
+		assert.Equal(t, tt.wantLevel, result.Level, "confidence=%v", tt.confidence)
+		assert.InDelta(t, tt.wantRank, result.Rank, 0.01, "confidence=%v", tt.confidence)
+	}
+}
+
+func TestSARIFFormatter_LLMPriorityOverride(t *testing.T) {
+	f := NewSARIFFormatter()
+	p := 1
+	signals := []signal.RawSignal{
+		{
+			Kind:       "todo",
+			Title:      "Critical fix needed",
+			Confidence: 0.3, // Would be P4/none without override
+			Priority:   &p,
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, f.Format(signals, &buf))
+
+	var doc sarifDocument
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &doc))
+
+	result := doc.Runs[0].Results[0]
+	assert.Equal(t, "error", result.Level)     // P1 override
+	assert.InDelta(t, 30.0, result.Rank, 0.01) // Rank still reflects raw confidence
+}
+
+func TestSARIFFormatter_MultipleKindsCreateMultipleRules(t *testing.T) {
+	f := NewSARIFFormatter()
+	signals := []signal.RawSignal{
+		{Kind: "todo", Title: "first", Confidence: 0.5},
+		{Kind: "vuln", Title: "CVE-2024-1234", Confidence: 0.9},
+		{Kind: "todo", Title: "second", Confidence: 0.4},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, f.Format(signals, &buf))
+
+	var doc sarifDocument
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &doc))
+
+	run := doc.Runs[0]
+
+	// Two unique kinds -> two rules (sorted alphabetically).
+	require.Len(t, run.Tool.Driver.Rules, 2)
+	assert.Equal(t, "todo", run.Tool.Driver.Rules[0].ID)
+	assert.Equal(t, "vuln", run.Tool.Driver.Rules[1].ID)
+
+	// Three results total.
+	require.Len(t, run.Results, 3)
+
+	// Both "todo" results reference rule index 0.
+	assert.Equal(t, 0, run.Results[0].RuleIndex)
+	assert.Equal(t, 0, run.Results[2].RuleIndex)
+	// "vuln" result references rule index 1.
+	assert.Equal(t, 1, run.Results[1].RuleIndex)
+}
+
+func TestSARIFFormatter_DefaultVersion(t *testing.T) {
+	f := NewSARIFFormatter()
+	signals := []signal.RawSignal{
+		{Kind: "todo", Title: "test", Confidence: 0.5},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, f.Format(signals, &buf))
+
+	var doc sarifDocument
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &doc))
+
+	assert.Equal(t, "dev", doc.Runs[0].Tool.Driver.Version)
+}
+
+func TestSARIFFormatter_WriteFailure(t *testing.T) {
+	f := NewSARIFFormatter()
+	signals := []signal.RawSignal{
+		{Kind: "todo", Title: "test", Confidence: 0.5},
+	}
+
+	w := &failWriter{failAfter: 0}
+	err := f.Format(signals, w)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "write sarif")
+}
+
+func TestSARIFFormatter_WriteFailureNewline(t *testing.T) {
+	f := NewSARIFFormatter()
+	signals := []signal.RawSignal{
+		{Kind: "todo", Title: "test", Confidence: 0.5},
+	}
+
+	w := &failWriter{failAfter: 1}
+	err := f.Format(signals, w)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "write sarif trailing newline")
+}
+
+func TestSARIFFormatter_UnknownKindFallback(t *testing.T) {
+	f := NewSARIFFormatter()
+	signals := []signal.RawSignal{
+		{Kind: "some-new-kind", Title: "test", Confidence: 0.5},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, f.Format(signals, &buf))
+
+	var doc sarifDocument
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &doc))
+
+	rule := doc.Runs[0].Tool.Driver.Rules[0]
+	assert.Equal(t, "some-new-kind", rule.ID)
+	assert.Contains(t, rule.ShortDescription.Text, "some-new-kind")
+}
+
+func TestPriorityToSARIFLevel(t *testing.T) {
+	assert.Equal(t, "error", priorityToSARIFLevel(1))
+	assert.Equal(t, "warning", priorityToSARIFLevel(2))
+	assert.Equal(t, "note", priorityToSARIFLevel(3))
+	assert.Equal(t, "none", priorityToSARIFLevel(4))
+	assert.Equal(t, "none", priorityToSARIFLevel(99))
+}
+
+func TestRuleDescription_Known(t *testing.T) {
+	assert.Equal(t, "Unresolved TODO comment in source code", ruleDescription("todo"))
+	assert.Equal(t, "Known vulnerability in dependency", ruleDescription("vuln"))
+}
+
+func TestRuleDescription_Unknown(t *testing.T) {
+	desc := ruleDescription("never-seen-before")
+	assert.Contains(t, desc, "never-seen-before")
+}
+
+func TestKindToCollector(t *testing.T) {
+	assert.Equal(t, "todos", kindToCollector("todo"))
+	assert.Equal(t, "vuln", kindToCollector("vuln"))
+	assert.Equal(t, "lotteryrisk", kindToCollector("low-lottery-risk"))
+	assert.Equal(t, "", kindToCollector("unknown-kind"))
+}
+
+func TestSARIFFormatter_ValidJSON(t *testing.T) {
+	f := NewSARIFFormatter()
+	f.Version = "1.0.0"
+
+	signals := []signal.RawSignal{
+		{Source: "todos", Kind: "todo", FilePath: "a.go", Line: 1, Title: "first", Confidence: 0.5, Tags: []string{"debt"}},
+		{Source: "vuln", Kind: "vuln", FilePath: "go.mod", Line: 17, Title: "CVE-2024-1234", Confidence: 0.95, Author: "scanner"},
+		{Source: "patterns", Kind: "large-file", FilePath: "big.go", Line: 0, Title: "File exceeds threshold", Confidence: 0.6},
+		{Source: "gitlog", Kind: "stale-branch", Title: "Branch old/feature", Confidence: 0.3},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, f.Format(signals, &buf))
+
+	// Verify valid JSON.
+	assert.True(t, json.Valid(buf.Bytes()), "output should be valid JSON")
+
+	// Verify structure roundtrips.
+	var doc sarifDocument
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &doc))
+	assert.Equal(t, "2.1.0", doc.Version)
+	require.Len(t, doc.Runs, 1)
+	assert.Len(t, doc.Runs[0].Results, 4)
+	// Rules are deduped: todo, vuln, large-file, stale-branch = 4 unique kinds.
+	assert.Len(t, doc.Runs[0].Tool.Driver.Rules, 4)
+}
+
+func TestSARIFFormatter_Registration(t *testing.T) {
+	f, err := GetFormatter("sarif")
+	require.NoError(t, err)
+	assert.Equal(t, "sarif", f.Name())
+}


### PR DESCRIPTION
## Summary

- Add `--format sarif` output that produces [SARIF v2.1.0](https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html) static analysis results
- Enables inline annotations in VS Code (via SARIF Viewer extension) and GitHub Code Scanning (via `upload-sarif` action)
- Maps signal kinds to SARIF rules, file/line to physical locations, confidence to rank (0–100), and priority (P1–P4) to SARIF levels (error/warning/note/none)
- Uses `SignalID` for stable `partialFingerprints` enabling cross-run deduplication

## Beads

- Epic: `stringer-3cb` (O4: SARIF Output Formatter)
- Story: `stringer-3cb.1` (O4.1: Core SARIF formatter)

## Test plan

- [x] 15 unit tests covering: empty signals, basic signal mapping, priority/level mapping, LLM priority override, multi-kind rule deduction, write failures, unknown kinds, registration
- [x] Full test suite passes (`go test -race ./...`)
- [x] Lint clean (`golangci-lint run ./...`)
- [ ] Manual: `stringer scan . -f sarif -o results.sarif` produces valid SARIF
- [ ] Manual: Load output in VS Code with SARIF Viewer extension

🤖 Generated with [Claude Code](https://claude.com/claude-code)