### PR TITLE
refactor: extract shared symlink safety check in collectors

### DIFF
--- a/internal/collectors/complexity.go
+++ b/internal/collectors/complexity.go
@@ -202,14 +202,8 @@ func (c *ComplexityCollector) Collect(ctx context.Context, repoPath string, opts
 		}
 
 		// Skip symlinks outside repo tree.
-		if d.Type()&os.ModeSymlink != 0 {
-			resolved, resolveErr := FS.EvalSymlinks(path)
-			if resolveErr != nil {
-				return nil
-			}
-			if !strings.HasPrefix(resolved, repoPath+string(filepath.Separator)) && resolved != repoPath {
-				return nil
-			}
+		if d.Type()&os.ModeSymlink != 0 && isSymlinkOutsideRepo(path, repoPath) {
+			return nil
 		}
 
 		if len(opts.IncludePatterns) > 0 && !matchesAny(relPath, opts.IncludePatterns) {

--- a/internal/collectors/coupling.go
+++ b/internal/collectors/coupling.go
@@ -101,14 +101,8 @@ func (c *CouplingCollector) Collect(ctx context.Context, repoPath string, opts s
 		}
 
 		// Skip symlinks outside repo tree.
-		if d.Type()&os.ModeSymlink != 0 {
-			resolved, resolveErr := FS.EvalSymlinks(path)
-			if resolveErr != nil {
-				return nil
-			}
-			if !strings.HasPrefix(resolved, repoPath+string(filepath.Separator)) && resolved != repoPath {
-				return nil
-			}
+		if d.Type()&os.ModeSymlink != 0 && isSymlinkOutsideRepo(path, repoPath) {
+			return nil
 		}
 
 		if len(opts.IncludePatterns) > 0 && !matchesAny(relPath, opts.IncludePatterns) {

--- a/internal/collectors/deadcode.go
+++ b/internal/collectors/deadcode.go
@@ -198,14 +198,8 @@ func (c *DeadCodeCollector) Collect(ctx context.Context, repoPath string, opts s
 		}
 
 		// Skip symlinks outside repo tree.
-		if d.Type()&os.ModeSymlink != 0 {
-			resolved, resolveErr := FS.EvalSymlinks(path)
-			if resolveErr != nil {
-				return nil
-			}
-			if !strings.HasPrefix(resolved, repoPath+string(filepath.Separator)) && resolved != repoPath {
-				return nil
-			}
+		if d.Type()&os.ModeSymlink != 0 && isSymlinkOutsideRepo(path, repoPath) {
+			return nil
 		}
 
 		if len(opts.IncludePatterns) > 0 && !matchesAny(relPath, opts.IncludePatterns) {

--- a/internal/collectors/duplication.go
+++ b/internal/collectors/duplication.go
@@ -97,14 +97,8 @@ func (c *DuplicationCollector) Collect(ctx context.Context, repoPath string, opt
 		}
 
 		// Skip symlinks outside repo tree.
-		if d.Type()&os.ModeSymlink != 0 {
-			resolved, resolveErr := FS.EvalSymlinks(path)
-			if resolveErr != nil {
-				return nil
-			}
-			if !strings.HasPrefix(resolved, repoPath+string(filepath.Separator)) && resolved != repoPath {
-				return nil
-			}
+		if d.Type()&os.ModeSymlink != 0 && isSymlinkOutsideRepo(path, repoPath) {
+			return nil
 		}
 
 		if len(opts.IncludePatterns) > 0 && !matchesAny(relPath, opts.IncludePatterns) {

--- a/internal/collectors/githygiene.go
+++ b/internal/collectors/githygiene.go
@@ -112,14 +112,8 @@ func (c *GitHygieneCollector) Collect(ctx context.Context, repoPath string, opts
 		}
 
 		// Skip symlinks outside repo tree.
-		if d.Type()&os.ModeSymlink != 0 {
-			resolved, resolveErr := FS.EvalSymlinks(path)
-			if resolveErr != nil {
-				return nil
-			}
-			if !strings.HasPrefix(resolved, repoPath+string(filepath.Separator)) && resolved != repoPath {
-				return nil
-			}
+		if d.Type()&os.ModeSymlink != 0 && isSymlinkOutsideRepo(path, repoPath) {
+			return nil
 		}
 
 		if len(opts.IncludePatterns) > 0 && !matchesAny(relPath, opts.IncludePatterns) {

--- a/internal/collectors/patterns.go
+++ b/internal/collectors/patterns.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"strings"
 
 	"github.com/davetashner/stringer/internal/collector"
 	"github.com/davetashner/stringer/internal/gitcli"
@@ -168,14 +167,8 @@ func (c *PatternsCollector) Collect(ctx context.Context, repoPath string, opts s
 		}
 
 		// Skip symlinks that resolve outside the repo tree.
-		if d.Type()&os.ModeSymlink != 0 {
-			resolved, resolveErr := FS.EvalSymlinks(path)
-			if resolveErr != nil {
-				return nil
-			}
-			if !strings.HasPrefix(resolved, repoPath+string(filepath.Separator)) && resolved != repoPath {
-				return nil
-			}
+		if d.Type()&os.ModeSymlink != 0 && isSymlinkOutsideRepo(path, repoPath) {
+			return nil
 		}
 
 		// Apply include-pattern filtering if patterns are set.

--- a/internal/collectors/symlink.go
+++ b/internal/collectors/symlink.go
@@ -1,0 +1,20 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
+package collectors
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// isSymlinkOutsideRepo returns true if path resolves to a location outside repoRoot.
+// It also returns true when the symlink cannot be resolved, treating unresolvable
+// symlinks as outside the repo for safety.
+func isSymlinkOutsideRepo(path, repoRoot string) bool {
+	resolved, err := FS.EvalSymlinks(path)
+	if err != nil {
+		return true
+	}
+	return !strings.HasPrefix(resolved, repoRoot+string(filepath.Separator)) && resolved != repoRoot
+}

--- a/internal/collectors/symlink_test.go
+++ b/internal/collectors/symlink_test.go
@@ -1,0 +1,94 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
+package collectors
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/davetashner/stringer/internal/testable"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsSymlinkOutsideRepo_InsideRepo(t *testing.T) {
+	dir := t.TempDir()
+	child := filepath.Join(dir, "sub", "file.go")
+	require := assert.New(t)
+
+	oldFS := FS
+	defer func() { FS = oldFS }()
+
+	FS = &testable.MockFileSystem{
+		EvalSymlinksFn: func(_ string) (string, error) {
+			return child, nil
+		},
+	}
+
+	require.False(isSymlinkOutsideRepo(child, dir))
+}
+
+func TestIsSymlinkOutsideRepo_OutsideRepo(t *testing.T) {
+	repoRoot := filepath.Join(os.TempDir(), "repo")
+	outsidePath := filepath.Join(os.TempDir(), "outside", "secret.go")
+
+	oldFS := FS
+	defer func() { FS = oldFS }()
+
+	FS = &testable.MockFileSystem{
+		EvalSymlinksFn: func(_ string) (string, error) {
+			return outsidePath, nil
+		},
+	}
+
+	assert.True(t, isSymlinkOutsideRepo("/some/link", repoRoot))
+}
+
+func TestIsSymlinkOutsideRepo_NonSymlink(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "real.go")
+
+	oldFS := FS
+	defer func() { FS = oldFS }()
+
+	// EvalSymlinks on a real file returns the same path.
+	FS = &testable.MockFileSystem{
+		EvalSymlinksFn: func(_ string) (string, error) {
+			return file, nil
+		},
+	}
+
+	assert.False(t, isSymlinkOutsideRepo(file, dir))
+}
+
+func TestIsSymlinkOutsideRepo_EvalError(t *testing.T) {
+	oldFS := FS
+	defer func() { FS = oldFS }()
+
+	FS = &testable.MockFileSystem{
+		EvalSymlinksFn: func(_ string) (string, error) {
+			return "", fmt.Errorf("permission denied")
+		},
+	}
+
+	assert.True(t, isSymlinkOutsideRepo("/any/path", "/repo"))
+}
+
+func TestIsSymlinkOutsideRepo_ExactRepoRoot(t *testing.T) {
+	repoRoot := filepath.Join(os.TempDir(), "repo")
+
+	oldFS := FS
+	defer func() { FS = oldFS }()
+
+	// A symlink that resolves to exactly the repo root should not be
+	// considered outside.
+	FS = &testable.MockFileSystem{
+		EvalSymlinksFn: func(_ string) (string, error) {
+			return repoRoot, nil
+		},
+	}
+
+	assert.False(t, isSymlinkOutsideRepo("/some/link", repoRoot))
+}

--- a/internal/collectors/todos.go
+++ b/internal/collectors/todos.go
@@ -176,14 +176,8 @@ func (c *TodoCollector) Collect(ctx context.Context, repoPath string, opts signa
 		}
 
 		// Skip symlinks that resolve outside the repo tree to prevent traversal.
-		if d.Type()&os.ModeSymlink != 0 {
-			resolved, resolveErr := FS.EvalSymlinks(path)
-			if resolveErr != nil {
-				return nil // skip unresolvable symlinks
-			}
-			if !strings.HasPrefix(resolved, repoPath+string(filepath.Separator)) && resolved != repoPath {
-				return nil
-			}
+		if d.Type()&os.ModeSymlink != 0 && isSymlinkOutsideRepo(path, repoPath) {
+			return nil
 		}
 
 		// Apply include-pattern filtering if patterns are set.


### PR DESCRIPTION
## Summary

- Extract duplicated symlink-outside-repo check from 7 collectors into shared `isSymlinkOutsideRepo` helper in `internal/collectors/symlink.go`
- Affected collectors: todos, duplication, coupling, patterns, complexity, deadcode, githygiene
- Net reduction: 57 lines removed, 14 added across collector files (plus new helper + test)
- Zero behavioral change — pure DRY extraction

## Test plan

- [x] `symlink_test.go` — 5 cases: inside repo, outside repo, non-symlink, EvalSymlinks error, exact root match
- [x] Full test suite passes with `-race`
- [x] golangci-lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)