### PR TITLE
chore: ignore local beads runtime and agent IDE paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,13 @@ Thumbs.db
 
 # Beads lock
 .beads/.jsonl.lock
+
+# Beads local runtime (embedded Dolt, backups, export scratch — not for git)
+.beads/backup/
+.beads/embeddeddolt/
+.beads/export-state.json
+
+# Local agent / IDE scratch (per-machine; never upstream)
+.claude/
+.cursor/
+.review/


### PR DESCRIPTION
## Summary

Extend `.gitignore` so common per-machine paths stop cluttering `git status` for contributors using embedded Dolt, local backups, Claude Code, Cursor, and ad-hoc review notes.

## Changes

- `.beads/backup/`, `.beads/embeddeddolt/`, `.beads/export-state.json` — local runtime / export scratch
- `.claude/`, `.cursor/`, `.review/` — local agent / IDE directories

Tracked `.beads` files (`issues.jsonl`, `config.yaml`, etc.) are unchanged and remain versioned.

## Test plan

- `git status` on a dev machine with these dirs present shows no untracked noise for the new patterns.