### PR TITLE
docs: clean up README architecture diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Stringer extracts these signals automatically, scores them by confidence, and ou
 - **Markdown** (`markdown`) — Human-readable summary grouped by collector with priority distribution
 - **Tasks** (`tasks`) — Claude Code task format for direct agent consumption
 - **SARIF** (`sarif`) — [SARIF v2.1.0](https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html) static analysis results for IDE and CI integration
+- **HTML** (`html`) — Self-contained single-file dashboard
+- **HTML directory** (`html-dir`) — Dashboard split into `index.html` plus external `assets/dashboard.{css,js}`; requires `--output` to name the target directory
 
 ### Pipeline
 
@@ -91,38 +93,38 @@ Stringer extracts these signals automatically, scores them by confidence, and ou
 - **Monorepo support** — Auto-detects workspaces (go.work, pnpm, npm, lerna, nx, cargo) and scans each independently with `--workspace` filtering
 
 ```
-                              ┌─────────────────────────────────┐
-                              │        Target Repository        │
-                              └────────────────┬────────────────┘
-                                               │
-     ┌──────────┬──────────┬──────────┬────────┼────────┬──────────┬──────────┐
-     ▼          ▼          ▼          ▼        ▼        ▼          ▼          ▼
- ┌───────┐ ┌───────┐ ┌────────┐ ┌────────┐ ┌──────┐ ┌──────┐ ┌──────┐ ┌──────────┐
- │ TODOs │ │  Git  │ │Patterns│ │Lottery │ │GitHub│ │ Dep  │ │ Vuln │ │Complexity│ (parallel)
- │       │ │  log  │ │        │ │ Risk   │ │      │ │ Hlth │ │      │ │          │
- └───┬───┘ └───┬───┘ └───┬────┘ └───┬────┘ └──┬───┘ └──┬───┘ └──┬───┘ └────┬─────┘
-     │         │         │         │          │        │        │           │
-     │    ┌────┴────┐ ┌──┴───┐ ┌──┴────┐ ┌───┴───┐ ┌─┴──────┐ │     ┌─────┴─────┐
-     │    │  Dead   │ │ Git  │ │  Doc  │ │Config │ │  API   │ │     │Duplication│
-     │    │  code   │ │Hygne │ │ Stale │ │ Drift │ │ Drift  │ │     │           │
-     │    └────┬────┘ └──┬───┘ └──┬────┘ └───┬───┘ └───┬────┘ │     └─────┬─────┘
-     │         │         │        │          │         │      │           │
-     │         │         │   ┌────┴─────┐    │         │      │           │
-     │         │         │   │ Coupling │    │         │      │           │
-     │         │         │   └────┬─────┘    │         │      │           │
-     └─────────┴─────────┴────────┴──────────┴─────────┴──────┴───────────┘
-                                               ▼
-                                        ┌────────────┐
-                                        │  Dedup +   │
-                                        │ Validation │
-                                        └──────┬─────┘
-                                               │
-                      ┌────────────┬───────────┼────────────┬────────────┐
-                      ▼            ▼           ▼            ▼            ▼
-                 ┌─────────┐ ┌──────────┐ ┌──────────┐ ┌─────────┐ ┌───────┐
-                 │  Beads  │ │   JSON   │ │ Markdown │ │  Tasks  │ │ SARIF │
-                 │  JSONL  │ │          │ │          │ │         │ │       │
-                 └─────────┘ └──────────┘ └──────────┘ └─────────┘ └───────┘
+                            ┌─────────────────────┐
+                            │  Target Repository  │
+                            └──────────┬──────────┘
+                                       │
+                                       ▼
+┌────────────────────────────────────────────────────────────────────────────┐
+│              15 collectors — all run concurrently (errgroup)               │
+│                                                                            │
+│ ┌────────────┐ ┌────────────┐ ┌────────────┐ ┌────────────┐ ┌────────────┐ │
+│ │   TODOs    │ │  Patterns  │ │ Dead Code  │ │ Complexity │ │Duplication │ │
+│ └────────────┘ └────────────┘ └────────────┘ └────────────┘ └────────────┘ │
+│                                                                            │
+│ ┌────────────┐ ┌────────────┐ ┌────────────┐ ┌────────────┐ ┌────────────┐ │
+│ │   Gitlog   │ │Git Hygiene │ │Lottery Risk│ │   GitHub   │ │  Coupling  │ │
+│ └────────────┘ └────────────┘ └────────────┘ └────────────┘ └────────────┘ │
+│                                                                            │
+│ ┌────────────┐ ┌────────────┐ ┌────────────┐ ┌────────────┐ ┌────────────┐ │
+│ │    Vuln    │ │ Dep Health │ │ Doc Stale  │ │Config Drift│ │ API Drift  │ │
+│ └────────────┘ └────────────┘ └────────────┘ └────────────┘ └────────────┘ │
+│                                                                            │
+└──────────────────────────────────────┬─────────────────────────────────────┘
+                                       │
+                                       ▼
+                           ┌──────────────────────┐
+                           │  Dedup + Validation  │
+                           └───────────┬──────────┘
+                                       │
+      ┌──────────┬──────────┬──────────┼──────────┬──────────┬──────────┐
+      ▼          ▼          ▼          ▼          ▼          ▼          ▼
+ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐
+ │ beads  │ │  json  │ │markdown│ │ sarif  │ │ tasks  │ │  html  │ │html-dir│
+ └────────┘ └────────┘ └────────┘ └────────┘ └────────┘ └────────┘ └────────┘
 ```
 
 ## Real-World Results


### PR DESCRIPTION
## Problem

The pipeline diagram drew the 15 collectors as a **three-tier tree**, with vertical connectors running from first-row collectors down into second-row ones — `Git log → Dead code`, `Lottery Risk → Doc Stale`, `Complexity → Duplication`, and so on.

All 15 collectors are independent siblings dispatched concurrently by the errgroup pipeline. None feeds another. The layout implied a dependency graph that doesn't exist.

Three smaller issues alongside it:

- The widest line ran ~112 cols, so the trailing `(parallel)` annotation was clipped in rendered views.
- `Git Hygne` (typo) and `Dep Hlth` (over-abbreviated).
- `html` and `html-dir` were missing — both shipped in v1.3.0 (#171, #173) but never made it into the diagram or the **Output Formats** list.

## Change

Redrawn as a single labelled band containing a uniform 5×3 grid, with one fan-in and one fan-out, so parallelism is unambiguous. Widest line is now **78 cols**.

Added the two missing formatter bullets to Output Formats, since the corrected diagram would otherwise contradict the prose immediately below it.

## Verification

Collector and formatter names checked against the `init()` registries rather than the old diagram:

- `internal/collectors` — 15 registered: `apidrift complexity configdrift coupling deadcode dephealth docstale duplication github githygiene gitlog lotteryrisk patterns todos vuln`
- `internal/output` — 7 registered: `beads html html-dir json markdown sarif tasks`

Formatter descriptions were read from the implementations — `html-dir` is `index.html` plus external `assets/dashboard.{css,js}`, not a multi-page export.

Docs-only; no Go files touched.

Closes stringer-7ae

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01855iZ2D6me9PjARM3QCJKq