### PR TITLE
fix(security): bump Go floor to 1.25.11 / 1.26.4 for GO-2026-5037 + 5039

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,13 +19,13 @@ jobs:
         # Display label (go-line) stays at major.minor so branch protection's
         # required-check names ("Test (Go 1.25)" / "Test (Go 1.26)") don't
         # break when we bump the security floor. Installed version (go-version)
-        # is pinned to the exact patch — currently the GO-2026-4918 /
-        # CVE-2026-33814 fixes (1.25.10 / 1.26.3).
+        # is pinned to the exact patch — currently the GO-2026-5037 /
+        # GO-2026-5039 (net/textproto + crypto/x509) fixes (1.25.11 / 1.26.4).
         include:
           - go-line: "1.25"
-            go-version: "1.25.10"
+            go-version: "1.25.11"
           - go-line: "1.26"
-            go-version: "1.26.3"
+            go-version: "1.26.4"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,10 +145,15 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26"
+          # Pin to the exact patch carrying the latest stdlib advisory fixes
+          # (GO-2026-5037 / 5039 -> 1.26.4). The unpinned "1.26" resolves to
+          # whatever's in the runner's tool cache, which can lag, causing
+          # govulncheck to flag stdlib vulns that go.mod's directive already
+          # gates against.
+          go-version: "1.26.4"
       - uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
         with:
-          go-version-input: "1.26"
+          go-version-input: "1.26.4"
           repo-checkout: false
 
   binary-size:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/davetashner/stringer
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/BurntSushi/toml v1.6.0


### PR DESCRIPTION
## Summary

Two new Go stdlib advisories landed today, both reachable from production code in stringer. Bumping the security floor before merging the three open dependabot PRs (which all fail Vulncheck on current `main`).

| Advisory | Package | Stringer reach |
|---|---|---|
| [**GO-2026-5039**](https://pkg.go.dev/vuln/GO-2026-5039) | `net/textproto` — arbitrary inputs in errors without escaping | `dephealth_deprecated.go:77` → `json.Decoder.Decode` → `textproto.Reader.ReadMIMEHeader` |
| [**GO-2026-5037**](https://pkg.go.dev/vuln/GO-2026-5037) | `crypto/x509` — inefficient candidate hostname parsing | `internal/docs/updater.go:41`, `cmd/stringer/main.go:26` via `errors.joinError.Error` |

Both are fixed in **go1.25.11** and **go1.26.4**.

## Changes

| | Before | After |
|---|---|---|
| `go.mod` directive | `1.25.10` | **`1.25.11`** |
| CI matrix install (1.25 line) | `1.25.10` | **`1.25.11`** |
| CI matrix install (1.26 line) | `1.26.3` | **`1.26.4`** |

Same shape as the GO-2026-4918 fix that shipped in v1.8.1 (PR #321). Display labels stay at major.minor so branch protection's required checks don't break.

## Test plan

- [x] `go build ./...` clean
- [ ] CI green (the Vulncheck job specifically — should now go silent on both advisories)

After this merges, the three open dependabot PRs (#334, #335, #336) get rebased and merged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TEaxuzb8Gq3CAP6r7bkMcb)_