### PR TITLE
feat: add stringer baseline CLI commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ stringer/
 │   ├── init.go                 # init subcommand (bootstrap stringer in a repo)
 │   ├── config.go               # config get/set/list subcommands
 │   ├── collectors.go           # collectors list/info subcommands (info shows thresholds, supports --json)
+│   ├── baseline.go             # baseline create/suppress/list/remove/status subcommands
 │   ├── mcp.go                  # mcp serve subcommand (MCP server)
 │   ├── validate.go             # validate subcommand (JSONL validation)
 │   ├── version.go              # version subcommand

--- a/cmd/stringer/baseline.go
+++ b/cmd/stringer/baseline.go
@@ -1,0 +1,597 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/davetashner/stringer/internal/baseline"
+	"github.com/davetashner/stringer/internal/collector"
+	_ "github.com/davetashner/stringer/internal/collectors"
+	"github.com/davetashner/stringer/internal/config"
+	"github.com/davetashner/stringer/internal/output"
+	"github.com/davetashner/stringer/internal/pipeline"
+	"github.com/davetashner/stringer/internal/signal"
+)
+
+// Signal ID format: str-[0-9a-f]{8}.
+var signalIDPattern = regexp.MustCompile(`^str-[0-9a-f]{8}$`)
+
+// Baseline command flags.
+var (
+	baselineCreateReason   string
+	baselineCollectors     string
+	baselineForce          bool
+	baselineSuppressReason string
+	baselineComment        string
+	baselineExpires        string
+	baselineJSON           bool
+	baselineListReason     string
+	baselineExpired        bool
+)
+
+// baselineCmd is the parent command for baseline subcommands.
+var baselineCmd = &cobra.Command{
+	Use:   "baseline",
+	Short: "Manage signal suppressions for repeat scans",
+	Long: `Manage signal suppressions so that acknowledged, won't-fix, or
+false-positive signals are filtered from future scan output.
+
+Suppressions are stored in .stringer/baseline.json and are intended to
+be version-controlled.`,
+}
+
+// baselineCreateCmd runs a scan and writes all signal IDs to the baseline.
+var baselineCreateCmd = &cobra.Command{
+	Use:   "create [path]",
+	Short: "Create a baseline from current scan results",
+	Long: `Run a full scan of the repository and write all signal IDs to
+.stringer/baseline.json. This establishes a baseline so that future scans
+only surface new signals.
+
+If a baseline already exists, use --force to overwrite it.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runBaselineCreate,
+}
+
+// baselineSuppressCmd adds or updates a single suppression.
+var baselineSuppressCmd = &cobra.Command{
+	Use:   "suppress <signal-id>",
+	Short: "Suppress a specific signal",
+	Long: `Add a suppression for the given signal ID. If the signal is already
+suppressed, its reason, comment, and expiry are updated.
+
+Signal IDs follow the format str-XXXXXXXX (8 hex digits).`,
+	Args: cobra.ExactArgs(1),
+	RunE: runBaselineSuppress,
+}
+
+// baselineListCmd shows current suppressions.
+var baselineListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all suppressions",
+	Long: `Display all current suppressions in a table format.
+
+Use --json for machine-readable output, --reason to filter by reason,
+and --expired to show only expired suppressions.`,
+	Args: cobra.NoArgs,
+	RunE: runBaselineList,
+}
+
+// baselineRemoveCmd removes suppressions.
+var baselineRemoveCmd = &cobra.Command{
+	Use:   "remove <signal-id>",
+	Short: "Remove a suppression",
+	Long: `Remove a single suppression by signal ID, or use --expired to remove
+all expired suppressions at once.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runBaselineRemove,
+}
+
+// baselineStatusCmd shows baseline summary statistics.
+var baselineStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show baseline summary statistics",
+	Long: `Display an overview of the current baseline: total suppressions,
+breakdown by reason, expired count, and oldest/newest suppression dates.`,
+	Args: cobra.NoArgs,
+	RunE: runBaselineStatus,
+}
+
+func init() {
+	// create flags
+	baselineCreateCmd.Flags().StringVar(&baselineCreateReason, "reason", "acknowledged",
+		"suppression reason (acknowledged, won't-fix, false-positive)")
+	baselineCreateCmd.Flags().StringVarP(&baselineCollectors, "collectors", "c", "",
+		"comma-separated list of collectors to run")
+	baselineCreateCmd.Flags().BoolVar(&baselineForce, "force", false,
+		"overwrite existing baseline")
+
+	// suppress flags
+	baselineSuppressCmd.Flags().StringVar(&baselineSuppressReason, "reason", "acknowledged",
+		"suppression reason (acknowledged, won't-fix, false-positive)")
+	baselineSuppressCmd.Flags().StringVar(&baselineComment, "comment", "",
+		"free-text comment")
+	baselineSuppressCmd.Flags().StringVar(&baselineExpires, "expires", "",
+		"expiration duration (e.g. 90d, 6m, 1y)")
+
+	// list flags
+	baselineListCmd.Flags().BoolVar(&baselineJSON, "json", false,
+		"machine-readable JSON output")
+	baselineListCmd.Flags().StringVar(&baselineListReason, "reason", "",
+		"filter by reason")
+	baselineListCmd.Flags().BoolVar(&baselineExpired, "expired", false,
+		"show only expired suppressions")
+
+	// remove flags
+	baselineRemoveCmd.Flags().BoolVar(&baselineExpired, "expired", false,
+		"remove all expired suppressions")
+
+	// status flags
+	baselineStatusCmd.Flags().BoolVar(&baselineJSON, "json", false,
+		"structured JSON output")
+
+	baselineCmd.AddCommand(baselineCreateCmd)
+	baselineCmd.AddCommand(baselineSuppressCmd)
+	baselineCmd.AddCommand(baselineListCmd)
+	baselineCmd.AddCommand(baselineRemoveCmd)
+	baselineCmd.AddCommand(baselineStatusCmd)
+
+	rootCmd.AddCommand(baselineCmd)
+}
+
+// resetBaselineFlags resets baseline command flags for testing.
+func resetBaselineFlags() {
+	baselineCreateReason = "acknowledged"
+	baselineSuppressReason = "acknowledged"
+	baselineListReason = ""
+	baselineCollectors = ""
+	baselineForce = false
+	baselineComment = ""
+	baselineExpires = ""
+	baselineJSON = false
+	baselineExpired = false
+
+	for _, cmd := range []*cobra.Command{
+		baselineCreateCmd, baselineSuppressCmd, baselineListCmd,
+		baselineRemoveCmd, baselineStatusCmd,
+	} {
+		cmd.Flags().VisitAll(func(f *pflag.Flag) {
+			_ = f.Value.Set(f.DefValue)
+			f.Changed = false
+		})
+	}
+}
+
+func runBaselineCreate(cmd *cobra.Command, args []string) error {
+	repoPath := "."
+	if len(args) > 0 {
+		repoPath = args[0]
+	}
+
+	absPath, gitRoot, err := resolveScanPath(repoPath)
+	if err != nil {
+		return err
+	}
+
+	reason := baseline.Reason(baselineCreateReason)
+	if err := baseline.ValidateReason(reason); err != nil {
+		return exitError(ExitInvalidArgs, "stringer: %v", err)
+	}
+
+	// Check for existing baseline.
+	existing, err := baseline.Load(absPath)
+	if err != nil {
+		return exitError(ExitTotalFailure, "stringer: failed to load baseline (%v)", err)
+	}
+	if existing != nil && !baselineForce {
+		return exitError(ExitInvalidArgs,
+			"stringer: baseline already exists — use --force to overwrite")
+	}
+
+	// Build scan config.
+	var collectors []string
+	if baselineCollectors != "" {
+		collectors = strings.Split(baselineCollectors, ",")
+		for i := range collectors {
+			collectors[i] = strings.TrimSpace(collectors[i])
+		}
+	}
+
+	fileCfg, err := config.Load(absPath)
+	if err != nil {
+		return exitError(ExitInvalidArgs, "stringer: failed to load config (%v)", err)
+	}
+
+	scanCfg := signal.ScanConfig{
+		RepoPath:   absPath,
+		Collectors: collectors,
+	}
+	scanCfg = config.Merge(fileCfg, scanCfg)
+
+	// Set GitRoot for subdirectory scans.
+	if gitRoot != absPath {
+		if scanCfg.CollectorOpts == nil {
+			scanCfg.CollectorOpts = make(map[string]signal.CollectorOpts)
+		}
+		for _, name := range []string{"todos", "gitlog", "lotteryrisk"} {
+			co := scanCfg.CollectorOpts[name]
+			co.GitRoot = gitRoot
+			scanCfg.CollectorOpts[name] = co
+		}
+	}
+
+	p, err := pipeline.New(scanCfg)
+	if err != nil {
+		available := collector.List()
+		sort.Strings(available)
+		return exitError(ExitInvalidArgs, "stringer: %v (available: %s)", err, strings.Join(available, ", "))
+	}
+
+	result, err := p.Run(cmd.Context())
+	if err != nil {
+		return exitError(ExitTotalFailure, "stringer: scan failed (%v)", err)
+	}
+
+	// Build baseline state from scan signals.
+	now := time.Now()
+	user := gitUserName()
+	state := &baseline.BaselineState{
+		Version: "1",
+	}
+
+	collectorSet := make(map[string]bool)
+	for _, sig := range result.Signals {
+		id := output.SignalID(sig, "str-")
+		baseline.AddOrUpdate(state, baseline.Suppression{
+			SignalID:     id,
+			Reason:       reason,
+			SuppressedBy: user,
+			SuppressedAt: now,
+		})
+		collectorSet[sig.Source] = true
+	}
+
+	if err := baseline.Save(absPath, state); err != nil {
+		return exitError(ExitTotalFailure, "stringer: failed to save baseline (%v)", err)
+	}
+
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Baselined %d signals from %d collectors\n",
+		len(state.Suppressions), len(collectorSet))
+	return nil
+}
+
+func runBaselineSuppress(cmd *cobra.Command, args []string) error {
+	signalID := args[0]
+
+	if !signalIDPattern.MatchString(signalID) {
+		return exitError(ExitInvalidArgs,
+			"stringer: invalid signal ID %q — must match str-[0-9a-f]{8}", signalID)
+	}
+
+	reason := baseline.Reason(baselineSuppressReason)
+	if err := baseline.ValidateReason(reason); err != nil {
+		return exitError(ExitInvalidArgs, "stringer: %v", err)
+	}
+
+	var expiresAt *time.Time
+	if baselineExpires != "" {
+		dur, err := parseDuration(baselineExpires)
+		if err != nil {
+			return exitError(ExitInvalidArgs, "stringer: invalid --expires value: %v", err)
+		}
+		t := time.Now().Add(dur)
+		expiresAt = &t
+	}
+
+	absPath, err := cmdFS.Abs(".")
+	if err != nil {
+		return exitError(ExitInvalidArgs, "stringer: cannot resolve path (%v)", err)
+	}
+
+	state, err := baseline.Load(absPath)
+	if err != nil {
+		return exitError(ExitTotalFailure, "stringer: failed to load baseline (%v)", err)
+	}
+	if state == nil {
+		state = &baseline.BaselineState{Version: "1"}
+	}
+
+	baseline.AddOrUpdate(state, baseline.Suppression{
+		SignalID:     signalID,
+		Reason:       reason,
+		Comment:      baselineComment,
+		SuppressedBy: gitUserName(),
+		SuppressedAt: time.Now(),
+		ExpiresAt:    expiresAt,
+	})
+
+	if err := baseline.Save(absPath, state); err != nil {
+		return exitError(ExitTotalFailure, "stringer: failed to save baseline (%v)", err)
+	}
+
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Suppressed %s (reason: %s)\n", signalID, reason)
+	return nil
+}
+
+func runBaselineList(cmd *cobra.Command, _ []string) error {
+	absPath, err := cmdFS.Abs(".")
+	if err != nil {
+		return exitError(ExitInvalidArgs, "stringer: cannot resolve path (%v)", err)
+	}
+
+	state, err := baseline.Load(absPath)
+	if err != nil {
+		return exitError(ExitTotalFailure, "stringer: failed to load baseline (%v)", err)
+	}
+
+	if state == nil || len(state.Suppressions) == 0 {
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No suppressions")
+		return nil
+	}
+
+	// Apply filters.
+	filtered := filterSuppressions(state.Suppressions)
+
+	if len(filtered) == 0 {
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No suppressions")
+		return nil
+	}
+
+	if baselineJSON {
+		data, err := json.MarshalIndent(filtered, "", "  ")
+		if err != nil {
+			return exitError(ExitTotalFailure, "stringer: JSON marshal failed (%v)", err)
+		}
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(data))
+		return nil
+	}
+
+	// Table output.
+	w := cmd.OutOrStdout()
+	_, _ = fmt.Fprintf(w, "%-14s %-16s %-40s %-16s %s\n",
+		"ID", "Reason", "Comment", "SuppressedBy", "Age")
+	_, _ = fmt.Fprintf(w, "%-14s %-16s %-40s %-16s %s\n",
+		"--", "------", "-------", "------------", "---")
+
+	for _, s := range filtered {
+		comment := s.Comment
+		if len(comment) > 40 {
+			comment = comment[:37] + "..."
+		}
+		age := formatAge(s.SuppressedAt)
+		_, _ = fmt.Fprintf(w, "%-14s %-16s %-40s %-16s %s\n",
+			s.SignalID, string(s.Reason), comment, s.SuppressedBy, age)
+	}
+
+	return nil
+}
+
+func runBaselineRemove(cmd *cobra.Command, args []string) error {
+	absPath, err := cmdFS.Abs(".")
+	if err != nil {
+		return exitError(ExitInvalidArgs, "stringer: cannot resolve path (%v)", err)
+	}
+
+	state, err := baseline.Load(absPath)
+	if err != nil {
+		return exitError(ExitTotalFailure, "stringer: failed to load baseline (%v)", err)
+	}
+
+	if state == nil {
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No suppressions")
+		return nil
+	}
+
+	if baselineExpired {
+		// Remove all expired suppressions.
+		count := 0
+		var kept []baseline.Suppression
+		for _, s := range state.Suppressions {
+			if baseline.IsExpired(s) {
+				count++
+			} else {
+				kept = append(kept, s)
+			}
+		}
+		state.Suppressions = kept
+
+		if err := baseline.Save(absPath, state); err != nil {
+			return exitError(ExitTotalFailure, "stringer: failed to save baseline (%v)", err)
+		}
+
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Removed %d expired suppressions\n", count)
+		return nil
+	}
+
+	if len(args) == 0 {
+		return exitError(ExitInvalidArgs,
+			"stringer: provide a signal ID or use --expired")
+	}
+
+	signalID := args[0]
+	if !signalIDPattern.MatchString(signalID) {
+		return exitError(ExitInvalidArgs,
+			"stringer: invalid signal ID %q — must match str-[0-9a-f]{8}", signalID)
+	}
+
+	if !baseline.Remove(state, signalID) {
+		return exitError(ExitInvalidArgs,
+			"stringer: signal %s not found in baseline", signalID)
+	}
+
+	if err := baseline.Save(absPath, state); err != nil {
+		return exitError(ExitTotalFailure, "stringer: failed to save baseline (%v)", err)
+	}
+
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Removed %s\n", signalID)
+	return nil
+}
+
+func runBaselineStatus(cmd *cobra.Command, _ []string) error {
+	absPath, err := cmdFS.Abs(".")
+	if err != nil {
+		return exitError(ExitInvalidArgs, "stringer: cannot resolve path (%v)", err)
+	}
+
+	state, err := baseline.Load(absPath)
+	if err != nil {
+		return exitError(ExitTotalFailure, "stringer: failed to load baseline (%v)", err)
+	}
+
+	if state == nil || len(state.Suppressions) == 0 {
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(),
+			"No baseline — run `stringer baseline create` to establish one")
+		return nil
+	}
+
+	total := len(state.Suppressions)
+	byReason := make(map[baseline.Reason]int)
+	expiredCount := 0
+	var oldest, newest time.Time
+
+	for _, s := range state.Suppressions {
+		byReason[s.Reason]++
+		if baseline.IsExpired(s) {
+			expiredCount++
+		}
+		if oldest.IsZero() || s.SuppressedAt.Before(oldest) {
+			oldest = s.SuppressedAt
+		}
+		if newest.IsZero() || s.SuppressedAt.After(newest) {
+			newest = s.SuppressedAt
+		}
+	}
+
+	if baselineJSON {
+		type statusJSON struct {
+			Total    int            `json:"total"`
+			ByReason map[string]int `json:"by_reason"`
+			Expired  int            `json:"expired"`
+			Oldest   string         `json:"oldest"`
+			Newest   string         `json:"newest"`
+		}
+		reasonMap := make(map[string]int, len(byReason))
+		for r, c := range byReason {
+			reasonMap[string(r)] = c
+		}
+		out := statusJSON{
+			Total:    total,
+			ByReason: reasonMap,
+			Expired:  expiredCount,
+			Oldest:   oldest.Format(time.RFC3339),
+			Newest:   newest.Format(time.RFC3339),
+		}
+		data, err := json.MarshalIndent(out, "", "  ")
+		if err != nil {
+			return exitError(ExitTotalFailure, "stringer: JSON marshal failed (%v)", err)
+		}
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(data))
+		return nil
+	}
+
+	w := cmd.OutOrStdout()
+	_, _ = fmt.Fprintf(w, "Total suppressions: %d\n", total)
+
+	// Sort reasons for stable output.
+	reasons := make([]string, 0, len(byReason))
+	for r := range byReason {
+		reasons = append(reasons, string(r))
+	}
+	sort.Strings(reasons)
+	for _, r := range reasons {
+		_, _ = fmt.Fprintf(w, "  %-16s %d\n", r+":", byReason[baseline.Reason(r)])
+	}
+
+	_, _ = fmt.Fprintf(w, "Expired: %d\n", expiredCount)
+	_, _ = fmt.Fprintf(w, "Oldest: %s\n", oldest.Format("2006-01-02"))
+	_, _ = fmt.Fprintf(w, "Newest: %s\n", newest.Format("2006-01-02"))
+
+	if total > 0 && float64(expiredCount)/float64(total) > 0.20 {
+		_, _ = fmt.Fprintf(w, "\nWarning: >20%% of suppressions are expired — run `stringer baseline remove --expired`\n")
+	}
+
+	return nil
+}
+
+// filterSuppressions applies the --reason and --expired filters.
+func filterSuppressions(suppressions []baseline.Suppression) []baseline.Suppression {
+	var result []baseline.Suppression
+	for _, s := range suppressions {
+		if baselineListReason != "" && string(s.Reason) != baselineListReason {
+			continue
+		}
+		if baselineExpired && !baseline.IsExpired(s) {
+			continue
+		}
+		result = append(result, s)
+	}
+	return result
+}
+
+// formatAge returns a human-readable age string from a timestamp.
+func formatAge(t time.Time) string {
+	d := time.Since(t)
+	switch {
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	case d < 30*24*time.Hour:
+		return fmt.Sprintf("%dd", int(d.Hours()/24))
+	case d < 365*24*time.Hour:
+		return fmt.Sprintf("%dmo", int(d.Hours()/(24*30)))
+	default:
+		return fmt.Sprintf("%dy", int(d.Hours()/(24*365)))
+	}
+}
+
+// gitUserName returns the git user.name or "unknown".
+func gitUserName() string {
+	out, err := exec.Command("git", "config", "user.name").Output()
+	if err != nil {
+		return "unknown"
+	}
+	name := strings.TrimSpace(string(out))
+	if name == "" {
+		return "unknown"
+	}
+	return name
+}
+
+// parseDuration parses duration strings like "90d", "6m", "1y".
+func parseDuration(s string) (time.Duration, error) {
+	if len(s) < 2 {
+		return 0, fmt.Errorf("invalid duration: %q", s)
+	}
+	numStr := s[:len(s)-1]
+	unit := s[len(s)-1]
+
+	var n int
+	if _, err := fmt.Sscanf(numStr, "%d", &n); err != nil {
+		return 0, fmt.Errorf("invalid duration number: %q", s)
+	}
+
+	switch unit {
+	case 'd':
+		return time.Duration(n) * 24 * time.Hour, nil
+	case 'w':
+		return time.Duration(n) * 7 * 24 * time.Hour, nil
+	case 'm':
+		return time.Duration(n) * 30 * 24 * time.Hour, nil
+	case 'y':
+		return time.Duration(n) * 365 * 24 * time.Hour, nil
+	default:
+		return 0, fmt.Errorf("invalid duration unit %q in %q (use d/w/m/y)", string(unit), s)
+	}
+}

