### PR TITLE
ci(deps): bump github/codeql-action to 4.37.3 atomically (supersedes #369/#372/#373/#374)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,8 +23,8 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: "1.26"
-      - uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v3
+      - uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v3
         with:
           languages: go
-      - uses: github/codeql-action/autobuild@7188fc363630916deb702c7fdcf4e481b751f97a # v3
-      - uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v3
+      - uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v3
+      - uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v3

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -29,6 +29,6 @@ jobs:
           results_format: sarif
           publish_results: true
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v3
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary

Same lockstep pattern as #353 (4.36.2→4.36.3), #361 (4.36.3→4.37.0), and #368 (4.37.0→4.37.1). Dependabot filed four separate PRs — #369 (autobuild), #372 (upload-sarif), #373 (analyze), #374 (init) — but the codeql-action subactions must share a version to avoid the CI config version mismatch:

```
##[error] Loaded a configuration file for version 'X', but running version 'Y'
```

This PR bumps all four call sites atomically to SHA `e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81` (v4.37.3):

- `.github/workflows/codeql.yml` — init, autobuild, analyze
- `.github/workflows/scorecard.yml` — upload-sarif

Supersedes #369, #372, #373, #374 — those will be closed once this lands.

## Test plan

- [x] CI (Analyze job) passes with all three codeql-action steps at 4.37.3.
- [x] Scorecard workflow's upload-sarif at matching SHA.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TEaxuzb8Gq3CAP6r7bkMcb)_