### PR TITLE
docs: update README banner for v1.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/davetashner/stringer/badge)](https://securityscorecards.dev/viewer/?uri=github.com/davetashner/stringer)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/11942/badge?v=2)](https://www.bestpractices.dev/projects/11942)
 
-> **v1.7.0.** SARIF formatter no longer panics on marshal failures. Path traversal validation hardened. Deadcode collector regex memoization for faster scans. Symlink safety checks deduplicated across 7 collectors. Dry-run output now includes workspace metadata for monorepo debugging.
+> **v1.8.0.** L1 Language Support Expansion is complete: PHP, Swift, Scala, and Elixir manifests are now scanned by both the `dephealth` and `vuln` collectors (10 dep-health ecosystems, 11 vuln ecosystems). Hot loops in clone detection, coupling SCC, and module fan-out now check `ctx.Err()` so Ctrl+C and CI timeouts cancel within ~1000 iterations. Signal-ID stability is pinned by a regression test, the complexity collector hoists its Ruby regexes (~5x faster per function), and registries expose `TryRegister` for runtime callers. Doc Staleness CI is now advisory so fork PRs are no longer blocked.
 
 **Codebase archaeology for developers and AI agents.** Scan any repo for hidden tech debt — TODOs, vulnerabilities, lottery risk, stale branches, unhealthy dependencies — and get structured results you can act on immediately.
 


### PR DESCRIPTION
## Summary
- Swap the `> **v1.7.0.** ...` banner near the top of `README.md` for a v1.8.0 summary.
- New blurb highlights: L1 language expansion (PHP/Swift/Scala/Elixir → 10 dep-health / 11 vuln ecosystems), `ctx.Err()` cancellation in hot loops, signal-ID stability regression test, Ruby regex hoist in the complexity collector, `TryRegister` registry API, and Doc Staleness flipping to advisory.
- Ecosystem counts in the body of the README (lines 48, 63, 64) were already current from PR #311; this PR only touches the banner.

## Test plan
- [x] `grep -n "v1\\.7\\.0" README.md` returns no matches
- [ ] CI green