### PR TITLE
ci(deps): bump github/codeql-action to 4.37.6 atomically (supersedes #384/#385/#386/#387)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,8 +23,8 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: "1.26"
-      - uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v3
+      - uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v3
         with:
           languages: go
-      - uses: github/codeql-action/autobuild@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v3
-      - uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v3
+      - uses: github/codeql-action/autobuild@5595ccaf912efad79be6eef63a5619ff05969be3 # v3
+      - uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v3

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -29,6 +29,6 @@ jobs:
           results_format: sarif
           publish_results: true
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v3
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary

Same lockstep pattern as #353, #361, #368, #375, #382. Dependabot filed four separate PRs — #384 (upload-sarif), #385 (init), #386 (analyze), #387 (autobuild) — but the codeql-action subactions must share a version to avoid the CI config version mismatch:

```
##[error] Loaded a configuration file for version 'X', but running version 'Y'
```

This PR bumps all four call sites atomically to SHA `5595ccaf912efad79be6eef63a5619ff05969be3` (v4.37.6):

- `.github/workflows/codeql.yml` — init, autobuild, analyze
- `.github/workflows/scorecard.yml` — upload-sarif

4.37.5 is skipped (4.37.6 supersedes it). Supersedes #384, #385, #386, #387 — those will be closed once this lands.

## Test plan

- [x] CI (Analyze job) passes with all three codeql-action steps at 4.37.6.
- [x] Scorecard workflow's upload-sarif at matching SHA.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TEaxuzb8Gq3CAP6r7bkMcb)_