### PR TITLE
feat: add workspace metadata to dry-run output

### DIFF
--- a/cmd/stringer/scan.go
+++ b/cmd/stringer/scan.go
@@ -185,7 +185,7 @@ func runScan(cmd *cobra.Command, args []string) error {
 
 	// 7. Handle dry-run.
 	if scanDryRun {
-		return printDryRun(cmd, sc.result, exitCode, sc.suppressedCount)
+		return printDryRun(cmd, sc.result, exitCode, sc.suppressedCount, sc.workspaces)
 	}
 
 	// 8. Configure SARIF formatter with baseline state if applicable.
@@ -676,8 +676,14 @@ func computeExitCode(result *signal.ScanResult, strict bool) int {
 	}
 }
 
+// workspaceSummary describes a workspace for dry-run output.
+type workspaceSummary struct {
+	Name string `json:"name"`
+	Path string `json:"path"`
+}
+
 // printDryRun prints a summary of the scan results without producing formatted output.
-func printDryRun(cmd *cobra.Command, result *signal.ScanResult, exitCode int, suppressedCount int) error {
+func printDryRun(cmd *cobra.Command, result *signal.ScanResult, exitCode int, suppressedCount int, workspaces []workspaceEntry) error {
 	if scanJSON {
 		type collectorSummary struct {
 			Name     string `json:"name"`
@@ -689,6 +695,7 @@ func printDryRun(cmd *cobra.Command, result *signal.ScanResult, exitCode int, su
 			TotalSignals    int                `json:"total_signals"`
 			SuppressedCount int                `json:"suppressed_count"`
 			Collectors      []collectorSummary `json:"collectors"`
+			Workspaces      []workspaceSummary `json:"workspaces,omitempty"`
 			Duration        string             `json:"duration"`
 			ExitCode        int                `json:"exit_code"`
 		}
@@ -710,6 +717,14 @@ func printDryRun(cmd *cobra.Command, result *signal.ScanResult, exitCode int, su
 			}
 			out.Collectors = append(out.Collectors, cs)
 		}
+		for _, ws := range workspaces {
+			if ws.Name != "" {
+				out.Workspaces = append(out.Workspaces, workspaceSummary{
+					Name: ws.Name,
+					Path: ws.Rel,
+				})
+			}
+		}
 
 		data, err := json.MarshalIndent(out, "", "  ")
 		if err != nil {
@@ -724,6 +739,17 @@ func printDryRun(cmd *cobra.Command, result *signal.ScanResult, exitCode int, su
 				status = fmt.Sprintf("error: %v", cr.Err)
 			}
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  %s: %s (%s)\n", cr.Collector, status, cr.Duration.Round(1_000_000))
+		}
+		// Show detected workspaces (monorepo mode).
+		hasNamed := false
+		for _, ws := range workspaces {
+			if ws.Name != "" {
+				if !hasNamed {
+					_, _ = fmt.Fprintln(cmd.OutOrStdout(), "workspaces:")
+					hasNamed = true
+				}
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  %s (%s)\n", ws.Name, ws.Rel)
+			}
 		}
 	}
 

--- a/cmd/stringer/scan_unit_test.go
+++ b/cmd/stringer/scan_unit_test.go
@@ -219,7 +219,7 @@ func TestPrintDryRun_TextMode(t *testing.T) {
 		Duration: 50 * time.Millisecond,
 	}
 
-	err := printDryRun(cmd, result, ExitOK, 0)
+	err := printDryRun(cmd, result, ExitOK, 0, nil)
 	require.NoError(t, err)
 
 	out := buf.String()
@@ -251,7 +251,7 @@ func TestPrintDryRun_TextModeWithError(t *testing.T) {
 		Duration: 10 * time.Millisecond,
 	}
 
-	err := printDryRun(cmd, result, ExitTotalFailure, 0)
+	err := printDryRun(cmd, result, ExitTotalFailure, 0, nil)
 	require.Error(t, err)
 
 	var ece *exitCodeError
@@ -296,7 +296,7 @@ func TestPrintDryRun_JSONMode(t *testing.T) {
 		Duration: 250 * time.Millisecond,
 	}
 
-	err := printDryRun(cmd, result, ExitOK, 0)
+	err := printDryRun(cmd, result, ExitOK, 0, nil)
 	require.NoError(t, err)
 
 	var parsed struct {
@@ -348,7 +348,7 @@ func TestPrintDryRun_JSONModeWithErrors(t *testing.T) {
 		Duration: 60 * time.Millisecond,
 	}
 
-	err := printDryRun(cmd, result, ExitPartialFailure, 0)
+	err := printDryRun(cmd, result, ExitPartialFailure, 0, nil)
 	require.Error(t, err)
 
 	var ece *exitCodeError
@@ -386,7 +386,7 @@ func TestPrintDryRun_ExitOKReturnsNil(t *testing.T) {
 		Duration: 1 * time.Millisecond,
 	}
 
-	err := printDryRun(cmd, result, ExitOK, 0)
+	err := printDryRun(cmd, result, ExitOK, 0, nil)
 	assert.NoError(t, err)
 }
 
@@ -418,7 +418,7 @@ func TestPrintDryRun_TextModeMultipleCollectors(t *testing.T) {
 		Duration: 250 * time.Millisecond,
 	}
 
-	err := printDryRun(cmd, result, ExitOK, 0)
+	err := printDryRun(cmd, result, ExitOK, 0, nil)
 	require.NoError(t, err)
 
 	out := buf.String()
@@ -442,7 +442,7 @@ func TestPrintDryRun_JSONModeZeroSignals(t *testing.T) {
 		Duration: 5 * time.Millisecond,
 	}
 
-	err := printDryRun(cmd, result, ExitOK, 0)
+	err := printDryRun(cmd, result, ExitOK, 0, nil)
 	require.NoError(t, err)
 
 	var parsed struct {
@@ -452,6 +452,129 @@ func TestPrintDryRun_JSONModeZeroSignals(t *testing.T) {
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &parsed))
 	assert.Equal(t, 0, parsed.TotalSignals)
 	assert.Equal(t, 0, parsed.ExitCode)
+}
+
+func TestPrintDryRun_JSONModeWithWorkspaces(t *testing.T) {
+	resetScanFlags()
+	scanDryRun = true
+	scanJSON = true
+
+	cmd := &cobra.Command{}
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+
+	result := &signal.ScanResult{
+		Signals: []signal.RawSignal{{Title: "s1"}},
+		Results: []signal.CollectorResult{
+			{Collector: "todos", Signals: []signal.RawSignal{{Title: "s1"}}, Duration: 10 * time.Millisecond},
+		},
+		Duration: 15 * time.Millisecond,
+	}
+
+	workspaces := []workspaceEntry{
+		{Name: "svc-a", Path: "/root/svc-a", Rel: "svc-a"},
+		{Name: "svc-b", Path: "/root/svc-b", Rel: "svc-b"},
+	}
+
+	err := printDryRun(cmd, result, ExitOK, 0, workspaces)
+	require.NoError(t, err)
+
+	var parsed struct {
+		TotalSignals int `json:"total_signals"`
+		Workspaces   []struct {
+			Name string `json:"name"`
+			Path string `json:"path"`
+		} `json:"workspaces"`
+	}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &parsed))
+	require.Len(t, parsed.Workspaces, 2)
+	assert.Equal(t, "svc-a", parsed.Workspaces[0].Name)
+	assert.Equal(t, "svc-a", parsed.Workspaces[0].Path)
+	assert.Equal(t, "svc-b", parsed.Workspaces[1].Name)
+	assert.Equal(t, "svc-b", parsed.Workspaces[1].Path)
+}
+
+func TestPrintDryRun_JSONModeNoNamedWorkspaces(t *testing.T) {
+	resetScanFlags()
+	scanDryRun = true
+	scanJSON = true
+
+	cmd := &cobra.Command{}
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+
+	result := &signal.ScanResult{
+		Signals:  nil,
+		Results:  nil,
+		Duration: 5 * time.Millisecond,
+	}
+
+	// Single non-monorepo workspace (empty name) should omit workspaces field.
+	workspaces := []workspaceEntry{
+		{Name: "", Path: "/root", Rel: "."},
+	}
+
+	err := printDryRun(cmd, result, ExitOK, 0, workspaces)
+	require.NoError(t, err)
+
+	// The "workspaces" key should not appear in JSON output.
+	assert.NotContains(t, buf.String(), `"workspaces"`)
+}
+
+func TestPrintDryRun_TextModeWithWorkspaces(t *testing.T) {
+	resetScanFlags()
+	scanDryRun = true
+	scanJSON = false
+
+	cmd := &cobra.Command{}
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+
+	result := &signal.ScanResult{
+		Signals: []signal.RawSignal{{Title: "s1"}},
+		Results: []signal.CollectorResult{
+			{Collector: "todos", Signals: []signal.RawSignal{{Title: "s1"}}, Duration: 10 * time.Millisecond},
+		},
+		Duration: 15 * time.Millisecond,
+	}
+
+	workspaces := []workspaceEntry{
+		{Name: "frontend", Path: "/root/frontend", Rel: "frontend"},
+		{Name: "backend", Path: "/root/backend", Rel: "backend"},
+	}
+
+	err := printDryRun(cmd, result, ExitOK, 0, workspaces)
+	require.NoError(t, err)
+
+	out := buf.String()
+	assert.Contains(t, out, "workspaces:")
+	assert.Contains(t, out, "frontend (frontend)")
+	assert.Contains(t, out, "backend (backend)")
+}
+
+func TestPrintDryRun_TextModeNoNamedWorkspaces(t *testing.T) {
+	resetScanFlags()
+	scanDryRun = true
+	scanJSON = false
+
+	cmd := &cobra.Command{}
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+
+	result := &signal.ScanResult{
+		Signals:  nil,
+		Results:  nil,
+		Duration: 5 * time.Millisecond,
+	}
+
+	workspaces := []workspaceEntry{
+		{Name: "", Path: "/root", Rel: "."},
+	}
+
+	err := printDryRun(cmd, result, ExitOK, 0, workspaces)
+	require.NoError(t, err)
+
+	assert.NotContains(t, buf.String(), "workspaces:")
 }
 
 // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add `workspaces` field to `--dry-run` JSON output (name + path for each detected workspace)
- Add workspace list to text-mode dry-run output
- Omitted via `omitempty` for non-monorepo scans (backwards compatible)

## Test plan

- [x] JSON mode with workspaces — verifies correct structure
- [x] JSON mode without workspaces — verifies key is absent
- [x] Text mode with workspaces — verifies header and entries
- [x] Text mode without workspaces — verifies section absent
- [x] All 7 existing dry-run tests updated for new parameter
- [x] Full test suite passes with `-race`
- [x] golangci-lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)