### PR TITLE
feat: SARIF baseline suppressions and comparison

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,7 @@ stringer/
 │   │   ├── beads.go            # Beads JSONL writer (primary)
 │   │   ├── json.go             # JSON with metadata envelope
 │   │   ├── markdown.go         # Human-readable markdown summary
-│   │   ├── sarif.go            # SARIF v2.1.0 static analysis output
+│   │   ├── sarif.go            # SARIF v2.1.0 output with suppressions + baseline comparison
 │   │   ├── tasks.go            # Claude Code task format
 │   │   └── signalid.go         # Shared deterministic signal ID generation
 │   ├── pipeline/           # Scan orchestration
@@ -218,6 +218,9 @@ golangci-lint run ./...
 
 # Skip baseline suppression filtering
 ./stringer scan /path/to/repo --no-baseline
+
+# SARIF with baseline comparison (marks results as new/unchanged/absent)
+./stringer scan /path/to/repo --format sarif --sarif-baseline previous.sarif -o current.sarif
 ```
 
 ## Key Design Decisions

--- a/cmd/stringer/scan.go
+++ b/cmd/stringer/scan.go
@@ -56,6 +56,7 @@ var (
 	scanWorkspace         string
 	scanNoWorkspaces      bool
 	scanNoBaseline        bool
+	scanSARIFBaseline     string
 )
 
 // scanCmd is the subcommand for scanning a repository.
@@ -99,6 +100,7 @@ func init() {
 	scanCmd.Flags().StringVar(&scanWorkspace, "workspace", "", "scan only named workspace(s) (comma-separated)")
 	scanCmd.Flags().BoolVar(&scanNoWorkspaces, "no-workspaces", false, "disable monorepo auto-detection, scan root as single directory")
 	scanCmd.Flags().BoolVar(&scanNoBaseline, "no-baseline", false, "skip baseline suppression filtering")
+	scanCmd.Flags().StringVar(&scanSARIFBaseline, "sarif-baseline", "", "previous SARIF file for baseline comparison (requires --format sarif)")
 }
 
 // scanContext holds shared state across the scan lifecycle, reducing parameter
@@ -112,8 +114,9 @@ type scanContext struct {
 	fileCfg         *config.Config
 	result          *signal.ScanResult
 	collectorNames  []string
-	allSignals      []signal.RawSignal // pre-filter signals for delta state
-	suppressedCount int                // count of baseline-suppressed signals
+	allSignals      []signal.RawSignal      // pre-filter signals for delta state
+	suppressedCount int                     // count of baseline-suppressed signals
+	baselineState   *baseline.BaselineState // retained for SARIF suppression mapping
 }
 
 func runScan(cmd *cobra.Command, args []string) error {
@@ -130,6 +133,18 @@ func runScan(cmd *cobra.Command, args []string) error {
 	if scanMinConfidence < 0 || scanMinConfidence > 1.0 {
 		return exitError(ExitInvalidArgs,
 			"stringer: --min-confidence must be between 0.0 and 1.0 (got %.2f)", scanMinConfidence)
+	}
+
+	// Validate --sarif-baseline requires --format sarif.
+	if scanSARIFBaseline != "" {
+		effectiveFormat := scanFormat
+		if ext := inferFormatFromExt(scanOutput); ext != "" && !cmd.Flags().Changed("format") {
+			effectiveFormat = ext
+		}
+		if effectiveFormat != "sarif" {
+			return exitError(ExitInvalidArgs,
+				"stringer: --sarif-baseline requires --format sarif")
+		}
 	}
 
 	sc := &scanContext{
@@ -173,19 +188,26 @@ func runScan(cmd *cobra.Command, args []string) error {
 		return printDryRun(cmd, sc.result, exitCode, sc.suppressedCount)
 	}
 
-	// 8. Write formatted output.
+	// 8. Configure SARIF formatter with baseline state if applicable.
+	if sc.scanCfg.OutputFormat == "sarif" {
+		if err := sc.configureSARIFFormatter(); err != nil {
+			return err
+		}
+	}
+
+	// 9. Write formatted output.
 	if err := writeScanOutput(cmd, sc.result, sc.scanCfg); err != nil {
 		return err
 	}
 
-	// 9. Save delta state from ALL signals (pre-filter), not just new ones.
+	// 10. Save delta state from ALL signals (pre-filter), not just new ones.
 	if scanDelta {
 		if err := saveDeltaState(absPath, sc.collectorNames, sc.allSignals, sc.workspaces); err != nil {
 			return exitError(ExitTotalFailure, "stringer: failed to save delta state (%v)", err)
 		}
 	}
 
-	// 10. Save scan history (best-effort).
+	// 11. Save scan history (best-effort).
 	if err := saveHistory(absPath, sc.result, sc.workspaces); err != nil {
 		slog.Warn("failed to save scan history", "error", err)
 	}
@@ -536,16 +558,24 @@ func (sc *scanContext) filterResults() error {
 	}
 
 	// Baseline suppression filter: remove signals that have been suppressed.
+	// For SARIF format, retain the baseline state so the formatter can emit
+	// SARIF suppressions instead of filtering signals out.
 	if !scanNoBaseline {
 		blState, blErr := baseline.Load(sc.absPath)
 		if blErr != nil {
 			slog.Warn("failed to load baseline", "error", blErr)
 		} else if blState != nil {
-			before := len(sc.result.Signals)
-			sc.result.Signals, sc.suppressedCount = pipeline.FilterSuppressed(
-				sc.result.Signals, blState, "str-")
-			slog.Info("baseline filter", "before", before, "after", len(sc.result.Signals),
-				"suppressed", sc.suppressedCount)
+			if sc.scanCfg.OutputFormat == "sarif" {
+				// SARIF format: keep all signals but save baseline for annotation.
+				sc.baselineState = blState
+				slog.Info("baseline loaded for SARIF suppressions", "count", len(blState.Suppressions))
+			} else {
+				before := len(sc.result.Signals)
+				sc.result.Signals, sc.suppressedCount = pipeline.FilterSuppressed(
+					sc.result.Signals, blState, "str-")
+				slog.Info("baseline filter", "before", before, "after", len(sc.result.Signals),
+					"suppressed", sc.suppressedCount)
+			}
 		}
 	}
 
@@ -696,6 +726,33 @@ func printDryRun(cmd *cobra.Command, result *signal.ScanResult, exitCode int, su
 	if exitCode != ExitOK {
 		return exitError(exitCode, "")
 	}
+	return nil
+}
+
+// configureSARIFFormatter sets baseline state and SARIF baseline on the
+// registered SARIF formatter so it can emit suppressions and baselineState.
+func (sc *scanContext) configureSARIFFormatter() error {
+	formatter, _ := output.GetFormatter("sarif")
+	sf, ok := formatter.(*output.SARIFFormatter)
+	if !ok {
+		return nil
+	}
+
+	// Wire baseline state for suppression mapping (SA5.1).
+	if sc.baselineState != nil {
+		sf.Baseline = sc.baselineState
+		sf.BaselinePrefix = "str-"
+	}
+
+	// Wire SARIF baseline for comparison (SA5.3).
+	if scanSARIFBaseline != "" {
+		doc, err := output.ParseSARIFBaseline(scanSARIFBaseline)
+		if err != nil {
+			return exitError(ExitInvalidArgs, "stringer: %v", err)
+		}
+		sf.SARIFBaseline = doc
+	}
+
 	return nil
 }
 

--- a/internal/output/sarif.go
+++ b/internal/output/sarif.go
@@ -13,6 +13,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/davetashner/stringer/internal/baseline"
 	"github.com/davetashner/stringer/internal/signal"
 	"github.com/google/uuid"
 )
@@ -37,6 +38,17 @@ type SARIFFormatter struct {
 
 	// NoSnippets disables code snippet embedding in results.
 	NoSnippets bool
+
+	// Baseline is the loaded baseline state. When set, results whose signal
+	// IDs match a suppression entry receive SARIF suppressions (§3.27.22).
+	// The prefix used for signal ID matching (e.g. "str-").
+	Baseline       *baseline.BaselineState
+	BaselinePrefix string
+
+	// SARIFBaseline is a previously-emitted SARIF document used for
+	// baseline comparison. When set, results receive baselineState
+	// values (new, unchanged, absent) per SARIF §3.27.24.
+	SARIFBaseline *sarifDocument
 }
 
 // Compile-time interface check.
@@ -122,10 +134,19 @@ type sarifResult struct {
 	RuleIndex           int                        `json:"ruleIndex"`
 	Level               string                     `json:"level"`
 	Rank                float64                    `json:"rank"`
+	BaselineState       string                     `json:"baselineState,omitempty"`
 	Message             sarifMultiformatMessage    `json:"message"`
 	Locations           []sarifLocation            `json:"locations,omitempty"`
+	Suppressions        []sarifSuppression         `json:"suppressions,omitempty"`
 	PartialFingerprints map[string]string          `json:"partialFingerprints,omitempty"`
 	Properties          map[string]json.RawMessage `json:"properties,omitempty"`
+}
+
+// sarifSuppression represents a SARIF suppression object (§3.27.22).
+type sarifSuppression struct {
+	Kind          string `json:"kind"`
+	Status        string `json:"status"`
+	Justification string `json:"justification,omitempty"`
 }
 
 type sarifLocation struct {
@@ -241,6 +262,15 @@ func (f *SARIFFormatter) buildRules(signals []signal.RawSignal) ([]sarifRule, ma
 func (f *SARIFFormatter) buildResults(signals []signal.RawSignal, ruleIndex map[string]int) []sarifResult {
 	results := make([]sarifResult, 0, len(signals))
 
+	// Build baseline lookup for suppression annotation.
+	blLookup := baseline.Lookup(f.Baseline)
+
+	// Build previous fingerprint set for baseline comparison.
+	var prevFingerprints map[string]bool
+	if f.SARIFBaseline != nil {
+		prevFingerprints = extractFingerprints(f.SARIFBaseline)
+	}
+
 	// File line cache for snippet extraction (path → lines).
 	fileCache := make(map[string][]string)
 
@@ -300,10 +330,117 @@ func (f *SARIFFormatter) buildResults(signals []signal.RawSignal, ruleIndex map[
 			result.Properties = props
 		}
 
+		// SA5.1: Map baseline suppressions to SARIF suppressions.
+		sigID := SignalID(sig, f.BaselinePrefix)
+		if sup, found := blLookup[sigID]; found && !baseline.IsExpired(sup) {
+			result.Suppressions = []sarifSuppression{
+				mapBaselineToSuppression(sup),
+			}
+		}
+
+		// SA5.3: Baseline comparison — assign baselineState.
+		if prevFingerprints != nil {
+			fp := result.PartialFingerprints["stringer/v1"]
+			if prevFingerprints[fp] {
+				result.BaselineState = "unchanged"
+			} else {
+				result.BaselineState = "new"
+			}
+		}
+
 		results = append(results, result)
 	}
 
+	// SA5.3: Emit absent results for fingerprints in previous but not current.
+	if prevFingerprints != nil {
+		currentFPs := make(map[string]bool, len(results))
+		for _, r := range results {
+			currentFPs[r.PartialFingerprints["stringer/v1"]] = true
+		}
+		absentResults := f.buildAbsentResults(prevFingerprints, currentFPs)
+		results = append(results, absentResults...)
+	}
+
 	return results
+}
+
+// mapBaselineToSuppression converts a baseline suppression reason to a SARIF
+// suppression object. Kind is always "external" (from baseline, not in-source).
+func mapBaselineToSuppression(sup baseline.Suppression) sarifSuppression {
+	s := sarifSuppression{
+		Kind:   "external",
+		Status: "accepted",
+	}
+	switch sup.Reason {
+	case baseline.ReasonAcknowledged:
+		// No justification needed, status is "accepted".
+	case baseline.ReasonWontFix:
+		s.Justification = "Won't fix"
+	case baseline.ReasonFalsePositive:
+		s.Justification = "False positive"
+	default:
+		// For any unrecognized reason, map to underReview.
+		s.Status = "underReview"
+	}
+
+	// Append the suppression note if present.
+	if sup.Comment != "" {
+		if s.Justification != "" {
+			s.Justification += ": " + sup.Comment
+		} else {
+			s.Justification = sup.Comment
+		}
+	}
+
+	return s
+}
+
+// extractFingerprints collects all stringer/v1 partialFingerprints from a
+// parsed SARIF document.
+func extractFingerprints(doc *sarifDocument) map[string]bool {
+	fps := make(map[string]bool)
+	for _, run := range doc.Runs {
+		for _, result := range run.Results {
+			if fp, ok := result.PartialFingerprints["stringer/v1"]; ok && fp != "" {
+				fps[fp] = true
+			}
+		}
+	}
+	return fps
+}
+
+// buildAbsentResults creates placeholder results for fingerprints that existed
+// in the previous SARIF baseline but are absent from the current scan.
+func (f *SARIFFormatter) buildAbsentResults(prevFPs map[string]bool, currentFPs map[string]bool) []sarifResult {
+	if f.SARIFBaseline == nil {
+		return nil
+	}
+
+	var absent []sarifResult
+	for _, run := range f.SARIFBaseline.Runs {
+		for _, prev := range run.Results {
+			fp := prev.PartialFingerprints["stringer/v1"]
+			if fp == "" || currentFPs[fp] {
+				continue
+			}
+			// Clone the previous result and mark as absent.
+			r := sarifResult{
+				RuleID:        prev.RuleID,
+				RuleIndex:     prev.RuleIndex,
+				Level:         prev.Level,
+				Rank:          prev.Rank,
+				BaselineState: "absent",
+				Message:       prev.Message,
+				Locations:     prev.Locations,
+				PartialFingerprints: map[string]string{
+					"stringer/v1": fp,
+				},
+				Properties: prev.Properties,
+			}
+			absent = append(absent, r)
+		}
+	}
+	return absent
 }
 
 // extractSnippet reads up to 3 lines of context around the target line.
@@ -456,6 +593,20 @@ func kindToCollector(kind string) string {
 		"local-replace": "dephealth", "retracted-version": "dephealth",
 	}
 	return collectorMap[kind]
+}
+
+// ParseSARIFBaseline reads a SARIF file and returns its parsed document.
+// This is used by --sarif-baseline to load the previous scan's output.
+func ParseSARIFBaseline(path string) (*sarifDocument, error) {
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		return nil, fmt.Errorf("read sarif baseline: %w", err)
+	}
+	var doc sarifDocument
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("parse sarif baseline: %w", err)
+	}
+	return &doc, nil
 }
 
 func mustMarshal(v any) json.RawMessage {

--- a/internal/output/sarif_test.go
+++ b/internal/output/sarif_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/davetashner/stringer/internal/baseline"
 	"github.com/davetashner/stringer/internal/signal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -585,4 +586,328 @@ func TestSARIFFormatter_Snippet_EmptyRepoPath(t *testing.T) {
 	region := doc.Runs[0].Results[0].Locations[0].PhysicalLocation.Region
 	require.NotNil(t, region)
 	assert.Nil(t, region.Snippet, "empty RepoPath should suppress snippets")
+}
+
+// --- SA5.1: Baseline suppression → SARIF suppression tests ---
+
+func TestSARIFFormatter_BaselineSuppressions(t *testing.T) {
+	// Create 5 signals, 3 of which are in the baseline.
+	signals := []signal.RawSignal{
+		{Source: "todos", Kind: "todo", FilePath: "a.go", Line: 1, Title: "TODO: fix A", Confidence: 0.5},
+		{Source: "todos", Kind: "todo", FilePath: "b.go", Line: 2, Title: "TODO: fix B", Confidence: 0.6},
+		{Source: "vuln", Kind: "vuln", FilePath: "go.mod", Line: 10, Title: "CVE-2024-001", Confidence: 0.9},
+		{Source: "todos", Kind: "fixme", FilePath: "c.go", Line: 3, Title: "FIXME: broken", Confidence: 0.7},
+		{Source: "gitlog", Kind: "churn", FilePath: "d.go", Line: 0, Title: "High churn", Confidence: 0.4},
+	}
+
+	// Build baseline with 3 suppressions matching signals 0, 2, 3.
+	prefix := "str-"
+	blState := &baseline.BaselineState{
+		Version: "1",
+		Suppressions: []baseline.Suppression{
+			{SignalID: SignalID(signals[0], prefix), Reason: baseline.ReasonAcknowledged, SuppressedAt: time.Now()},
+			{SignalID: SignalID(signals[2], prefix), Reason: baseline.ReasonWontFix, SuppressedAt: time.Now()},
+			{SignalID: SignalID(signals[3], prefix), Reason: baseline.ReasonFalsePositive, SuppressedAt: time.Now()},
+		},
+	}
+
+	f := NewSARIFFormatter()
+	f.Baseline = blState
+	f.BaselinePrefix = prefix
+
+	var buf bytes.Buffer
+	require.NoError(t, f.Format(signals, &buf))
+
+	var doc sarifDocument
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &doc))
+
+	results := doc.Runs[0].Results
+	require.Len(t, results, 5, "all 5 signals should appear in output")
+
+	// Signal 0: acknowledged → accepted, no justification.
+	require.Len(t, results[0].Suppressions, 1)
+	assert.Equal(t, "external", results[0].Suppressions[0].Kind)
+	assert.Equal(t, "accepted", results[0].Suppressions[0].Status)
+	assert.Empty(t, results[0].Suppressions[0].Justification)
+
+	// Signal 1: not suppressed → no suppressions.
+	assert.Empty(t, results[1].Suppressions)
+
+	// Signal 2: won't-fix → accepted + "Won't fix".
+	require.Len(t, results[2].Suppressions, 1)
+	assert.Equal(t, "external", results[2].Suppressions[0].Kind)
+	assert.Equal(t, "accepted", results[2].Suppressions[0].Status)
+	assert.Equal(t, "Won't fix", results[2].Suppressions[0].Justification)
+
+	// Signal 3: false-positive → accepted + "False positive".
+	require.Len(t, results[3].Suppressions, 1)
+	assert.Equal(t, "external", results[3].Suppressions[0].Kind)
+	assert.Equal(t, "accepted", results[3].Suppressions[0].Status)
+	assert.Equal(t, "False positive", results[3].Suppressions[0].Justification)
+
+	// Signal 4: not suppressed → no suppressions.
+	assert.Empty(t, results[4].Suppressions)
+}
+
+func TestSARIFFormatter_BaselineSuppressions_NoBaseline(t *testing.T) {
+	f := NewSARIFFormatter()
+	// Baseline is nil → no suppressions emitted.
+
+	signals := []signal.RawSignal{
+		{Kind: "todo", Title: "test", Confidence: 0.5},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, f.Format(signals, &buf))
+
+	var doc sarifDocument
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &doc))
+
+	assert.Empty(t, doc.Runs[0].Results[0].Suppressions)
+}
+
+func TestSARIFFormatter_BaselineSuppressions_ExpiredSkipped(t *testing.T) {
+	sig := signal.RawSignal{Source: "todos", Kind: "todo", FilePath: "a.go", Line: 1, Title: "TODO", Confidence: 0.5}
+	prefix := "str-"
+	expired := time.Now().Add(-24 * time.Hour)
+
+	blState := &baseline.BaselineState{
+		Version: "1",
+		Suppressions: []baseline.Suppression{
+			{SignalID: SignalID(sig, prefix), Reason: baseline.ReasonAcknowledged, SuppressedAt: time.Now(), ExpiresAt: &expired},
+		},
+	}
+
+	f := NewSARIFFormatter()
+	f.Baseline = blState
+	f.BaselinePrefix = prefix
+
+	var buf bytes.Buffer
+	require.NoError(t, f.Format([]signal.RawSignal{sig}, &buf))
+
+	var doc sarifDocument
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &doc))
+
+	assert.Empty(t, doc.Runs[0].Results[0].Suppressions, "expired suppressions should not emit SARIF suppression")
+}
+
+func TestSARIFFormatter_BaselineSuppressions_WithComment(t *testing.T) {
+	sig := signal.RawSignal{Source: "todos", Kind: "todo", FilePath: "a.go", Line: 1, Title: "TODO", Confidence: 0.5}
+	prefix := "str-"
+
+	blState := &baseline.BaselineState{
+		Version: "1",
+		Suppressions: []baseline.Suppression{
+			{SignalID: SignalID(sig, prefix), Reason: baseline.ReasonWontFix, Comment: "tracked elsewhere", SuppressedAt: time.Now()},
+		},
+	}
+
+	f := NewSARIFFormatter()
+	f.Baseline = blState
+	f.BaselinePrefix = prefix
+
+	var buf bytes.Buffer
+	require.NoError(t, f.Format([]signal.RawSignal{sig}, &buf))
+
+	var doc sarifDocument
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &doc))
+
+	require.Len(t, doc.Runs[0].Results[0].Suppressions, 1)
+	assert.Equal(t, "Won't fix: tracked elsewhere", doc.Runs[0].Results[0].Suppressions[0].Justification)
+}
+
+func TestMapBaselineToSuppression(t *testing.T) {
+	tests := []struct {
+		name        string
+		reason      baseline.Reason
+		comment     string
+		wantStatus  string
+		wantJustify string
+	}{
+		{"acknowledged", baseline.ReasonAcknowledged, "", "accepted", ""},
+		{"wont-fix", baseline.ReasonWontFix, "", "accepted", "Won't fix"},
+		{"false-positive", baseline.ReasonFalsePositive, "", "accepted", "False positive"},
+		{"acknowledged with comment", baseline.ReasonAcknowledged, "see ticket", "accepted", "see ticket"},
+		{"wont-fix with comment", baseline.ReasonWontFix, "low priority", "accepted", "Won't fix: low priority"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sup := baseline.Suppression{
+				Reason:  tt.reason,
+				Comment: tt.comment,
+			}
+			result := mapBaselineToSuppression(sup)
+			assert.Equal(t, "external", result.Kind)
+			assert.Equal(t, tt.wantStatus, result.Status)
+			assert.Equal(t, tt.wantJustify, result.Justification)
+		})
+	}
+}
+
+// --- SA5.3: SARIF baseline comparison tests ---
+
+func TestSARIFFormatter_BaselineComparison(t *testing.T) {
+	// Create 5 signals for the "previous" baseline SARIF.
+	prevSignals := []signal.RawSignal{
+		{Source: "todos", Kind: "todo", FilePath: "a.go", Line: 1, Title: "TODO: fix A", Confidence: 0.5},
+		{Source: "todos", Kind: "todo", FilePath: "b.go", Line: 2, Title: "TODO: fix B", Confidence: 0.6},
+		{Source: "vuln", Kind: "vuln", FilePath: "go.mod", Line: 10, Title: "CVE-2024-001", Confidence: 0.9},
+		{Source: "todos", Kind: "fixme", FilePath: "c.go", Line: 3, Title: "FIXME: broken", Confidence: 0.7},
+		{Source: "gitlog", Kind: "churn", FilePath: "d.go", Line: 5, Title: "High churn", Confidence: 0.4},
+	}
+
+	// Build previous SARIF document.
+	prevFormatter := NewSARIFFormatter()
+	var prevBuf bytes.Buffer
+	require.NoError(t, prevFormatter.Format(prevSignals, &prevBuf))
+	var prevDoc sarifDocument
+	require.NoError(t, json.Unmarshal(prevBuf.Bytes(), &prevDoc))
+
+	// Current scan has 5 signals: 3 unchanged (0,1,2) + 2 new (4,5).
+	// Signal 3 and 4 from previous are absent.
+	currentSignals := []signal.RawSignal{
+		prevSignals[0], // unchanged
+		prevSignals[1], // unchanged
+		prevSignals[2], // unchanged
+		{Source: "todos", Kind: "hack", FilePath: "e.go", Line: 1, Title: "HACK: workaround", Confidence: 0.3}, // new
+		{Source: "vuln", Kind: "vuln", FilePath: "go.mod", Line: 20, Title: "CVE-2024-999", Confidence: 0.8},   // new
+	}
+
+	f := NewSARIFFormatter()
+	f.SARIFBaseline = &prevDoc
+
+	var buf bytes.Buffer
+	require.NoError(t, f.Format(currentSignals, &buf))
+
+	var doc sarifDocument
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &doc))
+
+	results := doc.Runs[0].Results
+
+	// 5 current + 2 absent = 7 total results.
+	require.Len(t, results, 7, "should have 5 current + 2 absent results")
+
+	// First 3 should be unchanged.
+	assert.Equal(t, "unchanged", results[0].BaselineState)
+	assert.Equal(t, "unchanged", results[1].BaselineState)
+	assert.Equal(t, "unchanged", results[2].BaselineState)
+
+	// Next 2 should be new.
+	assert.Equal(t, "new", results[3].BaselineState)
+	assert.Equal(t, "new", results[4].BaselineState)
+
+	// Last 2 should be absent.
+	assert.Equal(t, "absent", results[5].BaselineState)
+	assert.Equal(t, "absent", results[6].BaselineState)
+
+	// Verify absent results have correct fingerprints from previous.
+	for _, r := range results[5:] {
+		assert.NotEmpty(t, r.PartialFingerprints["stringer/v1"])
+	}
+}
+
+func TestSARIFFormatter_NoBaselineComparison_NoBaselineState(t *testing.T) {
+	f := NewSARIFFormatter()
+	// SARIFBaseline is nil → no baselineState on results.
+
+	signals := []signal.RawSignal{
+		{Kind: "todo", Title: "test", Confidence: 0.5},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, f.Format(signals, &buf))
+
+	var doc sarifDocument
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &doc))
+
+	assert.Empty(t, doc.Runs[0].Results[0].BaselineState, "no baselineState when SARIFBaseline is nil")
+}
+
+func TestSARIFFormatter_BaselineComparison_AllNew(t *testing.T) {
+	// Empty previous doc.
+	prevDoc := sarifDocument{
+		Version: "2.1.0",
+		Runs:    []sarifRun{{Results: []sarifResult{}}},
+	}
+
+	f := NewSARIFFormatter()
+	f.SARIFBaseline = &prevDoc
+
+	signals := []signal.RawSignal{
+		{Kind: "todo", Title: "new signal", Confidence: 0.5},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, f.Format(signals, &buf))
+
+	var doc sarifDocument
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &doc))
+
+	require.Len(t, doc.Runs[0].Results, 1)
+	assert.Equal(t, "new", doc.Runs[0].Results[0].BaselineState)
+}
+
+func TestSARIFFormatter_BaselineComparison_AllAbsent(t *testing.T) {
+	prevSignals := []signal.RawSignal{
+		{Source: "todos", Kind: "todo", FilePath: "a.go", Line: 1, Title: "old signal", Confidence: 0.5},
+	}
+
+	prevFormatter := NewSARIFFormatter()
+	var prevBuf bytes.Buffer
+	require.NoError(t, prevFormatter.Format(prevSignals, &prevBuf))
+	var prevDoc sarifDocument
+	require.NoError(t, json.Unmarshal(prevBuf.Bytes(), &prevDoc))
+
+	f := NewSARIFFormatter()
+	f.SARIFBaseline = &prevDoc
+
+	// Empty current signals → the previous signal is absent.
+	var buf bytes.Buffer
+	require.NoError(t, f.Format([]signal.RawSignal{}, &buf))
+
+	var doc sarifDocument
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &doc))
+
+	require.Len(t, doc.Runs[0].Results, 1)
+	assert.Equal(t, "absent", doc.Runs[0].Results[0].BaselineState)
+	assert.Equal(t, "old signal", doc.Runs[0].Results[0].Message.Text)
+}
+
+func TestParseSARIFBaseline(t *testing.T) {
+	// Write a valid SARIF file and parse it.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "baseline.sarif")
+
+	f := NewSARIFFormatter()
+	signals := []signal.RawSignal{
+		{Source: "todos", Kind: "todo", FilePath: "a.go", Line: 1, Title: "test", Confidence: 0.5},
+	}
+	var buf bytes.Buffer
+	require.NoError(t, f.Format(signals, &buf))
+	require.NoError(t, os.WriteFile(path, buf.Bytes(), 0o600))
+
+	doc, err := ParseSARIFBaseline(path)
+	require.NoError(t, err)
+	require.NotNil(t, doc)
+	assert.Equal(t, "2.1.0", doc.Version)
+	require.Len(t, doc.Runs, 1)
+	require.Len(t, doc.Runs[0].Results, 1)
+	assert.NotEmpty(t, doc.Runs[0].Results[0].PartialFingerprints["stringer/v1"])
+}
+
+func TestParseSARIFBaseline_NotFound(t *testing.T) {
+	_, err := ParseSARIFBaseline("/nonexistent/path.sarif")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "read sarif baseline")
+}
+
+func TestParseSARIFBaseline_InvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.sarif")
+	require.NoError(t, os.WriteFile(path, []byte("not json"), 0o600))
+
+	_, err := ParseSARIFBaseline(path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parse sarif baseline")
 }


### PR DESCRIPTION
## Summary

- **SA5.1**: Map baseline suppressions to SARIF suppression objects (§3.27.22). Baseline reasons (`acknowledged`, `won't-fix`, `false-positive`) map to SARIF suppressions with `kind: external`, `status: accepted`, and appropriate justification text. When outputting SARIF format, suppressed signals remain in the output with suppressions attached instead of being filtered out.

- **SA5.3**: Add `--sarif-baseline previous.sarif` flag for baseline comparison. Results matched by `partialFingerprints[stringer/v1]` get `baselineState` values: `unchanged` (present in both), `new` (only in current), or `absent` (only in previous). The flag validates that `--format sarif` is also set.

## Test plan

- [x] 3 baseline suppressions → 3 results with suppressions arrays, 2 without
- [x] Acknowledged → accepted (no justification)
- [x] Won't-fix → accepted + "Won't fix"
- [x] False-positive → accepted + "False positive"
- [x] Expired suppressions not emitted
- [x] Suppression comments appended to justification
- [x] No suppressions when baseline is nil
- [x] 5 baseline signals, 3 unchanged + 2 new + 2 absent → correct baselineState
- [x] No baselineState when --sarif-baseline not used
- [x] All-new and all-absent edge cases
- [x] ParseSARIFBaseline: valid file, missing file, invalid JSON
- [x] --sarif-baseline validates --format sarif requirement
- [x] Build, tests, and linter all pass

Closes stringer-175.1
Closes stringer-175.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)