### PR TITLE
ci(deps): bump github/codeql-action to 4.37.0 atomically (supersedes #355/#356/#359/#360)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,8 +23,8 @@ jobs:
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: "1.26"
-      - uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v3
+      - uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v3
         with:
           languages: go
-      - uses: github/codeql-action/autobuild@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v3
-      - uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v3
+      - uses: github/codeql-action/autobuild@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v3
+      - uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v3

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -29,6 +29,6 @@ jobs:
           results_format: sarif
           publish_results: true
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v3
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary

Same pattern as #353 (which handled 4.36.2 → 4.36.3): dependabot split the codeql-action subaction bumps across four PRs — #355 (analyze), #356 (upload-sarif), #359 (autobuild), #360 (init) — but the subactions must move in lockstep to avoid a config version mismatch:

```
##[error] Loaded a configuration file for version 'X', but running version 'Y'
```

This PR bumps all four call sites atomically to SHA `99df26d4f13ea111d4ec1a7dddef6063f76b97e9` (v4.37.0):

- `.github/workflows/codeql.yml` — init, autobuild, analyze
- `.github/workflows/scorecard.yml` — upload-sarif

Supersedes #355, #356, #359, #360 — those will be closed once this lands.

## Test plan

- [x] CI (Analyze job) passes with all three codeql-action steps at 4.37.0.
- [x] Scorecard workflow's upload-sarif at matching SHA.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TEaxuzb8Gq3CAP6r7bkMcb)_