### PR TITLE
refactor: add TryRegister variants for collector and report registries

### DIFF
--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -7,6 +7,7 @@ package collector
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -34,16 +35,34 @@ var (
 	registry = make(map[string]Collector)
 )
 
-// Register adds a collector to the global registry.
-// It panics if a collector with the same name is already registered.
-func Register(c Collector) {
+// ErrAlreadyRegistered is returned by TryRegister when a collector with the
+// same Name() is already in the registry. Wrapped with the offending name.
+var ErrAlreadyRegistered = errors.New("collector already registered")
+
+// TryRegister adds a collector to the global registry and returns an error
+// if a collector with the same Name() is already registered. Prefer this
+// over Register when the caller can handle the error (e.g. dynamic loaders,
+// tests).
+func TryRegister(c Collector) error {
 	mu.Lock()
 	defer mu.Unlock()
 	name := c.Name()
 	if _, exists := registry[name]; exists {
-		panic(fmt.Sprintf("collector already registered: %s", name))
+		return fmt.Errorf("%w: %s", ErrAlreadyRegistered, name)
 	}
 	registry[name] = c
+	return nil
+}
+
+// Register adds a collector to the global registry. It panics with a
+// descriptive message if registration fails — typically because a collector
+// with the same Name() was already registered (usually a duplicate blank
+// import). Intended for use from package init() where returning an error
+// isn't an option; runtime callers should use TryRegister.
+func Register(c Collector) {
+	if err := TryRegister(c); err != nil {
+		panic(err.Error())
+	}
 }
 
 // Get returns the collector with the given name, or nil if not found.

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -5,7 +5,9 @@ package collector
 
 import (
 	"context"
+	"errors"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/davetashner/stringer/internal/signal"
@@ -56,6 +58,33 @@ func TestRegisterDuplicatePanics(t *testing.T) {
 		}
 	}()
 	Register(&stubCollector{name: "dup"})
+}
+
+func TestTryRegister_NoConflict(t *testing.T) {
+	resetForTesting()
+
+	if err := TryRegister(&stubCollector{name: "unique"}); err != nil {
+		t.Fatalf("TryRegister returned unexpected error: %v", err)
+	}
+	if Get("unique") == nil {
+		t.Fatal("Get returned nil after successful TryRegister")
+	}
+}
+
+func TestTryRegister_Conflict(t *testing.T) {
+	resetForTesting()
+	Register(&stubCollector{name: "dup"})
+
+	err := TryRegister(&stubCollector{name: "dup"})
+	if err == nil {
+		t.Fatal("TryRegister should return an error on duplicate registration")
+	}
+	if !errors.Is(err, ErrAlreadyRegistered) {
+		t.Errorf("error should wrap ErrAlreadyRegistered, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "dup") {
+		t.Errorf("error message should include the offending name; got %q", err.Error())
+	}
 }
 
 func TestList(t *testing.T) {

--- a/internal/report/section.go
+++ b/internal/report/section.go
@@ -41,17 +41,34 @@ var (
 	order    []string // insertion order for deterministic listing
 )
 
-// Register adds a section to the global registry.
-// It panics if a section with the same name is already registered.
-func Register(s Section) {
+// ErrAlreadyRegistered is returned by TryRegister when a section with the
+// same Name() is already in the registry. Wrapped with the offending name.
+var ErrAlreadyRegistered = errors.New("report section already registered")
+
+// TryRegister adds a section to the global registry and returns an error if
+// a section with the same Name() is already registered. Prefer this over
+// Register when the caller can handle the error.
+func TryRegister(s Section) error {
 	mu.Lock()
 	defer mu.Unlock()
 	name := s.Name()
 	if _, exists := registry[name]; exists {
-		panic(fmt.Sprintf("report section already registered: %s", name))
+		return fmt.Errorf("%w: %s", ErrAlreadyRegistered, name)
 	}
 	registry[name] = s
 	order = append(order, name)
+	return nil
+}
+
+// Register adds a section to the global registry. It panics with a
+// descriptive message if registration fails — typically because a section
+// with the same Name() was already registered (usually a duplicate blank
+// import). Intended for use from package init() where returning an error
+// isn't an option; runtime callers should use TryRegister.
+func Register(s Section) {
+	if err := TryRegister(s); err != nil {
+		panic(err.Error())
+	}
 }
 
 // Get returns the section with the given name, or nil if not found.

--- a/internal/report/section_test.go
+++ b/internal/report/section_test.go
@@ -62,6 +62,26 @@ func TestRegister_DuplicatePanics(t *testing.T) {
 	})
 }
 
+func TestTryRegister_NoConflict(t *testing.T) {
+	resetForTesting()
+	defer restoreSections()
+
+	err := TryRegister(&stubSection{name: "unique"})
+	require.NoError(t, err)
+	require.NotNil(t, Get("unique"))
+}
+
+func TestTryRegister_Conflict(t *testing.T) {
+	resetForTesting()
+	defer restoreSections()
+
+	Register(&stubSection{name: "dup"})
+	err := TryRegister(&stubSection{name: "dup"})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrAlreadyRegistered), "error should wrap ErrAlreadyRegistered")
+	assert.Contains(t, err.Error(), "dup", "error should include the offending name")
+}
+
 func TestGet_NotFound(t *testing.T) {
 	resetForTesting()
 	defer restoreSections()


### PR DESCRIPTION
## Summary

Adds `TryRegister(c) error` on both `internal/collector` and `internal/report` registries. Existing `Register(c)` stays — it now wraps `TryRegister` and panics with the same descriptive message on duplicate registration.

The rationale: `init()`-time callers have nowhere to return an error to, so panic is the right move there. Runtime callers (tests verifying collision behavior, dynamic collector selection, future plugin systems) need a handleable path. Returning a wrapped `ErrAlreadyRegistered` sentinel gives them one without churning every existing call site.

## Changes

- `internal/collector/collector.go`: `ErrAlreadyRegistered` sentinel, `TryRegister`, `Register` refactored to wrap `TryRegister`.
- `internal/report/section.go`: same pattern.
- Added `TestTryRegister_NoConflict` and `TestTryRegister_Conflict` on both packages.
- 14 existing `init()` call sites and all `Register`-using tests are untouched.

## Test plan

- [x] `go test ./internal/collector/... ./internal/report/... -count=1` — pass
- [x] `go build ./...` — clean
- [ ] CI green

Closes `stringer-td3`.