### PR TITLE
ci: make Doc Staleness advisory (warn instead of block)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,10 +398,18 @@ jobs:
     name: Doc Staleness
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
-    # TEMP: surfaced as non-blocking until the gh pr comment step is reworked
-    # to handle fork PRs (workflow token lacks write access on forks).
-    # Revert this once the comment-posting path is fixed. Tracked in stringer-td9
-    # follow-up — see PR #309 review.
+    # Doc Staleness is advisory: it surfaces in the Actions UI and posts a
+    # heads-up comment on the PR, but it does not block merges.
+    # Rationale:
+    #   - The job posts a maintainer comment via gh pr comment, which fails
+    #     on fork PRs because the workflow token lacks write access — that
+    #     would block external contributors on a CI artifact, not a real
+    #     doc-staleness issue.
+    #   - Doc currency is a soft signal. We'd rather see the warning and
+    #     fix it in a follow-up than block on it.
+    # The hard interface-drift gate inside the job still exits non-zero on
+    # real signature drift; that just shows up as a job failure now instead
+    # of a merge block.
     continue-on-error: true
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,6 +398,11 @@ jobs:
     name: Doc Staleness
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
+    # TEMP: surfaced as non-blocking until the gh pr comment step is reworked
+    # to handle fork PRs (workflow token lacks write access on forks).
+    # Revert this once the comment-posting path is fixed. Tracked in stringer-td9
+    # follow-up — see PR #309 review.
+    continue-on-error: true
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Summary

Mark the `Doc Staleness` job as `continue-on-error: true`. The check still runs and reports in the Actions UI; it just no longer blocks merges.

## Why advisory, not temporary

Two reasons reinforce keeping this warn-only long-term:

1. **Fork PRs can't post the maintainer comment.** The job's last step uses `gh pr comment` with the workflow's `GITHUB_TOKEN`, which fork PRs don't have write access for. That fails the whole job on a CI plumbing issue rather than a real doc-staleness problem — and any sustained fork contribution flow trips it.
2. **Doc currency is a soft signal.** A reviewer can spot doc drift; the cost of blocking merges on a heuristic isn't worth it. Warning + heads-up comment is the right level.

The **hard interface-drift gate** inside the job still exits non-zero when `Collector` / `Formatter` / `Section` signatures actually drift from `AGENTS.md`. That now surfaces as a visible Actions job failure rather than a merge block — reviewers will still see it, and we can choose to act on it without it gating the PR.

## Test plan

- [x] YAML edit is isolated to the `doc-staleness` job
- [ ] CI green on this PR — Doc Staleness reports without failing the run