### PR TITLE
feat: integrate baseline suppression filtering into scan pipeline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,7 @@ stringer/
 │   │   ├── pipeline.go         # New(), Run() — parallel execution via errgroup
 │   │   ├── dedup.go            # Content-based signal deduplication
 │   │   ├── enrich.go           # Cross-signal confidence boosting (co-location)
+│   │   ├── baseline.go         # FilterSuppressed() — baseline suppression filtering
 │   │   └── validate.go         # ScanConfig validation
 │   ├── redact/             # Secret redaction
 │   │   └── redact.go           # Scrub sensitive patterns from signal content
@@ -211,6 +212,9 @@ golangci-lint run ./...
 
 # Dry run with machine-readable JSON output
 ./stringer scan /path/to/repo --dry-run --json
+
+# Skip baseline suppression filtering
+./stringer scan /path/to/repo --no-baseline
 ```
 
 ## Key Design Decisions

--- a/cmd/stringer/scan.go
+++ b/cmd/stringer/scan.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/davetashner/stringer/internal/analysis"
+	"github.com/davetashner/stringer/internal/baseline"
 	"github.com/davetashner/stringer/internal/beads"
 	"github.com/davetashner/stringer/internal/collector"
 	_ "github.com/davetashner/stringer/internal/collectors"
@@ -54,6 +55,7 @@ var (
 	scanInferDeps         bool
 	scanWorkspace         string
 	scanNoWorkspaces      bool
+	scanNoBaseline        bool
 )
 
 // scanCmd is the subcommand for scanning a repository.
@@ -96,20 +98,22 @@ func init() {
 	scanCmd.Flags().BoolVar(&scanInferDeps, "infer-deps", false, "use LLM to detect dependencies between signals")
 	scanCmd.Flags().StringVar(&scanWorkspace, "workspace", "", "scan only named workspace(s) (comma-separated)")
 	scanCmd.Flags().BoolVar(&scanNoWorkspaces, "no-workspaces", false, "disable monorepo auto-detection, scan root as single directory")
+	scanCmd.Flags().BoolVar(&scanNoBaseline, "no-baseline", false, "skip baseline suppression filtering")
 }
 
 // scanContext holds shared state across the scan lifecycle, reducing parameter
 // passing between stages.
 type scanContext struct {
-	cmd            *cobra.Command
-	absPath        string
-	gitRoot        string
-	workspaces     []workspaceEntry
-	scanCfg        signal.ScanConfig
-	fileCfg        *config.Config
-	result         *signal.ScanResult
-	collectorNames []string
-	allSignals     []signal.RawSignal // pre-filter signals for delta state
+	cmd             *cobra.Command
+	absPath         string
+	gitRoot         string
+	workspaces      []workspaceEntry
+	scanCfg         signal.ScanConfig
+	fileCfg         *config.Config
+	result          *signal.ScanResult
+	collectorNames  []string
+	allSignals      []signal.RawSignal // pre-filter signals for delta state
+	suppressedCount int                // count of baseline-suppressed signals
 }
 
 func runScan(cmd *cobra.Command, args []string) error {
@@ -166,7 +170,7 @@ func runScan(cmd *cobra.Command, args []string) error {
 
 	// 7. Handle dry-run.
 	if scanDryRun {
-		return printDryRun(cmd, sc.result, exitCode)
+		return printDryRun(cmd, sc.result, exitCode, sc.suppressedCount)
 	}
 
 	// 8. Write formatted output.
@@ -531,6 +535,20 @@ func (sc *scanContext) filterResults() error {
 		}
 	}
 
+	// Baseline suppression filter: remove signals that have been suppressed.
+	if !scanNoBaseline {
+		blState, blErr := baseline.Load(sc.absPath)
+		if blErr != nil {
+			slog.Warn("failed to load baseline", "error", blErr)
+		} else if blState != nil {
+			before := len(sc.result.Signals)
+			sc.result.Signals, sc.suppressedCount = pipeline.FilterSuppressed(
+				sc.result.Signals, blState, "str-")
+			slog.Info("baseline filter", "before", before, "after", len(sc.result.Signals),
+				"suppressed", sc.suppressedCount)
+		}
+	}
+
 	// Post-pipeline confidence filter.
 	if scanMinConfidence > 0 {
 		var filtered []signal.RawSignal
@@ -625,7 +643,7 @@ func computeExitCode(result *signal.ScanResult, strict bool) int {
 }
 
 // printDryRun prints a summary of the scan results without producing formatted output.
-func printDryRun(cmd *cobra.Command, result *signal.ScanResult, exitCode int) error {
+func printDryRun(cmd *cobra.Command, result *signal.ScanResult, exitCode int, suppressedCount int) error {
 	if scanJSON {
 		type collectorSummary struct {
 			Name     string `json:"name"`
@@ -634,16 +652,18 @@ func printDryRun(cmd *cobra.Command, result *signal.ScanResult, exitCode int) er
 			Error    string `json:"error,omitempty"`
 		}
 		type dryRunOutput struct {
-			TotalSignals int                `json:"total_signals"`
-			Collectors   []collectorSummary `json:"collectors"`
-			Duration     string             `json:"duration"`
-			ExitCode     int                `json:"exit_code"`
+			TotalSignals    int                `json:"total_signals"`
+			SuppressedCount int                `json:"suppressed_count"`
+			Collectors      []collectorSummary `json:"collectors"`
+			Duration        string             `json:"duration"`
+			ExitCode        int                `json:"exit_code"`
 		}
 
 		out := dryRunOutput{
-			TotalSignals: len(result.Signals),
-			Duration:     result.Duration.String(),
-			ExitCode:     exitCode,
+			TotalSignals:    len(result.Signals),
+			SuppressedCount: suppressedCount,
+			Duration:        result.Duration.String(),
+			ExitCode:        exitCode,
 		}
 		for _, cr := range result.Results {
 			cs := collectorSummary{

--- a/cmd/stringer/scan_test.go
+++ b/cmd/stringer/scan_test.go
@@ -323,6 +323,88 @@ func TestScan_HistoryDepthFlag(t *testing.T) {
 	}
 }
 
+func TestScan_NoBaselineFlag(t *testing.T) {
+	binary := buildBinary(t)
+	root := initTestRepo(t)
+
+	// --no-baseline should skip baseline filtering (no baseline file exists,
+	// so output should be identical — but verify the flag is accepted).
+	cmd := exec.Command(binary, "scan", root, "--no-baseline", "--dry-run", "--quiet") //nolint:gosec // test helper
+	stdout, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("stringer scan --no-baseline --dry-run failed: %v", err)
+	}
+	if !strings.Contains(string(stdout), "signal(s) found") {
+		t.Errorf("expected dry-run output, got:\n%s", stdout)
+	}
+}
+
+func TestScan_DryRunJSON_SuppressedCount(t *testing.T) {
+	binary := buildBinary(t)
+	root := initTestRepo(t)
+
+	cmd := exec.Command(binary, "scan", root, "--dry-run", "--json", "--quiet") //nolint:gosec // test helper
+	stdout, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("stringer scan --dry-run --json failed: %v", err)
+	}
+
+	var result struct {
+		TotalSignals    int `json:"total_signals"`
+		SuppressedCount int `json:"suppressed_count"`
+	}
+	if err := json.Unmarshal(stdout, &result); err != nil {
+		t.Fatalf("dry-run JSON is not valid: %v\noutput: %s", err, stdout)
+	}
+
+	// No baseline file exists, so suppressed_count should be 0.
+	if result.SuppressedCount != 0 {
+		t.Errorf("suppressed_count = %d, want 0 (no baseline file)", result.SuppressedCount)
+	}
+}
+
+func TestScan_BaselineFiltering(t *testing.T) {
+	binary := buildBinary(t)
+	root := initTestRepo(t)
+
+	// First, scan to get signal count without baseline.
+	cmd := exec.Command(binary, "scan", root, "--dry-run", "--json", "--quiet") //nolint:gosec // test helper
+	stdout, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("first scan failed: %v", err)
+	}
+
+	var first struct {
+		TotalSignals int `json:"total_signals"`
+	}
+	if err := json.Unmarshal(stdout, &first); err != nil {
+		t.Fatalf("first scan JSON invalid: %v", err)
+	}
+	if first.TotalSignals < 1 {
+		t.Skip("no signals found in test repo — cannot test baseline filtering")
+	}
+
+	// Now scan with --no-baseline to confirm same count.
+	cmd = exec.Command(binary, "scan", root, "--no-baseline", "--dry-run", "--json", "--quiet") //nolint:gosec // test helper
+	stdout, err = cmd.Output()
+	if err != nil {
+		t.Fatalf("--no-baseline scan failed: %v", err)
+	}
+
+	var noBase struct {
+		TotalSignals    int `json:"total_signals"`
+		SuppressedCount int `json:"suppressed_count"`
+	}
+	if err := json.Unmarshal(stdout, &noBase); err != nil {
+		t.Fatalf("--no-baseline JSON invalid: %v", err)
+	}
+
+	// With --no-baseline, suppressed_count must be 0.
+	if noBase.SuppressedCount != 0 {
+		t.Errorf("--no-baseline suppressed_count = %d, want 0", noBase.SuppressedCount)
+	}
+}
+
 func TestScan_DefaultPath(t *testing.T) {
 	binary := buildBinary(t)
 	root := initTestRepo(t)

--- a/cmd/stringer/scan_unit_test.go
+++ b/cmd/stringer/scan_unit_test.go
@@ -219,7 +219,7 @@ func TestPrintDryRun_TextMode(t *testing.T) {
 		Duration: 50 * time.Millisecond,
 	}
 
-	err := printDryRun(cmd, result, ExitOK)
+	err := printDryRun(cmd, result, ExitOK, 0)
 	require.NoError(t, err)
 
 	out := buf.String()
@@ -251,7 +251,7 @@ func TestPrintDryRun_TextModeWithError(t *testing.T) {
 		Duration: 10 * time.Millisecond,
 	}
 
-	err := printDryRun(cmd, result, ExitTotalFailure)
+	err := printDryRun(cmd, result, ExitTotalFailure, 0)
 	require.Error(t, err)
 
 	var ece *exitCodeError
@@ -296,7 +296,7 @@ func TestPrintDryRun_JSONMode(t *testing.T) {
 		Duration: 250 * time.Millisecond,
 	}
 
-	err := printDryRun(cmd, result, ExitOK)
+	err := printDryRun(cmd, result, ExitOK, 0)
 	require.NoError(t, err)
 
 	var parsed struct {
@@ -348,7 +348,7 @@ func TestPrintDryRun_JSONModeWithErrors(t *testing.T) {
 		Duration: 60 * time.Millisecond,
 	}
 
-	err := printDryRun(cmd, result, ExitPartialFailure)
+	err := printDryRun(cmd, result, ExitPartialFailure, 0)
 	require.Error(t, err)
 
 	var ece *exitCodeError
@@ -386,7 +386,7 @@ func TestPrintDryRun_ExitOKReturnsNil(t *testing.T) {
 		Duration: 1 * time.Millisecond,
 	}
 
-	err := printDryRun(cmd, result, ExitOK)
+	err := printDryRun(cmd, result, ExitOK, 0)
 	assert.NoError(t, err)
 }
 
@@ -418,7 +418,7 @@ func TestPrintDryRun_TextModeMultipleCollectors(t *testing.T) {
 		Duration: 250 * time.Millisecond,
 	}
 
-	err := printDryRun(cmd, result, ExitOK)
+	err := printDryRun(cmd, result, ExitOK, 0)
 	require.NoError(t, err)
 
 	out := buf.String()
@@ -442,7 +442,7 @@ func TestPrintDryRun_JSONModeZeroSignals(t *testing.T) {
 		Duration: 5 * time.Millisecond,
 	}
 
-	err := printDryRun(cmd, result, ExitOK)
+	err := printDryRun(cmd, result, ExitOK, 0)
 	require.NoError(t, err)
 
 	var parsed struct {

--- a/internal/pipeline/baseline.go
+++ b/internal/pipeline/baseline.go
@@ -1,0 +1,38 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
+package pipeline
+
+import (
+	"log/slog"
+
+	"github.com/davetashner/stringer/internal/baseline"
+	"github.com/davetashner/stringer/internal/output"
+	"github.com/davetashner/stringer/internal/signal"
+)
+
+// FilterSuppressed removes signals whose IDs appear in the baseline.
+// Expired suppressions are NOT filtered (signal reappears after TTL).
+// Returns the filtered signals and count of suppressed signals.
+func FilterSuppressed(signals []signal.RawSignal, state *baseline.BaselineState, prefix string) ([]signal.RawSignal, int) {
+	lookup := baseline.Lookup(state)
+	if len(lookup) == 0 {
+		return signals, 0
+	}
+
+	suppressed := 0
+	result := make([]signal.RawSignal, 0, len(signals))
+
+	for _, sig := range signals {
+		id := output.SignalID(sig, prefix)
+		sup, found := lookup[id]
+		if found && !baseline.IsExpired(sup) {
+			suppressed++
+			slog.Debug("suppressed signal", "id", id, "reason", sup.Reason)
+			continue
+		}
+		result = append(result, sig)
+	}
+
+	return result, suppressed
+}

--- a/internal/pipeline/baseline_test.go
+++ b/internal/pipeline/baseline_test.go
@@ -1,0 +1,185 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
+package pipeline
+
+import (
+	"testing"
+	"time"
+
+	"github.com/davetashner/stringer/internal/baseline"
+	"github.com/davetashner/stringer/internal/output"
+	"github.com/davetashner/stringer/internal/signal"
+)
+
+func makeTestSignal(source, kind, file string, line int, title string) signal.RawSignal {
+	return signal.RawSignal{
+		Source:     source,
+		Kind:       kind,
+		FilePath:   file,
+		Line:       line,
+		Title:      title,
+		Confidence: 0.5,
+	}
+}
+
+func TestFilterSuppressed_NilBaseline(t *testing.T) {
+	signals := []signal.RawSignal{
+		makeTestSignal("todos", "todo", "main.go", 10, "fix this"),
+	}
+	result, count := FilterSuppressed(signals, nil, "str-")
+	if count != 0 {
+		t.Errorf("suppressed count = %d, want 0", count)
+	}
+	if len(result) != 1 {
+		t.Errorf("result length = %d, want 1", len(result))
+	}
+}
+
+func TestFilterSuppressed_EmptyBaseline(t *testing.T) {
+	signals := []signal.RawSignal{
+		makeTestSignal("todos", "todo", "main.go", 10, "fix this"),
+	}
+	state := &baseline.BaselineState{
+		Version:      "1",
+		Suppressions: []baseline.Suppression{},
+	}
+	result, count := FilterSuppressed(signals, state, "str-")
+	if count != 0 {
+		t.Errorf("suppressed count = %d, want 0", count)
+	}
+	if len(result) != 1 {
+		t.Errorf("result length = %d, want 1", len(result))
+	}
+}
+
+func TestFilterSuppressed_SomeMatched(t *testing.T) {
+	signals := []signal.RawSignal{
+		makeTestSignal("todos", "todo", "main.go", 10, "fix this"),
+		makeTestSignal("todos", "todo", "main.go", 20, "handle error"),
+		makeTestSignal("todos", "todo", "util.go", 5, "refactor"),
+		makeTestSignal("gitlog", "churn", "main.go", 0, "high churn"),
+		makeTestSignal("patterns", "pattern", "config.go", 1, "singleton"),
+	}
+
+	// Suppress the first 3 signals by computing their IDs.
+	prefix := "str-"
+	id0 := output.SignalID(signals[0], prefix)
+	id1 := output.SignalID(signals[1], prefix)
+	id2 := output.SignalID(signals[2], prefix)
+
+	state := &baseline.BaselineState{
+		Version: "1",
+		Suppressions: []baseline.Suppression{
+			{SignalID: id0, Reason: baseline.ReasonAcknowledged, SuppressedAt: time.Now()},
+			{SignalID: id1, Reason: baseline.ReasonWontFix, SuppressedAt: time.Now()},
+			{SignalID: id2, Reason: baseline.ReasonFalsePositive, SuppressedAt: time.Now()},
+		},
+	}
+
+	result, count := FilterSuppressed(signals, state, prefix)
+	if count != 3 {
+		t.Errorf("suppressed count = %d, want 3", count)
+	}
+	if len(result) != 2 {
+		t.Errorf("result length = %d, want 2", len(result))
+	}
+
+	// Verify the remaining signals are the unsuppressed ones.
+	if result[0].Title != "high churn" {
+		t.Errorf("result[0].Title = %q, want %q", result[0].Title, "high churn")
+	}
+	if result[1].Title != "singleton" {
+		t.Errorf("result[1].Title = %q, want %q", result[1].Title, "singleton")
+	}
+}
+
+func TestFilterSuppressed_ExpiredNotFiltered(t *testing.T) {
+	sig := makeTestSignal("todos", "todo", "main.go", 10, "expired suppression")
+	prefix := "str-"
+	id := output.SignalID(sig, prefix)
+
+	past := time.Now().Add(-24 * time.Hour)
+	state := &baseline.BaselineState{
+		Version: "1",
+		Suppressions: []baseline.Suppression{
+			{SignalID: id, Reason: baseline.ReasonAcknowledged, SuppressedAt: time.Now().Add(-48 * time.Hour), ExpiresAt: &past},
+		},
+	}
+
+	result, count := FilterSuppressed([]signal.RawSignal{sig}, state, prefix)
+	if count != 0 {
+		t.Errorf("suppressed count = %d, want 0 (expired suppression should not filter)", count)
+	}
+	if len(result) != 1 {
+		t.Errorf("result length = %d, want 1", len(result))
+	}
+}
+
+func TestFilterSuppressed_NotExpiredStillFiltered(t *testing.T) {
+	sig := makeTestSignal("todos", "todo", "main.go", 10, "future expiry")
+	prefix := "str-"
+	id := output.SignalID(sig, prefix)
+
+	future := time.Now().Add(24 * time.Hour)
+	state := &baseline.BaselineState{
+		Version: "1",
+		Suppressions: []baseline.Suppression{
+			{SignalID: id, Reason: baseline.ReasonWontFix, SuppressedAt: time.Now(), ExpiresAt: &future},
+		},
+	}
+
+	result, count := FilterSuppressed([]signal.RawSignal{sig}, state, prefix)
+	if count != 1 {
+		t.Errorf("suppressed count = %d, want 1", count)
+	}
+	if len(result) != 0 {
+		t.Errorf("result length = %d, want 0", len(result))
+	}
+}
+
+func TestFilterSuppressed_RoundTrip(t *testing.T) {
+	// Verify that signal ID computation is consistent: create a signal,
+	// compute its ID, store in baseline, and confirm it gets filtered.
+	sig := signal.RawSignal{
+		Source:     "todos",
+		Kind:       "todo",
+		FilePath:   "pkg/handler.go",
+		Line:       42,
+		Title:      "TODO: implement retry logic",
+		Confidence: 0.7,
+	}
+	prefix := "str-"
+	id := output.SignalID(sig, prefix)
+
+	state := &baseline.BaselineState{
+		Version: "1",
+		Suppressions: []baseline.Suppression{
+			{SignalID: id, Reason: baseline.ReasonAcknowledged, SuppressedAt: time.Now()},
+		},
+	}
+
+	result, count := FilterSuppressed([]signal.RawSignal{sig}, state, prefix)
+	if count != 1 {
+		t.Errorf("round-trip: suppressed count = %d, want 1", count)
+	}
+	if len(result) != 0 {
+		t.Errorf("round-trip: result length = %d, want 0", len(result))
+	}
+}
+
+func TestFilterSuppressed_EmptySignals(t *testing.T) {
+	state := &baseline.BaselineState{
+		Version: "1",
+		Suppressions: []baseline.Suppression{
+			{SignalID: "str-abc123", Reason: baseline.ReasonAcknowledged, SuppressedAt: time.Now()},
+		},
+	}
+	result, count := FilterSuppressed(nil, state, "str-")
+	if count != 0 {
+		t.Errorf("suppressed count = %d, want 0", count)
+	}
+	if len(result) != 0 {
+		t.Errorf("result length = %d, want 0", len(result))
+	}
+}


### PR DESCRIPTION
## Summary

- Add `FilterSuppressed()` function in `internal/pipeline/baseline.go` that filters signals matching baseline suppressions using O(1) hash map lookup
- Expired suppressions are NOT filtered, allowing signals to reappear after TTL
- Add `--no-baseline` flag to `stringer scan` to skip baseline filtering
- Include `suppressed_count` field in `--dry-run --json` output
- Baseline filtering runs after beads dedup, before confidence/kind filters
- Delta scanning interaction: suppressed signals remain in delta state but are excluded from output

## Test plan

- [x] `FilterSuppressed` unit tests: nil baseline, empty baseline, partial matches, expired suppressions, round-trip ID verification
- [x] Integration tests: `--no-baseline` flag accepted, dry-run JSON includes `suppressed_count`, baseline filtering with `--no-baseline` comparison
- [x] All existing tests pass with updated `printDryRun` signature
- [x] `go build`, `go test -race`, `golangci-lint run` all pass

Closes stringer-kv9.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)