### PR TITLE
ci(deps): bump github/codeql-action to 4.37.7 atomically (supersedes #390/#391)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,8 +23,8 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: "1.26"
-      - uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v3
+      - uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v3
         with:
           languages: go
-      - uses: github/codeql-action/autobuild@5595ccaf912efad79be6eef63a5619ff05969be3 # v3
-      - uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v3
+      - uses: github/codeql-action/autobuild@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v3
+      - uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v3

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -29,6 +29,6 @@ jobs:
           results_format: sarif
           publish_results: true
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v3
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary

Same lockstep pattern as #353, #361, #368, #375, #382, #388. Dependabot filed only two subaction PRs — #390 (analyze), #391 (upload-sarif) — but init/autobuild would remain at 4.37.6, tripping the CI config version mismatch:

```
##[error] Loaded a configuration file for version 'X', but running version 'Y'
```

This PR bumps all four call sites atomically to SHA `ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd` (v4.37.7):

- `.github/workflows/codeql.yml` — init, autobuild, analyze
- `.github/workflows/scorecard.yml` — upload-sarif

Supersedes #390, #391 — those will be closed once this lands.

## Test plan

- [x] CI (Analyze job) passes with all three codeql-action steps at 4.37.7.
- [x] Scorecard workflow's upload-sarif at matching SHA.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TEaxuzb8Gq3CAP6r7bkMcb)_