### PR TITLE
ci: add per-package coverage summary to CI step summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,38 @@ jobs:
             echo "::error::Coverage ${total}% is below threshold ${threshold}%"
             exit 1
           fi
+      - name: Coverage by package (step summary)
+        if: always()
+        run: |
+          {
+            echo "## Coverage by package"
+            echo
+            echo '| Package | Coverage |'
+            echo '| --- | --- |'
+            go tool cover -func=coverage.out \
+              | awk '
+                /^total:/ { total=$3; next }
+                {
+                  # func-level rows look like: pkg/path/file.go:LINE: funcName  XX.X%
+                  # aggregate by package (strip ":LINE: funcName")
+                  split($1, parts, "/")
+                  n=length($1)
+                  i=index($1, ".go:")
+                  if (i>0) {
+                    pkg=substr($1, 1, i-1)
+                    sub(/\/[^/]+$/, "", pkg)
+                  } else { pkg=$1 }
+                  pct=$NF
+                  gsub("%","",pct)
+                  sum[pkg]+=pct
+                  cnt[pkg]++
+                }
+                END {
+                  for (p in sum) printf "| `%s` | %.1f%% |\n", p, sum[p]/cnt[p]
+                  if (total!="") printf "| **total** | **%s** |\n", total
+                }' \
+              | sort
+          } >> "$GITHUB_STEP_SUMMARY"
 
   vulncheck:
     name: Vulncheck


### PR DESCRIPTION
## Summary

On review, the Coverage CI job already runs `go test -coverprofile` and gates at a 90% threshold — the survey overstated this gap. What is actually missing is per-package visibility when a regression lands.

This PR adds one step to the existing Coverage job: an awk pass over `go tool cover -func` output that aggregates to the package level and writes a Markdown table to `$GITHUB_STEP_SUMMARY`. That renders under the Coverage job in the Actions UI so reviewers can skim which packages moved without downloading the profile.

The step uses `if: always()` so the summary appears even when the threshold gate fails — that's when you most want to see it.

## What I did not do

I considered adding an `actions/upload-artifact` step to publish `coverage.out`. Skipped it to avoid pulling in a new pinned action dependency in a small PR; the step summary covers the primary use case (visibility during PR review). Easy to add later if the downloadable profile turns out to matter.

## Test plan

- [x] YAML syntax: `git diff` is isolated to the coverage job
- [ ] CI green — the summary table will show up on this PR's Coverage job

Closes `stringer-td6`.