### PR TITLE
ci(deps): bump github/codeql-action to 4.37.8 atomically (supersedes #398-#401)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,8 +23,8 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: "1.26"
-      - uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v3
+      - uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v3
         with:
           languages: go
-      - uses: github/codeql-action/autobuild@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v3
-      - uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v3
+      - uses: github/codeql-action/autobuild@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v3
+      - uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v3

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -29,6 +29,6 @@ jobs:
           results_format: sarif
           publish_results: true
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v3
+        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary

Bumps `github/codeql-action` from 4.37.7 to 4.37.8 across **all four call sites** in one commit, following the established lockstep pattern (#353, #361, #368, #375, #382, #388, #393).

Dependabot filed four separate subaction PRs this cycle. Merging them individually would leave the other call sites at 4.37.7 between merges — tripping the CI config version mismatch — and each merge would force a rebase of the remaining three.

## Changes

| File | Actions |
|------|---------|
| `.github/workflows/codeql.yml` | `init`, `autobuild`, `analyze` |
| `.github/workflows/scorecard.yml` | `upload-sarif` |

All pinned to `db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28`.

## SHA verification

Verified against the upstream annotated tag rather than trusting the Dependabot diff alone:

```
v4.37.8 -> db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28
```

Supersedes #398, #399, #400, #401.

Closes stringer-123

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01855iZ2D6me9PjARM3QCJKq