### PR TITLE
ci(deps): bump github/codeql-action to 4.36.3 atomically (supersedes #350/#351/#352)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,8 +23,8 @@ jobs:
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: "1.26"
-      - uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3
+      - uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v3
         with:
           languages: go
-      - uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3
-      - uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3
+      - uses: github/codeql-action/autobuild@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v3
+      - uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v3

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -29,6 +29,6 @@ jobs:
           results_format: sarif
           publish_results: true
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3
+        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary

Dependabot filed three separate PRs (#350 init, #351 autobuild, #352 analyze) to bump `github/codeql-action` 4.36.2 → 4.36.3, but each PR fails CI on its own because the codeql-action subactions must move in lockstep. The init step writes a config file for its own version, and older autobuild/analyze steps reject a newer config:

```
##[error] Loaded a configuration file for version '4.36.3', but running version '4.36.2'
```

This PR bumps all four call sites atomically to SHA `54f647b7e1bb85c95cddabcd46b0c578ec92bc1a` (v4.36.3):

- `.github/workflows/codeql.yml` — init, autobuild, analyze
- `.github/workflows/scorecard.yml` — upload-sarif (same action, needs to move together)

Supersedes #350, #351, #352 — those will be closed once this lands.

## Test plan

- [x] CI (Analyze job) passes with all three codeql-action steps at 4.36.3.
- [x] Scorecard workflow uses matching SHA for consistency.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TEaxuzb8Gq3CAP6r7bkMcb)_