### PR TITLE
ci(deps): bump github/codeql-action to 4.37.4 atomically (supersedes #379/#380/#381)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,8 +23,8 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: "1.26"
-      - uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v3
+      - uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v3
         with:
           languages: go
-      - uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v3
-      - uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v3
+      - uses: github/codeql-action/autobuild@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v3
+      - uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v3


### PR DESCRIPTION
## Summary

Same lockstep pattern as #353, #361, #368, #375. Dependabot filed three separate PRs — #379 (analyze), #380 (autobuild), #381 (init) — but the codeql-action subactions in `codeql.yml` must share a version to avoid the CI config version mismatch:

```
##[error] Loaded a configuration file for version 'X', but running version 'Y'
```

This PR bumps all three call sites in `codeql.yml` atomically to SHA `f205ea1c3313d32999d8d6a48b4f6530d4437b38` (v4.37.4).

`scorecard.yml`'s `upload-sarif` was already bumped to 4.37.4 in #378 (safe to bump standalone since it doesn't share config with the codeql.yml trio).

Supersedes #379, #380, #381 — those will be closed once this lands.

## Test plan

- [x] CI (Analyze job) passes with all three codeql-action steps at 4.37.4.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TEaxuzb8Gq3CAP6r7bkMcb)_