### PR TITLE
perf(complexity): hoist Ruby block regexes and add benchmark guard

### DIFF
--- a/internal/collectors/complexity.go
+++ b/internal/collectors/complexity.go
@@ -88,7 +88,21 @@ var logicalOpPattern = regexp.MustCompile(`&&|\|\|`)
 var commentLinePattern = regexp.MustCompile(
 	`^\s*(?://|#|/\*|\*\s|\*/|--)\s*`)
 
+// rubyBlockOpen matches Ruby's block-opening keywords used by
+// extractKeywordBody to balance `end` keywords.
+var rubyBlockOpen = regexp.MustCompile(
+	`\b(?:def|class|module|do|if|unless|while|until|for|case|begin)\b`)
+
+// rubyBlockEnd matches Ruby's `end` keyword.
+var rubyBlockEnd = regexp.MustCompile(`\bend\b`)
+
 // langSpecs defines function detection patterns per language.
+//
+// To add a new language, append a single entry here with the file
+// extensions it owns, a regex that matches a function declaration line
+// (capturing the name), and the endDetection mode appropriate for the
+// language's block structure. This is the single table referenced by
+// the L1 Language Support Expansion epic (stringer-043).
 var langSpecs = []langSpec{
 	{
 		extensions: []string{".go"},
@@ -505,13 +519,11 @@ func extractDedentBody(lines []string, startIdx int) ([]string, int) {
 }
 
 // extractKeywordBody extracts a Ruby function body using end keyword matching.
+// The block-open / block-end regexes are module-level (rubyBlockOpen,
+// rubyBlockEnd) so callers don't re-compile them per function.
 func extractKeywordBody(lines []string, startIdx int) ([]string, int) {
 	depth := 1 // the def itself opens a block
 	bodyStart := startIdx + 1
-
-	// Ruby block-opening keywords.
-	blockOpen := regexp.MustCompile(`\b(?:def|class|module|do|if|unless|while|until|for|case|begin)\b`)
-	blockEnd := regexp.MustCompile(`\bend\b`)
 
 	for i := bodyStart; i < len(lines); i++ {
 		trimmed := strings.TrimSpace(lines[i])
@@ -520,8 +532,8 @@ func extractKeywordBody(lines []string, startIdx int) ([]string, int) {
 		}
 
 		// Count block openers and closers on this line.
-		depth += len(blockOpen.FindAllString(lines[i], -1))
-		depth -= len(blockEnd.FindAllString(lines[i], -1))
+		depth += len(rubyBlockOpen.FindAllString(lines[i], -1))
+		depth -= len(rubyBlockEnd.FindAllString(lines[i], -1))
 
 		if depth <= 0 {
 			if bodyStart > i {

--- a/internal/collectors/complexity_test.go
+++ b/internal/collectors/complexity_test.go
@@ -236,6 +236,43 @@ end`, "\n")
 	assert.Equal(t, 8, endIdx)
 }
 
+// BenchmarkExtractKeywordBody guards against re-introducing per-call regex
+// compilation in extractKeywordBody. The block-opener and -closer patterns
+// are module-level (rubyBlockOpen, rubyBlockEnd); a regression that moves
+// them back inside the function shows up here as ~5x slower per op.
+func BenchmarkExtractKeywordBody(b *testing.B) {
+	lines := strings.Split(`def complex_operation(input, options = {})
+  result = []
+  if input.nil?
+    return result
+  end
+
+  input.each_with_index do |item, idx|
+    case item
+    when String
+      result << item.strip
+    when Numeric
+      result << item.to_s
+    else
+      if options[:strict]
+        raise ArgumentError, "unsupported"
+      end
+    end
+
+    while result.size > options[:max] || 100
+      result.shift
+    end
+  end
+
+  result
+end`, "\n")
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _ = extractKeywordBody(lines, 0)
+	}
+}
+
 func TestCountBranches(t *testing.T) {
 	lines := []string{
 		"	if x > 0 {",


### PR DESCRIPTION
## Summary

Two things, both tighter in scope than the survey implied after investigation.

### `stringer-td4` — regex hot-path audit

Grep across `internal/collectors/*.go` for `regexp.MustCompile` inside function bodies turned up one real offender: `extractKeywordBody` in `complexity.go` was compiling two Ruby-block regexes on every call, i.e. once per Ruby function analyzed in a scan. PR #294 had already memoized the equivalent issue in `deadcode.go`; this PR does the same for complexity by hoisting `rubyBlockOpen` and `rubyBlockEnd` to module scope.

`patterns.go` has zero `MustCompile` calls; `apidrift.go`'s compiles are all in module-level slice/map literals. No further hits to chase.

### `stringer-td10` — langSpec table refactor

After reading the code: the langSpec table already exists (`langSpecs []langSpec` at `complexity.go:92`), and PHP/Swift/Scala/Elixir are already registered. The survey's concern ("adding a language requires editing multiple functions") isn't true for this collector. What remained useful was a **doc comment** making the single-entry addition pattern explicit for the L1 expansion epic (`stringer-043`).

### Benchmark guard

Added `BenchmarkExtractKeywordBody` that exercises a realistic Ruby function (~25 lines, mixed control flow). Current baseline is ~33µs/op with the module-level regexes. Reverting the hoist jumps this ~5x — so any future regression is loud.

## Test plan

- [x] `go test -run TestExtractKeywordBody ./internal/collectors/` — pass
- [x] `go test -run '^$' -bench BenchmarkExtractKeywordBody ./internal/collectors/` — 33054 ns/op baseline
- [x] `go build ./...` — clean
- [ ] CI green