--- a/cmd/stringer/baseline_test.go
+++ b/cmd/stringer/baseline_test.go
@@ -1,0 +1,861 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/davetashner/stringer/internal/baseline"
+)
+
+func TestBaselineCmd_IsRegistered(t *testing.T) {
+	found := false
+	for _, cmd := range rootCmd.Commands() {
+		if cmd.Use == "baseline" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "baseline command should be registered on rootCmd")
+}
+
+func TestBaselineSubcommands_AreRegistered(t *testing.T) {
+	subs := map[string]bool{}
+	for _, cmd := range baselineCmd.Commands() {
+		subs[cmd.Name()] = true
+	}
+	assert.True(t, subs["create"], "create subcommand should be registered")
+	assert.True(t, subs["suppress"], "suppress subcommand should be registered")
+	assert.True(t, subs["list"], "list subcommand should be registered")
+	assert.True(t, subs["remove"], "remove subcommand should be registered")
+	assert.True(t, subs["status"], "status subcommand should be registered")
+}
+
+// --- suppress tests ---
+
+func TestBaselineSuppress_ValidID(t *testing.T) {
+	resetBaselineFlags()
+	dir := t.TempDir()
+
+	origDir, _ := os.Getwd()
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	stdout := new(bytes.Buffer)
+	rootCmd.SetOut(stdout)
+	rootCmd.SetArgs([]string{"baseline", "suppress", "str-abcd1234", "--reason", "won't-fix", "--comment", "test comment"})
+
+	err := rootCmd.Execute()
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "Suppressed str-abcd1234")
+	assert.Contains(t, stdout.String(), "won't-fix")
+
+	// Verify baseline file was created.
+	state, err := baseline.Load(dir)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.Len(t, state.Suppressions, 1)
+	assert.Equal(t, "str-abcd1234", state.Suppressions[0].SignalID)
+	assert.Equal(t, baseline.ReasonWontFix, state.Suppressions[0].Reason)
+	assert.Equal(t, "test comment", state.Suppressions[0].Comment)
+}
+
+func TestBaselineSuppress_InvalidID(t *testing.T) {
+	resetBaselineFlags()
+	dir := t.TempDir()
+
+	origDir, _ := os.Getwd()
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	stdout := new(bytes.Buffer)
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(new(bytes.Buffer))
+
+	tests := []string{
+		"invalid",
+		"str-xyz",
+		"str-abcd12345", // too long
+		"str-ABCD1234",  // uppercase
+		"abc-12345678",  // wrong prefix
+	}
+	for _, id := range tests {
+		resetBaselineFlags()
+		rootCmd.SetArgs([]string{"baseline", "suppress", id})
+		err := rootCmd.Execute()
+		assert.Error(t, err, "expected error for ID %q", id)
+	}
+}
+
+func TestBaselineSuppress_UpdateExisting(t *testing.T) {
+	resetBaselineFlags()
+	dir := t.TempDir()
+
+	// Pre-create a baseline with an existing suppression.
+	state := &baseline.BaselineState{
+		Version: "1",
+		Suppressions: []baseline.Suppression{
+			{
+				SignalID:     "str-abcd1234",
+				Reason:       baseline.ReasonAcknowledged,
+				Comment:      "old comment",
+				SuppressedAt: time.Now().Add(-24 * time.Hour),
+			},
+		},
+	}
+	require.NoError(t, baseline.Save(dir, state))
+
+	origDir, _ := os.Getwd()
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	stdout := new(bytes.Buffer)
+	rootCmd.SetOut(stdout)
+	rootCmd.SetArgs([]string{"baseline", "suppress", "str-abcd1234", "--reason", "false-positive", "--comment", "updated"})
+
+	err := rootCmd.Execute()
+	require.NoError(t, err)
+
+	// Should still have exactly 1 suppression (updated, not duplicated).
+	updated, err := baseline.Load(dir)
+	require.NoError(t, err)
+	assert.Len(t, updated.Suppressions, 1)
+	assert.Equal(t, baseline.ReasonFalsePositive, updated.Suppressions[0].Reason)
+	assert.Equal(t, "updated", updated.Suppressions[0].Comment)
+}
+
+func TestBaselineSuppress_WithExpiry(t *testing.T) {
+	resetBaselineFlags()
+	dir := t.TempDir()
+
+	origDir, _ := os.Getwd()
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	stdout := new(bytes.Buffer)
+	rootCmd.SetOut(stdout)
+	rootCmd.SetArgs([]string{"baseline", "suppress", "str-abcd1234", "--expires", "90d"})
+
+	err := rootCmd.Execute()
+	require.NoError(t, err)
+
+	state, err := baseline.Load(dir)
+	require.NoError(t, err)
+	require.NotNil(t, state.Suppressions[0].ExpiresAt)
+	// Expiry should be roughly 90 days from now.
+	expected := time.Now().Add(90 * 24 * time.Hour)
+	assert.WithinDuration(t, expected, *state.Suppressions[0].ExpiresAt, time.Minute)
+}
+
+func TestBaselineSuppress_InvalidExpiry(t *testing.T) {
+	resetBaselineFlags()
+	dir := t.TempDir()
+
+	origDir, _ := os.Getwd()
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	stdout := new(bytes.Buffer)
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{"baseline", "suppress", "str-abcd1234", "--expires", "invalid"})
+
+	err := rootCmd.Execute()
+	assert.Error(t, err)
+}
+
+func TestBaselineSuppress_InvalidReason(t *testing.T) {
+	resetBaselineFlags()
+	dir := t.TempDir()
+
+	origDir, _ := os.Getwd()
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	stdout := new(bytes.Buffer)
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{"baseline", "suppress", "str-abcd1234", "--reason", "bad-reason"})
+
+	err := rootCmd.Execute()
+	assert.Error(t, err)
+}
+
+// --- list tests ---
+
+func TestBaselineList_Empty(t *testing.T) {
+	resetBaselineFlags()
+	dir := t.TempDir()
+
+	origDir, _ := os.Getwd()
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	stdout := new(bytes.Buffer)
+	rootCmd.SetOut(stdout)
+	rootCmd.SetArgs([]string{"baseline", "list"})
+
+	err := rootCmd.Execute()
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "No suppressions")
+}
+
+func TestBaselineList_WithSuppressions(t *testing.T) {
+	resetBaselineFlags()
+	dir := t.TempDir()
+
+	now := time.Now()
+	state := &baseline.BaselineState{
+		Version: "1",
+		Suppressions: []baseline.Suppression{
+			{
+				SignalID:     "str-aaaaaaaa",
+				Reason:       baseline.ReasonAcknowledged,
+				Comment:      "reviewed this one",
+				SuppressedBy: "alice",
+				SuppressedAt: now,
+			},
+			{
+				SignalID:     "str-bbbbbbbb",
+				Reason:       baseline.ReasonWontFix,
+				Comment:      "this comment is really long and should be truncated to forty characters maximum",
+				SuppressedBy: "bob",
+				SuppressedAt: now,
+			},
+		},
+	}
+	require.NoError(t, baseline.Save(dir, state))
+
+	origDir, _ := os.Getwd()
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	stdout := new(bytes.Buffer)
+	rootCmd.SetOut(stdout)
+	rootCmd.SetArgs([]string{"baseline", "list"})
+
+	err := rootCmd.Execute()
+	require.NoError(t, err)
+
+	out := stdout.String()
+	assert.Contains(t, out, "str-aaaaaaaa")
+	assert.Contains(t, out, "str-bbbbbbbb")
+	assert.Contains(t, out, "acknowledged")
+	assert.Contains(t, out, "won't-fix")
+	assert.Contains(t, out, "alice")
+	assert.Contains(t, out, "bob")
+	// Long comment should be truncated.
+	assert.Contains(t, out, "...")
+}
+
+func TestBaselineList_JSON(t *testing.T) {
+	resetBaselineFlags()
+	dir := t.TempDir()
+
+	state := &baseline.BaselineState{
+		Version: "1",
+		Suppressions: []baseline.Suppression{
+			{
+				SignalID:     "str-aaaaaaaa",
+				Reason:       baseline.ReasonAcknowledged,
+				SuppressedAt: time.Now(),
+			},
+		},
+	}
+	require.NoError(t, baseline.Save(dir, state))
+
+	origDir, _ := os.Getwd()
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	stdout := new(bytes.Buffer)
+	rootCmd.SetOut(stdout)
+	rootCmd.SetArgs([]string{"baseline", "list", "--json"})
+
+	err := rootCmd.Execute()
+	require.NoError(t, err)
+
+	var parsed []baseline.Suppression
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &parsed))
+	assert.Len(t, parsed, 1)
+	assert.Equal(t, "str-aaaaaaaa", parsed[0].SignalID)
+}
+
+func TestBaselineList_FilterByReason(t *testing.T) {
+	resetBaselineFlags()
+	dir := t.TempDir()
+
+	state := &baseline.BaselineState{
+		Version: "1",
+		Suppressions: []baseline.Suppression{
+			{SignalID: "str-aaaaaaaa", Reason: baseline.ReasonAcknowledged, SuppressedAt: time.Now()},
+			{SignalID: "str-bbbbbbbb", Reason: baseline.ReasonWontFix, SuppressedAt: time.Now()},
+		},
+	}
+	require.NoError(t, baseline.Save(dir, state))
+
+	origDir, _ := os.Getwd()
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	stdout := new(bytes.Buffer)
+	rootCmd.SetOut(stdout)
+	rootCmd.SetArgs([]string{"baseline", "list", "--reason", "won't-fix"})
+
+	err := rootCmd.Execute()
+	require.NoError(t, err)
+
+	out := stdout.String()
+	assert.Contains(t, out, "str-bbbbbbbb")
+	assert.NotContains(t, out, "str-aaaaaaaa")
+}
+
+func TestBaselineList_FilterExpired(t *testing.T) {
+	resetBaselineFlags()
+	dir := t.TempDir()
+
+	past := time.Now().Add(-time.Hour)
+	future := time.Now().Add(time.Hour)
+	state := &baseline.BaselineState{
+		Version: "1",
+		Suppressions: []baseline.Suppression{
+			{SignalID: "str-aaaaaaaa", Reason: baseline.ReasonAcknowledged, SuppressedAt: time.Now(), ExpiresAt: &past},
+			{SignalID: "str-bbbbbbbb", Reason: baseline.ReasonWontFix, SuppressedAt: time.Now(), ExpiresAt: &future},
+		},
+	}
+	require.NoError(t, baseline.Save(dir, state))
+
+	origDir, _ := os.Getwd()
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	stdout := new(bytes.Buffer)
+	rootCmd.SetOut(stdout)
+	rootCmd.SetArgs([]string{"baseline", "list", "--expired"})
+
+	err := rootCmd.Execute()
+	require.NoError(t, err)
+
+	out := stdout.String()
+	assert.Contains(t, out, "str-aaaaaaaa")
+	assert.NotContains(t, out, "str-bbbbbbbb")
+}
+
+// --- remove tests ---
+
+func TestBaselineRemove_ByID(t *testing.T) {
+	resetBaselineFlags()
+	dir := t.TempDir()
+
+	state := &baseline.BaselineState{
+		Version: "1",
+		Suppressions: []baseline.Suppression{
+			{SignalID: "str-aaaaaaaa", Reason: baseline.ReasonAcknowledged, SuppressedAt: time.Now()},
+			{SignalID: "str-bbbbbbbb", Reason: baseline.ReasonWontFix, SuppressedAt: time.Now()},
+		},
+	}
+	require.NoError(t, baseline.Save(dir, state))
+
+	origDir, _ := os.Getwd()
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	stdout := new(bytes.Buffer)
+	rootCmd.SetOut(stdout)
+	rootCmd.SetArgs([]string{"baseline", "remove", "str-aaaaaaaa"})
+
+	err := rootCmd.Execute()
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "Removed str-aaaaaaaa")
+
+	// Verify only one suppression remains.
+	updated, err := baseline.Load(dir)
+	require.NoError(t, err)
+	assert.Len(t, updated.Suppressions, 1)
+	assert.Equal(t, "str-bbbbbbbb", updated.Suppressions[0].SignalID)
+}
+
+func TestBaselineRemove_NotFound(t *testing.T) {
+	resetBaselineFlags()
+	dir := t.TempDir()
+
+	state := &baseline.BaselineState{
+		Version: "1",
+		Suppressions: []baseline.Suppression{
+			{SignalID: "str-aaaaaaaa", Reason: baseline.ReasonAcknowledged, SuppressedAt: time.Now()},
+		},
+	}
+	require.NoError(t, baseline.Save(dir, state))
+
+	origDir, _ := os.Getwd()
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	stdout := new(bytes.Buffer)
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{"baseline", "remove", "str-99999999"})
+
+	err := rootCmd.Execute()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestBaselineRemove_Expired(t *testing.T) {
+	resetBaselineFlags()
+	dir := t.TempDir()
+
+	past := time.Now().Add(-time.Hour)
+	future := time.Now().Add(time.Hour)
+	state := &baseline.BaselineState{
+		Version: "1",
+		Suppressions: []baseline.Suppression{
+			{SignalID: "str-aaaaaaaa", Reason: baseline.ReasonAcknowledged, SuppressedAt: time.Now(), ExpiresAt: &past},
+			{SignalID: "str-bbbbbbbb", Reason: baseline.ReasonWontFix, SuppressedAt: time.Now(), ExpiresAt: &future},
+			{SignalID: "str-cccccccc", Reason: baseline.ReasonFalsePositive, SuppressedAt: time.Now(), ExpiresAt: &past},
+		},
+	}
+	require.NoError(t, baseline.Save(dir, state))
+
+	origDir, _ := os.Getwd()
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	stdout := new(bytes.Buffer)
+	rootCmd.SetOut(stdout)
+	rootCmd.SetArgs([]string{"baseline", "remove", "--expired"})
+
+	err := rootCmd.Execute()
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "Removed 2 expired suppressions")
+
+	updated, err := baseline.Load(dir)
+	require.NoError(t, err)
+	assert.Len(t, updated.Suppressions, 1)
+	assert.Equal(t, "str-bbbbbbbb", updated.Suppressions[0].SignalID)
+}
+
+func TestBaselineRemove_NoBaseline(t *testing.T) {
+	resetBaselineFlags()
+	dir := t.TempDir()
+
+	origDir, _ := os.Getwd()
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	stdout := new(bytes.Buffer)
+	rootCmd.SetOut(stdout)
+	rootCmd.SetArgs([]string{"baseline", "remove", "--expired"})
+
+	err := rootCmd.Execute()
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "No suppressions")
+}
+
+func TestBaselineRemove_NoArgsNoFlags(t *testing.T) {
+	resetBaselineFlags()
+	dir := t.TempDir()
+
+	state := &baseline.BaselineState{
+		Version:      "1",
+		Suppressions: []baseline.Suppression{{SignalID: "str-aaaaaaaa", Reason: baseline.ReasonAcknowledged, SuppressedAt: time.Now()}},
+	}
+	require.NoError(t, baseline.Save(dir, state))
+
+	origDir, _ := os.Getwd()
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	stdout := new(bytes.Buffer)
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{"baseline", "remove"})
+
+	err := rootCmd.Execute()
+	assert.Error(t, err)
+}
+
+// --- status tests ---
+
+func TestBaselineStatus_NoBaseline(t *testing.T) {
+	resetBaselineFlags()
+	dir := t.TempDir()
+
+	origDir, _ := os.Getwd()
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	stdout := new(bytes.Buffer)
+	rootCmd.SetOut(stdout)
+	rootCmd.SetArgs([]string{"baseline", "status"})
+
+	err := rootCmd.Execute()
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "No baseline")
+	assert.Contains(t, stdout.String(), "stringer baseline create")
+}
+
+func TestBaselineStatus_WithSuppressions(t *testing.T) {
+	resetBaselineFlags()
+	dir := t.TempDir()
+
+	past := time.Now().Add(-time.Hour)
+	now := time.Now()
+	state := &baseline.BaselineState{
+		Version: "1",
+		Suppressions: []baseline.Suppression{
+			{SignalID: "str-aaaaaaaa", Reason: baseline.ReasonAcknowledged, SuppressedAt: now},
+			{SignalID: "str-bbbbbbbb", Reason: baseline.ReasonWontFix, SuppressedAt: now},
+			{SignalID: "str-cccccccc", Reason: baseline.ReasonAcknowledged, SuppressedAt: now.Add(-48 * time.Hour), ExpiresAt: &past},
+		},
+	}
+	require.NoError(t, baseline.Save(dir, state))
+
+	origDir, _ := os.Getwd()
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	stdout := new(bytes.Buffer)
+	rootCmd.SetOut(stdout)
+	rootCmd.SetArgs([]string{"baseline", "status"})
+
+	err := rootCmd.Execute()
+	require.NoError(t, err)
+
+	out := stdout.String()
+	assert.Contains(t, out, "Total suppressions: 3")
+	assert.Contains(t, out, "acknowledged:")
+	assert.Contains(t, out, "won't-fix:")
+	assert.Contains(t, out, "Expired: 1")
+	assert.Contains(t, out, "Oldest:")
+	assert.Contains(t, out, "Newest:")
+}
+
+func TestBaselineStatus_JSON(t *testing.T) {
+	resetBaselineFlags()
+	dir := t.TempDir()
+
+	now := time.Now()
+	state := &baseline.BaselineState{
+		Version: "1",
+		Suppressions: []baseline.Suppression{
+			{SignalID: "str-aaaaaaaa", Reason: baseline.ReasonAcknowledged, SuppressedAt: now},
+		},
+	}
+	require.NoError(t, baseline.Save(dir, state))
+
+	origDir, _ := os.Getwd()
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	stdout := new(bytes.Buffer)
+	rootCmd.SetOut(stdout)
+	rootCmd.SetArgs([]string{"baseline", "status", "--json"})
+
+	err := rootCmd.Execute()
+	require.NoError(t, err)
+
+	var parsed map[string]interface{}
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &parsed))
+	assert.Equal(t, float64(1), parsed["total"])
+	assert.Equal(t, float64(0), parsed["expired"])
+}
+
+func TestBaselineStatus_ExpiredWarning(t *testing.T) {
+	resetBaselineFlags()
+	dir := t.TempDir()
+
+	past := time.Now().Add(-time.Hour)
+	now := time.Now()
+	// 3 out of 4 expired (75%) - should trigger the >20% warning.
+	state := &baseline.BaselineState{
+		Version: "1",
+		Suppressions: []baseline.Suppression{
+			{SignalID: "str-aaaaaaaa", Reason: baseline.ReasonAcknowledged, SuppressedAt: now, ExpiresAt: &past},
+			{SignalID: "str-bbbbbbbb", Reason: baseline.ReasonAcknowledged, SuppressedAt: now, ExpiresAt: &past},
+			{SignalID: "str-cccccccc", Reason: baseline.ReasonAcknowledged, SuppressedAt: now, ExpiresAt: &past},
+			{SignalID: "str-dddddddd", Reason: baseline.ReasonAcknowledged, SuppressedAt: now},
+		},
+	}
+	require.NoError(t, baseline.Save(dir, state))
+
+	origDir, _ := os.Getwd()
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	stdout := new(bytes.Buffer)
+	rootCmd.SetOut(stdout)
+	rootCmd.SetArgs([]string{"baseline", "status"})
+
+	err := rootCmd.Execute()
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "Warning")
+	assert.Contains(t, stdout.String(), "baseline remove --expired")
+}
+
+// --- create tests ---
+
+func TestBaselineCreate_ExistingNoForce(t *testing.T) {
+	resetBaselineFlags()
+	dir := t.TempDir()
+
+	// Create a .git directory so resolveScanPath finds it.
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".git"), 0o750))
+
+	// Pre-create baseline.
+	state := &baseline.BaselineState{Version: "1", Suppressions: []baseline.Suppression{{SignalID: "str-aaaaaaaa"}}}
+	require.NoError(t, baseline.Save(dir, state))
+
+	stdout := new(bytes.Buffer)
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{"baseline", "create", dir})
+
+	err := rootCmd.Execute()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "--force")
+}
+
+func TestBaselineCreate_InvalidReason(t *testing.T) {
+	resetBaselineFlags()
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".git"), 0o750))
+
+	stdout := new(bytes.Buffer)
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{"baseline", "create", dir, "--reason", "bad-reason"})
+
+	err := rootCmd.Execute()
+	assert.Error(t, err)
+}
+
+// --- helper tests ---
+
+func TestParseDuration(t *testing.T) {
+	tests := []struct {
+		input   string
+		want    time.Duration
+		wantErr bool
+	}{
+		{"90d", 90 * 24 * time.Hour, false},
+		{"6m", 6 * 30 * 24 * time.Hour, false},
+		{"1y", 365 * 24 * time.Hour, false},
+		{"2w", 14 * 24 * time.Hour, false},
+		{"x", 0, true},
+		{"", 0, true},
+		{"abc", 0, true},
+		{"90z", 0, true},
+	}
+
+	for _, tc := range tests {
+		got, err := parseDuration(tc.input)
+		if tc.wantErr {
+			assert.Error(t, err, "parseDuration(%q) should error", tc.input)
+		} else {
+			require.NoError(t, err, "parseDuration(%q)", tc.input)
+			assert.Equal(t, tc.want, got, "parseDuration(%q)", tc.input)
+		}
+	}
+}
+
+func TestFormatAge(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		t    time.Time
+		want string
+	}{
+		{now.Add(-30 * time.Minute), "30m"},
+		{now.Add(-5 * time.Hour), "5h"},
+		{now.Add(-3 * 24 * time.Hour), "3d"},
+		{now.Add(-60 * 24 * time.Hour), "2mo"},
+		{now.Add(-400 * 24 * time.Hour), "1y"},
+	}
+
+	for _, tc := range tests {
+		got := formatAge(tc.t)
+		assert.Equal(t, tc.want, got)
+	}
+}
+
+func TestSignalIDPattern(t *testing.T) {
+	valid := []string{"str-abcd1234", "str-00000000", "str-ffffffff", "str-12345678"}
+	invalid := []string{"str-ABCD1234", "str-abc", "str-abcd12345", "abc-12345678", "invalid", "str-ghij1234"}
+
+	for _, id := range valid {
+		assert.True(t, signalIDPattern.MatchString(id), "expected %q to be valid", id)
+	}
+	for _, id := range invalid {
+		assert.False(t, signalIDPattern.MatchString(id), "expected %q to be invalid", id)
+	}
+}
+
+func TestBaselineRemove_InvalidID(t *testing.T) {
+	resetBaselineFlags()
+	dir := t.TempDir()
+
+	state := &baseline.BaselineState{
+		Version:      "1",
+		Suppressions: []baseline.Suppression{{SignalID: "str-aaaaaaaa", Reason: baseline.ReasonAcknowledged, SuppressedAt: time.Now()}},
+	}
+	require.NoError(t, baseline.Save(dir, state))
+
+	origDir, _ := os.Getwd()
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	stdout := new(bytes.Buffer)
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{"baseline", "remove", "bad-id"})
+
+	err := rootCmd.Execute()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid signal ID")
+}
+
+func TestBaselineSuppress_DefaultReason(t *testing.T) {
+	resetBaselineFlags()
+	dir := t.TempDir()
+
+	origDir, _ := os.Getwd()
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	stdout := new(bytes.Buffer)
+	rootCmd.SetOut(stdout)
+	rootCmd.SetArgs([]string{"baseline", "suppress", "str-abcd1234"})
+
+	err := rootCmd.Execute()
+	require.NoError(t, err)
+
+	state, err := baseline.Load(dir)
+	require.NoError(t, err)
+	assert.Equal(t, baseline.ReasonAcknowledged, state.Suppressions[0].Reason)
+}
+
+func TestFilterSuppressions(t *testing.T) {
+	past := time.Now().Add(-time.Hour)
+	future := time.Now().Add(time.Hour)
+
+	suppressions := []baseline.Suppression{
+		{SignalID: "a", Reason: baseline.ReasonAcknowledged, ExpiresAt: &past},
+		{SignalID: "b", Reason: baseline.ReasonWontFix, ExpiresAt: &future},
+		{SignalID: "c", Reason: baseline.ReasonAcknowledged},
+	}
+
+	// No filters.
+	baselineListReason = ""
+	baselineExpired = false
+	result := filterSuppressions(suppressions)
+	assert.Len(t, result, 3)
+
+	// Filter by reason.
+	baselineListReason = "acknowledged"
+	baselineExpired = false
+	result = filterSuppressions(suppressions)
+	assert.Len(t, result, 2)
+
+	// Filter expired.
+	baselineListReason = ""
+	baselineExpired = true
+	result = filterSuppressions(suppressions)
+	assert.Len(t, result, 1)
+	assert.Equal(t, "a", result[0].SignalID)
+
+	// Both filters.
+	baselineListReason = "acknowledged"
+	baselineExpired = true
+	result = filterSuppressions(suppressions)
+	assert.Len(t, result, 1)
+	assert.Equal(t, "a", result[0].SignalID)
+
+	// Reset.
+	baselineListReason = ""
+	baselineExpired = false
+}
+
+func TestBaselineList_NoBaselineFile(t *testing.T) {
+	resetBaselineFlags()
+	dir := t.TempDir()
+
+	origDir, _ := os.Getwd()
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	stdout := new(bytes.Buffer)
+	rootCmd.SetOut(stdout)
+	rootCmd.SetArgs([]string{"baseline", "list"})
+
+	err := rootCmd.Execute()
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "No suppressions")
+}
+
+func TestBaselineList_AllFilteredOut(t *testing.T) {
+	resetBaselineFlags()
+	dir := t.TempDir()
+
+	state := &baseline.BaselineState{
+		Version: "1",
+		Suppressions: []baseline.Suppression{
+			{SignalID: "str-aaaaaaaa", Reason: baseline.ReasonAcknowledged, SuppressedAt: time.Now()},
+		},
+	}
+	require.NoError(t, baseline.Save(dir, state))
+
+	origDir, _ := os.Getwd()
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	stdout := new(bytes.Buffer)
+	rootCmd.SetOut(stdout)
+	rootCmd.SetArgs([]string{"baseline", "list", "--reason", "won't-fix"})
+
+	err := rootCmd.Execute()
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "No suppressions")
+}
+
+// Ensure the suppress command works with default reason when --reason is not explicitly passed.
+// This tests that the flag detection via Changed() works correctly.
+func TestBaselineSuppress_ChangedFlagDetection(t *testing.T) {
+	resetBaselineFlags()
+	dir := t.TempDir()
+
+	origDir, _ := os.Getwd()
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	stdout := new(bytes.Buffer)
+	rootCmd.SetOut(stdout)
+	// No --reason flag provided; should default to "acknowledged".
+	rootCmd.SetArgs([]string{"baseline", "suppress", "str-12345678"})
+
+	err := rootCmd.Execute()
+	require.NoError(t, err)
+
+	state, err := baseline.Load(dir)
+	require.NoError(t, err)
+	require.Len(t, state.Suppressions, 1)
+	assert.Equal(t, baseline.ReasonAcknowledged, state.Suppressions[0].Reason)
+	assert.Contains(t, stdout.String(), "acknowledged")
+}
+
+func TestGitUserName(t *testing.T) {
+	// Just verify it returns a non-empty string (it will be either the git
+	// user name or "unknown").
+	name := gitUserName()
+	assert.NotEmpty(t, name)
+	assert.False(t, strings.ContainsAny(name, "\n\r"))
+}


### PR DESCRIPTION
## Summary

- Add `stringer baseline` parent command with `create`, `suppress`, `list`, `remove`, and `status` subcommands
- `create` runs a scan and baselines all signal IDs to `.stringer/baseline.json`
- `suppress` adds/updates individual suppressions with reason, comment, and expiry
- `list` shows suppressions in table or JSON format with reason/expired filters
- `remove` deletes by ID or removes all expired suppressions
- `status` provides summary stats with expired-percentage warning
- Comprehensive test coverage for all subcommands, edge cases, and helpers

Closes stringer-kv9.2
Closes stringer-kv9.3
Closes stringer-kv9.4
Closes stringer-kv9.6

## Test plan

- [x] `go build ./cmd/stringer/` compiles cleanly
- [x] `go test -race ./cmd/stringer/...` passes all new and existing tests
- [x] `golangci-lint run ./cmd/stringer/...` reports no issues
- [x] Suppress with valid/invalid signal IDs
- [x] List with --json, --reason, --expired filters
- [x] Remove by ID and --expired
- [x] Status with/without baseline, expired warning threshold
- [x] Create with --force, invalid reason, existing baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)