### PR TITLE
docs: document signal-id stability contract and logging conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -344,6 +344,17 @@ When you open a PR that implements an Accepted DR, flip its status in the same P
 5. Add tests in `internal/collectors/yourname_test.go`
 6. Update `README.md` collector list
 
+### Logging conventions
+
+Stringer uses the stdlib `log/slog` everywhere. Follow these rules so agents and CI consumers can parse logs reliably:
+
+- **Level:** `Info` for user-visible status (caps reached, collectors disabled). `Warn` for recoverable degradation (parse failure, skipping a file). `Debug` for per-item tracing. `Error` only for abort-worthy conditions that stop the scan.
+- **Message:** lowercase, no terminal punctuation, prefixed with the collector/component name: `"complexity: Go AST parse failed, skipping file"`.
+- **Error field:** name it exactly `"error"` and pass the raw error value (slog formats it). Always include at least one context field alongside (e.g. `"file"`, `"path"`, `"package"`).
+- **Never concatenate runtime values into the message.** Do not write `slog.Warn("vuln: reading "+name, …)`; use `slog.Warn("vuln: reading manifest", "file", name, …)` so structured consumers can index on `file`.
+- **Do not log-and-return the same error.** Either log it or wrap-and-return (with `fmt.Errorf("…: %w", err)`), not both — pick based on whether the caller can do anything with it.
+- **Field names:** `snake_case`, stable across releases. Common keys: `file`, `path`, `package`, `version`, `url`, `status`, `cap`, `attempt`.
+
 ### Adding a new formatter
 
 1. Create `internal/output/yourformat.go`

--- a/internal/collectors/vuln.go
+++ b/internal/collectors/vuln.go
@@ -287,13 +287,13 @@ func parseGradleQueries(repoPath string) (string, []PackageQuery) {
 			if errors.Is(err, os.ErrNotExist) {
 				continue
 			}
-			slog.Warn("vuln: reading "+name, "error", err)
+			slog.Warn("vuln: reading manifest", "file", name, "error", err)
 			return "", nil
 		}
 
 		queries, err := parseGradleDeps(data)
 		if err != nil {
-			slog.Warn("vuln: parsing "+name, "error", err)
+			slog.Warn("vuln: parsing manifest", "file", name, "error", err)
 			return "", nil
 		}
 		return name, queries
@@ -364,13 +364,13 @@ func parseCsprojQueries(repoPath string) (string, []PackageQuery) {
 	for _, f := range csprojFiles {
 		data, err := FS.ReadFile(filepath.Join(repoPath, f))
 		if err != nil {
-			slog.Warn("vuln: reading "+f, "error", err)
+			slog.Warn("vuln: reading csproj", "file", f, "error", err)
 			continue
 		}
 
 		parsed, err := parseCsprojDeps(data)
 		if err != nil {
-			slog.Warn("vuln: parsing "+f, "error", err)
+			slog.Warn("vuln: parsing csproj", "file", f, "error", err)
 			continue
 		}
 

--- a/internal/output/signalid.go
+++ b/internal/output/signalid.go
@@ -11,8 +11,29 @@ import (
 )
 
 // SignalID produces a deterministic ID from signal content.
-// It hashes Source + Kind + FilePath + Line + Title using SHA-256,
-// truncates to 8 hex characters, and prepends the given prefix.
+//
+// It hashes these fields, in this order, separated by NUL bytes:
+//
+//	Source | Kind | FilePath | Line | Title
+//
+// using SHA-256, takes the first 4 bytes, hex-encodes them (8 lowercase hex
+// chars), and prepends the given prefix.
+//
+// # Stability contract
+//
+// Signal IDs are the join key that links a scanned signal to the beads issue
+// tracking it. Changing any of the following breaks existing beads silently:
+//
+//   - the set or order of hashed fields
+//   - the separator (NUL byte)
+//   - the hash algorithm or truncation length
+//   - the hex encoding case or prefix format
+//
+// Treat the composition above as a fixed contract. If it ever needs to change,
+// ship both old and new IDs for a transition window and migrate callers that
+// persist IDs (the beads JSONL, baselines, report output). The regression
+// tests in signalid_test.go pin specific hash outputs — they will fail loudly
+// on any change here.
 func SignalID(sig signal.RawSignal, prefix string) string {
 	h := sha256.New()
 	// Write each field separated by null bytes to avoid collisions

--- a/internal/output/signalid_test.go
+++ b/internal/output/signalid_test.go
@@ -80,6 +80,47 @@ func TestSignalID_FieldSensitivity(t *testing.T) {
 	}
 }
 
+// TestSignalID_StabilityContract pins specific hash outputs so any change
+// to the hash composition (input fields, order, separator, truncation,
+// encoding) fails loudly. Signal IDs are persisted in the beads JSONL,
+// baselines, and report output — changing them orphans existing records.
+// Do NOT update these values without a planned migration path. See the
+// stability contract in signalid.go.
+func TestSignalID_StabilityContract(t *testing.T) {
+	cases := []struct {
+		name string
+		sig  signal.RawSignal
+		want string
+	}{
+		{
+			name: "simple",
+			sig:  signal.RawSignal{Source: "todos", Kind: "todo", FilePath: "main.go", Line: 42, Title: "Add tests"},
+			want: "str-5b5245ca",
+		},
+		{
+			name: "empty_fields",
+			sig:  signal.RawSignal{},
+			want: "str-c5c464c3",
+		},
+		{
+			name: "unicode_title",
+			sig:  signal.RawSignal{Source: "patterns", Kind: "antipattern", FilePath: "internal/foo/bar.go", Line: 123, Title: "Complex function — 复杂"},
+			want: "str-e3e3ac3e",
+		},
+		{
+			name: "zero_line",
+			sig:  signal.RawSignal{Source: "todos", Kind: "todo", FilePath: "x.go", Line: 0, Title: "t"},
+			want: "str-ebd1a532",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := SignalID(tc.sig, "str-")
+			assert.Equal(t, tc.want, got, "hash composition is part of the stability contract; see signalid.go")
+		})
+	}
+}
+
 func TestSignalID_MatchesBeadsFormatter(t *testing.T) {
 	sig := testSignal()
 


### PR DESCRIPTION
## Summary

- **Signal ID stability (`stringer-td8`):** Expand `SignalID` godoc in `internal/output/signalid.go` with an explicit stability contract — hash inputs, separator, truncation, encoding. Add `TestSignalID_StabilityContract` with four pinned hash outputs so any change to the composition fails CI loudly.
- **Logging conventions (`stringer-td11`):** Add a "Logging conventions" subsection to `AGENTS.md` codifying level, message format, error field, and anti-patterns. Fix four string-concat log calls in `internal/collectors/vuln.go` to use structured fields instead.

## Test plan

- [x] `go test ./internal/output/... -run TestSignalID` — all pass, 4 new pinned-hash cases green
- [x] `go build ./...` clean
- [ ] CI green