### PR TITLE
chore: soft-warn when gitleaks not installed

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -39,9 +39,7 @@ if command -v gitleaks >/dev/null 2>&1; then
         exit 1
     fi
 else
-    echo "ERROR: gitleaks not installed. Secret scanning is required." >&2
-    echo "  Install: brew install gitleaks" >&2
-    exit 1
+    echo "warning: gitleaks not installed, skipping secret scan (install: brew install gitleaks)" >&2
 fi
 
 # --- Backlog dashboard regeneration ---


### PR DESCRIPTION
## Summary
- Change pre-commit hook to print a warning instead of hard-failing when gitleaks is not installed
- Reduces first-contributor friction — new contributors can commit without installing gitleaks first
- When gitleaks IS installed, it still hard-fails on detected secrets (no change)
- go vet and gofmt checks remain hard-fails (no change)

Closes stringer-cm7

## Test plan
- [ ] Verify hook warns (not fails) when gitleaks is absent
- [ ] Verify hook still blocks commits with secrets when gitleaks is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)