### PR TITLE
fix: add context cancellation in duplication/coupling hot loops

### DIFF
--- a/internal/collectors/coupling.go
+++ b/internal/collectors/coupling.go
@@ -192,10 +192,16 @@ func (c *CouplingCollector) Collect(ctx context.Context, repoPath string, opts s
 	}
 
 	// Phase 3: Detect cycles via Tarjan's SCC.
-	sccs := tarjanSCC(graph)
+	sccs, err := tarjanSCC(ctx, graph)
+	if err != nil {
+		return nil, err
+	}
 
 	// Phase 4: Compute fan-out.
-	highFanOut := fanOutModules(graph, fanOutThreshold)
+	highFanOut, err := fanOutModules(ctx, graph, fanOutThreshold)
+	if err != nil {
+		return nil, err
+	}
 
 	// Phase 5: Generate signals.
 	var signals []signal.RawSignal

--- a/internal/collectors/coupling_graph.go
+++ b/internal/collectors/coupling_graph.go
@@ -4,6 +4,7 @@
 package collectors
 
 import (
+	"context"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -345,7 +346,8 @@ func moduleForFile(relPath string, ext string) string {
 
 // tarjanSCC finds all strongly connected components in the graph.
 // Returns only components with 2+ nodes (actual cycles).
-func tarjanSCC(graph importGraph) [][]string {
+// It checks for context cancellation at each top-level node visit.
+func tarjanSCC(ctx context.Context, graph importGraph) ([][]string, error) {
 	index := 0
 	stack := []string{}
 	onStack := map[string]bool{}
@@ -395,12 +397,15 @@ func tarjanSCC(graph importGraph) [][]string {
 
 	// Visit all nodes, including those with no outgoing edges.
 	for v := range graph {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		if _, visited := indices[v]; !visited {
 			strongConnect(v)
 		}
 	}
 
-	return sccs
+	return sccs, nil
 }
 
 // --- Fan-out analysis ---
@@ -409,9 +414,17 @@ const defaultFanOutThreshold = 10
 
 // fanOutModules returns modules whose direct import count meets or exceeds
 // the threshold, along with their counts.
-func fanOutModules(graph importGraph, threshold int) map[string]int {
+// It checks for context cancellation every 1000 modules.
+func fanOutModules(ctx context.Context, graph importGraph, threshold int) (map[string]int, error) {
 	results := make(map[string]int)
+	checked := 0
 	for mod, deps := range graph {
+		checked++
+		if checked%1000 == 0 {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+		}
 		// Deduplicate imports.
 		unique := make(map[string]bool)
 		for _, d := range deps {
@@ -422,7 +435,7 @@ func fanOutModules(graph importGraph, threshold int) map[string]int {
 			results[mod] = count
 		}
 	}
-	return results
+	return results, nil
 }
 
 // readGoModulePath reads the module path from a go.mod file.

--- a/internal/collectors/coupling_test.go
+++ b/internal/collectors/coupling_test.go
@@ -289,7 +289,10 @@ func TestTarjanSCC_SimpleCycle(t *testing.T) {
 		"A": {"B"},
 		"B": {"A"},
 	}
-	sccs := tarjanSCC(graph)
+	sccs, err := tarjanSCC(context.Background(), graph)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if len(sccs) != 1 {
 		t.Fatalf("expected 1 SCC, got %d", len(sccs))
@@ -305,7 +308,10 @@ func TestTarjanSCC_ThreeNodeCycle(t *testing.T) {
 		"B": {"C"},
 		"C": {"A"},
 	}
-	sccs := tarjanSCC(graph)
+	sccs, err := tarjanSCC(context.Background(), graph)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if len(sccs) != 1 {
 		t.Fatalf("expected 1 SCC, got %d", len(sccs))
@@ -321,7 +327,10 @@ func TestTarjanSCC_NoCycle(t *testing.T) {
 		"B": {"C"},
 		"C": nil,
 	}
-	sccs := tarjanSCC(graph)
+	sccs, err := tarjanSCC(context.Background(), graph)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if len(sccs) != 0 {
 		t.Errorf("expected 0 SCCs for acyclic graph, got %d", len(sccs))
@@ -334,7 +343,10 @@ func TestTarjanSCC_SelfLoop(t *testing.T) {
 		"A": {"A"},
 		"B": nil,
 	}
-	sccs := tarjanSCC(graph)
+	sccs, err := tarjanSCC(context.Background(), graph)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if len(sccs) != 0 {
 		t.Errorf("expected 0 SCCs (self-loops filtered), got %d", len(sccs))
@@ -349,7 +361,10 @@ func TestTarjanSCC_DisconnectedComponents(t *testing.T) {
 		"D": {"C"},
 		"E": nil, // isolated node
 	}
-	sccs := tarjanSCC(graph)
+	sccs, err := tarjanSCC(context.Background(), graph)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if len(sccs) != 2 {
 		t.Fatalf("expected 2 SCCs, got %d", len(sccs))
@@ -363,7 +378,10 @@ func TestTarjanSCC_MultipleCyclesSharedNode(t *testing.T) {
 		"B": {"A", "C"},
 		"C": {"B"},
 	}
-	sccs := tarjanSCC(graph)
+	sccs, err := tarjanSCC(context.Background(), graph)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if len(sccs) != 1 {
 		t.Fatalf("expected 1 SCC (overlapping cycles merge), got %d", len(sccs))
@@ -381,7 +399,10 @@ func TestFanOutModules(t *testing.T) {
 		"a":   {"b"},
 		"b":   nil,
 	}
-	result := fanOutModules(graph, 10)
+	result, err := fanOutModules(context.Background(), graph, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if len(result) != 1 {
 		t.Fatalf("expected 1 high-fan-out module, got %d", len(result))
@@ -396,7 +417,10 @@ func TestFanOutModules_BelowThreshold(t *testing.T) {
 		"a": {"b", "c"},
 		"b": {"c"},
 	}
-	result := fanOutModules(graph, 10)
+	result, err := fanOutModules(context.Background(), graph, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if len(result) != 0 {
 		t.Errorf("expected 0 results below threshold, got %d", len(result))
@@ -407,7 +431,10 @@ func TestFanOutModules_DeduplicatesImports(t *testing.T) {
 	graph := importGraph{
 		"a": {"b", "b", "b", "c"}, // b listed 3 times, only counts once
 	}
-	result := fanOutModules(graph, 3)
+	result, err := fanOutModules(context.Background(), graph, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if len(result) != 0 {
 		t.Errorf("expected 0 results (deduplicated count is 2), got %d", len(result))
@@ -984,4 +1011,35 @@ func Hub() { a.A(); b.B(); c.C(); d.D(); e.E() }
 		}
 	}
 	assert.Greater(t, fanOutCount2, 0, "should trigger with threshold 3")
+}
+
+func TestTarjanSCC_ContextCancellation(t *testing.T) {
+	// Build a graph large enough to have multiple top-level visits.
+	graph := make(importGraph)
+	for i := 0; i < 100; i++ {
+		graph[fmt.Sprintf("mod%d", i)] = nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := tarjanSCC(ctx, graph)
+	if err == nil {
+		t.Error("expected error from cancelled context")
+	}
+}
+
+func TestFanOutModules_ContextCancellation(t *testing.T) {
+	graph := make(importGraph)
+	for i := 0; i < 2000; i++ {
+		graph[fmt.Sprintf("mod%d", i)] = []string{"dep"}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := fanOutModules(ctx, graph, 10)
+	if err == nil {
+		t.Error("expected error from cancelled context")
+	}
 }

--- a/internal/collectors/duplication.go
+++ b/internal/collectors/duplication.go
@@ -156,10 +156,17 @@ func (c *DuplicationCollector) Collect(ctx context.Context, repoPath string, opt
 			return nil, err
 		}
 		normalized := normalizeType1(f.lines)
-		type1Entries = append(type1Entries, buildWindowHashes(normalized, f.relPath, winSize)...)
+		entries, hashErr := buildWindowHashes(ctx, normalized, f.relPath, winSize)
+		if hashErr != nil {
+			return nil, hashErr
+		}
+		type1Entries = append(type1Entries, entries...)
 	}
 
-	type1Groups := groupClones(type1Entries, winSize)
+	type1Groups, err := groupClones(ctx, type1Entries, winSize)
+	if err != nil {
+		return nil, err
+	}
 
 	// Phase 3: Build Type 2 (near-clone) hash windows.
 	var type2Entries []windowEntry
@@ -168,10 +175,17 @@ func (c *DuplicationCollector) Collect(ctx context.Context, repoPath string, opt
 			return nil, err
 		}
 		normalized := normalizeType2(f.lines)
-		type2Entries = append(type2Entries, buildWindowHashes(normalized, f.relPath, winSize)...)
+		entries, hashErr := buildWindowHashes(ctx, normalized, f.relPath, winSize)
+		if hashErr != nil {
+			return nil, hashErr
+		}
+		type2Entries = append(type2Entries, entries...)
 	}
 
-	type2Groups := groupClones(type2Entries, winSize)
+	type2Groups, err := groupClones(ctx, type2Entries, winSize)
+	if err != nil {
+		return nil, err
+	}
 	for i := range type2Groups {
 		type2Groups[i].NearClone = true
 	}

--- a/internal/collectors/duplication_hash.go
+++ b/internal/collectors/duplication_hash.go
@@ -4,6 +4,7 @@
 package collectors
 
 import (
+	"context"
 	"hash/fnv"
 	"regexp"
 	"strings"
@@ -129,12 +130,18 @@ type windowEntry struct {
 }
 
 // buildWindowHashes creates hash entries for all sliding windows in a file.
-func buildWindowHashes(normalized []normalizedLine, path string, winSize int) []windowEntry {
+// It checks for context cancellation every 1000 windows.
+func buildWindowHashes(ctx context.Context, normalized []normalizedLine, path string, winSize int) ([]windowEntry, error) {
 	if len(normalized) < winSize {
-		return nil
+		return nil, nil
 	}
 	entries := make([]windowEntry, 0, len(normalized)-winSize+1)
 	for i := 0; i <= len(normalized)-winSize; i++ {
+		if i%1000 == 0 {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+		}
 		entries = append(entries, windowEntry{
 			hash:      hashWindow(normalized, i, winSize),
 			path:      path,
@@ -142,12 +149,13 @@ func buildWindowHashes(normalized []normalizedLine, path string, winSize int) []
 			normIdx:   i,
 		})
 	}
-	return entries
+	return entries, nil
 }
 
 // groupClones groups window entries by hash, then extends adjacent matching
 // windows into larger blocks. Returns clone groups with 2+ locations.
-func groupClones(entries []windowEntry, winSize int) []cloneGroup {
+// It checks for context cancellation every 1000 hash buckets.
+func groupClones(ctx context.Context, entries []windowEntry, winSize int) ([]cloneGroup, error) {
 	// Group by hash.
 	byHash := make(map[uint64][]windowEntry)
 	for _, e := range entries {
@@ -155,7 +163,15 @@ func groupClones(entries []windowEntry, winSize int) []cloneGroup {
 	}
 
 	var groups []cloneGroup
+	checked := 0
 	for _, matches := range byHash {
+		checked++
+		if checked%1000 == 0 {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+		}
+
 		if len(matches) < 2 {
 			continue
 		}
@@ -188,7 +204,7 @@ func groupClones(entries []windowEntry, winSize int) []cloneGroup {
 		})
 	}
 
-	return mergeAdjacentGroups(groups, winSize)
+	return mergeAdjacentGroups(groups, winSize), nil
 }
 
 // mergeAdjacentGroups merges clone groups whose locations are adjacent

--- a/internal/collectors/duplication_test.go
+++ b/internal/collectors/duplication_test.go
@@ -131,7 +131,10 @@ func TestHashWindowShortFile(t *testing.T) {
 	lines := []normalizedLine{
 		{text: "a"}, {text: "b"},
 	}
-	entries := buildWindowHashes(lines, "short.go", defaultWindowSize)
+	entries, err := buildWindowHashes(context.Background(), lines, "short.go", defaultWindowSize)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(entries) != 0 {
 		t.Errorf("expected 0 entries for short file, got %d", len(entries))
 	}
@@ -146,10 +149,21 @@ func TestGroupClones(t *testing.T) {
 	}
 
 	var entries []windowEntry
-	entries = append(entries, buildWindowHashes(lines, "file1.go", defaultWindowSize)...)
-	entries = append(entries, buildWindowHashes(lines, "file2.go", defaultWindowSize)...)
+	e1, err := buildWindowHashes(context.Background(), lines, "file1.go", defaultWindowSize)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entries = append(entries, e1...)
+	e2, err := buildWindowHashes(context.Background(), lines, "file2.go", defaultWindowSize)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entries = append(entries, e2...)
 
-	groups := groupClones(entries, defaultWindowSize)
+	groups, err := groupClones(context.Background(), entries, defaultWindowSize)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if len(groups) == 0 {
 		t.Fatal("expected at least 1 clone group")
@@ -922,6 +936,44 @@ func TestCollect_ConfigurableMaxFiles(t *testing.T) {
 	m := c.Metrics().(*DuplicationMetrics)
 	if m.FilesScanned > 2 {
 		t.Errorf("expected at most 2 files scanned with cap=2, got %d", m.FilesScanned)
+	}
+}
+
+// TestBuildWindowHashesCancellation verifies that buildWindowHashes respects context cancellation.
+func TestBuildWindowHashesCancellation(t *testing.T) {
+	// Build a large enough input to trigger the periodic check.
+	lines := make([]normalizedLine, 2000)
+	for i := range lines {
+		lines[i] = normalizedLine{text: fmt.Sprintf("line %d", i), origLine: i + 1}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := buildWindowHashes(ctx, lines, "big.go", defaultWindowSize)
+	if err == nil {
+		t.Error("expected error from cancelled context")
+	}
+}
+
+// TestGroupClonesCancellation verifies that groupClones respects context cancellation.
+func TestGroupClonesCancellation(t *testing.T) {
+	// Build enough entries to trigger the periodic check (>1000 unique hashes).
+	var entries []windowEntry
+	for i := 0; i < 2000; i++ {
+		entries = append(entries, windowEntry{
+			hash:      uint64(i),
+			path:      "a.go",
+			startLine: i + 1,
+		})
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := groupClones(ctx, entries, defaultWindowSize)
+	if err == nil {
+		t.Error("expected error from cancelled context")
 	}
 }
 

--- a/internal/collectors/duplication_test.go
+++ b/internal/collectors/duplication_test.go
@@ -960,11 +960,11 @@ func TestBuildWindowHashesCancellation(t *testing.T) {
 func TestGroupClonesCancellation(t *testing.T) {
 	// Build enough entries to trigger the periodic check (>1000 unique hashes).
 	var entries []windowEntry
-	for i := 0; i < 2000; i++ {
+	for i := uint64(0); i < 2000; i++ {
 		entries = append(entries, windowEntry{
-			hash:      uint64(i),
+			hash:      i,
 			path:      "a.go",
-			startLine: i + 1,
+			startLine: int(i) + 1, //nolint:gosec // G115: bounded loop counter (i < 2000), safe.
 		})
 	}
 


### PR DESCRIPTION
## Summary

- Add `context.Context` parameter and periodic `ctx.Err()` checks (every 1000 iterations) to `buildWindowHashes`, `groupClones`, `tarjanSCC`, and `fanOutModules`
- Update callers in `DuplicationCollector.Collect` and `CouplingCollector.Collect` to propagate cancellation errors
- Add dedicated cancellation tests for each inner function

Resolves stringer-td9.

## Motivation

On large repos, these CPU-bound inner loops (FNV-64a sliding window hashing, Tarjan SCC traversal) could run for extended periods without checking for context cancellation. A timeout or user interrupt would not take effect until the function returned to its caller.

## Test plan

- [x] All existing collector tests pass (`go test -race ./internal/collectors/...`)
- [x] New cancellation tests verify each function returns an error on a pre-cancelled context
- [x] Full test suite passes (only pre-existing `TestScan_BdImportRoundTrip` failure unrelated to this change)
- [x] `go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)