### PR TITLE
fix: deduplicate collector source in beads labels

### DIFF
--- a/internal/output/beads.go
+++ b/internal/output/beads.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"slices"
 	"strings"
 	"time"
 
@@ -227,7 +228,7 @@ func (b *BeadsFormatter) buildLabels(sig signal.RawSignal) []string {
 		generatedLabel = "stringer_generated"
 	}
 	labels = append(labels, generatedLabel)
-	if sig.Source != "" {
+	if sig.Source != "" && !slices.Contains(labels, sig.Source) {
 		labels = append(labels, sig.Source)
 	}
 	if sig.Workspace != "" {

--- a/internal/output/beads_test.go
+++ b/internal/output/beads_test.go
@@ -467,6 +467,25 @@ func TestLabelsWithNoTags(t *testing.T) {
 	}
 }
 
+func TestLabelsDeduplicateSource(t *testing.T) {
+	sig := signal.RawSignal{
+		Source: "complexity",
+		Kind:   "task",
+		Title:  "Test",
+		Tags:   []string{"complexity", "refactor-candidate"},
+	}
+	rec := NewBeadsFormatter().signalToBead(sig)
+	want := []string{"complexity", "refactor-candidate", "stringer-generated"}
+	if len(rec.Labels) != len(want) {
+		t.Fatalf("Labels = %v, want %v", rec.Labels, want)
+	}
+	for i, label := range want {
+		if rec.Labels[i] != label {
+			t.Errorf("Labels[%d] = %q, want %q", i, rec.Labels[i], label)
+		}
+	}
+}
+
 func TestFormatRoundTrip(t *testing.T) {
 	sig := testSignal()
 	var buf bytes.Buffer


### PR DESCRIPTION
## Summary
- **Bug**: `buildLabels()` appended `sig.Source` unconditionally, creating duplicate labels when a collector already included its own name in `Tags` (e.g., `["complexity", "refactor-candidate", "stringer-generated", "complexity"]`)
- **Fix**: Added `slices.Contains` guard before appending Source to labels
- **Test**: Added `TestLabelsDeduplicateSource` regression test

Affected collectors: complexity, coupling, dephealth (and sub-collectors), and any future collector whose Tags include the collector name.

Found during Q3 real-world stress testing (`stringer-311`).

## Test plan
- [x] `go test -race ./internal/output/...` passes
- [x] `go test -race ./...` passes (all 23 packages)
- [x] `golangci-lint run ./...` clean
- [x] Verified fix with live scan: `stringer scan . --collectors=complexity` now produces `["complexity", "refactor-candidate", "stringer-generated"]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)