### PR TITLE
fix(vuln): reachability-aware, score-accurate, loudly-partial vulnerability scanning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ stringer/
 │   │   ├── lotteryrisk*.go     # Lottery risk: core, ownership math, review analysis
 │   │   ├── github.go           # GitHub issues, PRs, and review comments
 │   │   ├── dephealth*.go       # Dependency health: 10 ecosystems (Go, npm, Cargo, Maven, NuGet, PyPI, Packagist, SwiftPM, sbt, Hex)
-│   │   ├── vuln*.go            # Vuln scanner: 11 ecosystems via OSV.dev (+ PHP, Swift, Scala, Elixir parsers)
+│   │   ├── vuln*.go            # Vuln scanner: 11 ecosystems via OSV.dev (+ PHP, Swift, Scala, Elixir parsers); CVSS v3 base-score severity, npm dev/prod reachability, paginated OSV queries with partial-coverage accounting (DR-023)
 │   │   ├── configdrift.go       # Config drift: env var drift, dead keys, inconsistent defaults
 │   │   ├── apidrift.go         # API drift: undocumented routes, unimplemented spec paths, stale versions
 │   │   ├── docstale.go         # Doc staleness: stale docs, co-change drift, broken links

--- a/docs/decisions/023-vuln-reachability-and-severity.md
+++ b/docs/decisions/023-vuln-reachability-and-severity.md
@@ -1,0 +1,33 @@
+# 023: Vulnerability Reachability and Severity Scoring
+
+**Status:** Accepted (pre-authorized in session, 2026-08-27)
+**Date:** 2026-08-27
+**Context:** stringer-kgr, stringer-bqg, stringer-g9b — evaluation of stringer 1.8.6 output against davetashner/sandtable (TypeScript/React) showed the vuln collector inverting triage: four of five filed beads were dev-only, two at P1, while the one production-reachable advisory (image-size 0.7.5, nested under texture-compressor) was missed entirely. Severity ordering was unrelated to CVSS score.
+
+## Problem
+
+Three related accuracy defects in the vuln collector:
+
+1. **Lost findings.** `parseNpmLockDeps` deduplicated packages by name only, so a lockfile holding the same package at two versions (nested dependencies) queried only one — chosen by map iteration order, i.e. nondeterministically. On sandtable this dropped the production-reachable vulnerable version and kept the dev-only one.
+2. **Lost reachability.** The lockfile's `dev` flag was parsed and discarded, so dev-only advisories ranked equal to production ones and no bead said which it was.
+3. **Wrong severity.** `severityFromCVSS` derived severity from CIA impact flags alone ("any H → high"), ignoring the base score. A network DoS (7.5) and a full compromise (9.8) tied; a moderate advisory could outrank a high one after flag-flattening.
+
+Additionally, partial OSV failures (unfetchable details, unpaginated `querybatch` results, total network failure) were silent or near-silent, so an incomplete security scan looked complete.
+
+## Options
+
+**Severity:** (a) keep flag heuristic; (b) parse the numeric score OSV sometimes provides; (c) compute the CVSS v3.x base score from the vector per the FIRST spec. Chose **(c)**: deterministic, testable against published scores, works for every advisory carrying a vector, and the flag heuristic remains as fallback for unparseable vectors.
+
+**Confidence bands** (drive P1–P4 via the ≥0.8/≥0.6/≥0.4 mapping): critical 0.95 → P1, high 0.85 → P1, medium 0.65 → P2, low 0.45 → P3, none 0.30 → P4, no-data 0.80 unchanged (avoids reshuffling ecosystems whose advisories lack vectors).
+
+**Dev discount:** (a) separate priority track; (b) confidence multiplier; (c) flat −0.2 with floor 0.3. Chose **(c)**: one band down, so dev+high (0.65 → P2) sorts below prod+high (0.85 → P1) and above prod+medium only on ties — simple, explainable in the bead body. When the same name+version is reachable both ways, production wins.
+
+**Dedup key:** name+version (parser) and vulnID+ecosystem+name+version (client). Each installed instance of a vulnerable version is a distinct finding.
+
+**Partial coverage:** `QueryBatch` now returns `OSVQueryResult{Details, FailedFetches, Truncated}`; `querybatch` pagination (`next_page_token`) is followed up to 5 pages per query; total failure sets `VulnMetrics.Unavailable` and logs at Warn. Scans stay non-fatal offline, but never silently.
+
+## Consequences
+
+- npm gains full reachability awareness; other ecosystems with a dev distinction (Cargo `dev-dependencies`, Poetry/uv groups, Gemfile groups) parse as production until given the same treatment (follow-up bead).
+- Severity labels now include "critical" and "none"; consumers of `VulnEntry.Severity` see the new values.
+- The npm-audit reconciliation eval (stringer-kgr proposal 2) remains open — this record covers the mechanism fixes, not the eval harness.

--- a/internal/collectors/vuln.go
+++ b/internal/collectors/vuln.go
@@ -26,8 +26,11 @@ func init() {
 
 // VulnMetrics holds structured vulnerability data from the last scan.
 type VulnMetrics struct {
-	TotalVulns int
-	Vulns      []VulnEntry
+	TotalVulns    int
+	Vulns         []VulnEntry
+	FailedFetches int  // vuln detail fetches that errored (results incomplete)
+	Truncated     int  // queries whose paginated results were cut short
+	Unavailable   bool // true when the OSV service could not be reached at all
 }
 
 // VulnEntry represents a single vulnerability finding.
@@ -41,6 +44,7 @@ type VulnEntry struct {
 	Severity     string
 	Ecosystem    string
 	FilePath     string
+	Dev          bool
 }
 
 // VulnCollector detects known vulnerabilities in Go module dependencies
@@ -187,16 +191,27 @@ func (c *VulnCollector) Collect(ctx context.Context, repoPath string, _ signal.C
 		client = newOSVClient(30 * time.Second)
 	}
 
-	results, err := client.QueryBatch(ctx, queries)
+	res, err := client.QueryBatch(ctx, queries)
 	if err != nil {
-		slog.Info("vuln scan unavailable, skipping", "error", err)
-		return nil, nil // graceful degradation
+		// Graceful degradation for offline scans, but loudly: a security
+		// scan that silently reports nothing looks like a clean bill of
+		// health (stringer-kgr).
+		slog.Warn("vuln scan unavailable — dependencies were NOT checked for vulnerabilities", "error", err)
+		c.metrics = &VulnMetrics{Unavailable: true}
+		return nil, nil
 	}
 
 	var signals []signal.RawSignal
-	metrics := &VulnMetrics{}
+	metrics := &VulnMetrics{
+		FailedFetches: res.FailedFetches,
+		Truncated:     res.Truncated,
+	}
+	if res.FailedFetches > 0 || res.Truncated > 0 {
+		slog.Warn("vuln scan incomplete — some vulnerability data could not be fetched",
+			"failed_detail_fetches", res.FailedFetches, "truncated_queries", res.Truncated)
+	}
 
-	for _, r := range results {
+	for _, r := range res.Details {
 		cve := extractCVE(r.Aliases)
 		titleID := cve
 		if titleID == "" {
@@ -212,8 +227,36 @@ func (c *VulnCollector) Collect(ctx context.Context, repoPath string, _ signal.C
 			desc = fmt.Sprintf("%s\n\nNo fix available for %s %s.", r.Summary, r.PackageName, r.Version)
 		}
 
+		// Prefer the actual CVSS base score; fall back to the coarse
+		// impact-flag heuristic when the vector cannot be parsed.
 		severity := severityFromCVSS(r.Severity)
+		var scoreNote string
+		if score, ok := cvssBaseScore(r.Severity); ok {
+			severity = severityFromScore(score)
+			scoreNote = fmt.Sprintf("Severity: %s (CVSS %.1f)", severity, score)
+		} else if severity != "" {
+			scoreNote = fmt.Sprintf("Severity: %s", severity)
+		}
 		confidence := confidenceForSeverity(severity)
+
+		// Development-only dependencies cannot reach production users; rank
+		// them below production advisories of equal severity (stringer-bqg).
+		if r.Dev {
+			confidence -= 0.2
+			if confidence < 0.3 {
+				confidence = 0.3
+			}
+		}
+
+		reachNote := "Reachability: production — this dependency ships with the built artifact."
+		if r.Dev {
+			reachNote = "Reachability: dev-only — this dependency is used at build/development time and does not ship to users."
+		}
+		if scoreNote != "" {
+			desc = desc + "\n\n" + scoreNote + "\n" + reachNote
+		} else {
+			desc = desc + "\n\n" + reachNote
+		}
 
 		// Look up the manifest file for this result.
 		meta := fileMap[r.Ecosystem+"|"+r.PackageName+"|"+r.Version]
@@ -247,6 +290,9 @@ func (c *VulnCollector) Collect(ctx context.Context, repoPath string, _ signal.C
 			tags = append(tags, cve)
 		}
 		tags = append(tags, r.ID)
+		if r.Dev {
+			tags = append(tags, "dev-only")
+		}
 
 		signals = append(signals, signal.RawSignal{
 			Source:      "vuln",
@@ -268,6 +314,7 @@ func (c *VulnCollector) Collect(ctx context.Context, repoPath string, _ signal.C
 			Severity:     severity,
 			Ecosystem:    meta.ecosystem,
 			FilePath:     meta.filePath,
+			Dev:          r.Dev,
 		})
 	}
 
@@ -589,14 +636,18 @@ func parseCVSSMetrics(cvss string, names ...string) map[string]string {
 // confidenceForSeverity maps a severity level to a confidence score.
 func confidenceForSeverity(severity string) float64 {
 	switch severity {
-	case "high":
+	case "critical":
 		return 0.95
+	case "none":
+		return 0.30
+	case "high":
+		return 0.85
 	case "medium":
-		return 0.80
+		return 0.65
 	case "low":
-		return 0.60
+		return 0.45
 	default:
-		return 0.80 // no severity data → default to medium
+		return 0.80 // no severity data → default to medium-high
 	}
 }
 

--- a/internal/collectors/vuln_cvss.go
+++ b/internal/collectors/vuln_cvss.go
@@ -1,0 +1,103 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
+package collectors
+
+import (
+	"math"
+	"strings"
+)
+
+// cvssBaseScore computes the CVSS v3.x base score from a vector string
+// (e.g. "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"). It returns the
+// score and true on success, or 0 and false when the vector is missing
+// required metrics. Both v3.0 and v3.1 vectors use the same base formula.
+//
+// Implemented per the FIRST CVSS v3.1 specification so that severity
+// reflects the actual score rather than a coarse impact-flag heuristic
+// (stringer-g9b): a network DoS (A:H only) scores 7.5, not the same as a
+// full C:H/I:H/A:H compromise at 9.8.
+func cvssBaseScore(vector string) (float64, bool) {
+	m := parseCVSSMetrics(vector, "AV", "AC", "PR", "UI", "S", "C", "I", "A")
+	if m == nil {
+		return 0, false
+	}
+
+	scopeChanged := m["S"] == "C"
+
+	av, ok1 := cvssWeight(m["AV"], map[string]float64{"N": 0.85, "A": 0.62, "L": 0.55, "P": 0.2})
+	ac, ok2 := cvssWeight(m["AC"], map[string]float64{"L": 0.77, "H": 0.44})
+	ui, ok3 := cvssWeight(m["UI"], map[string]float64{"N": 0.85, "R": 0.62})
+	c, ok4 := cvssWeight(m["C"], map[string]float64{"H": 0.56, "L": 0.22, "N": 0})
+	i, ok5 := cvssWeight(m["I"], map[string]float64{"H": 0.56, "L": 0.22, "N": 0})
+	a, ok6 := cvssWeight(m["A"], map[string]float64{"H": 0.56, "L": 0.22, "N": 0})
+
+	prWeights := map[string]float64{"N": 0.85, "L": 0.62, "H": 0.27}
+	if scopeChanged {
+		prWeights = map[string]float64{"N": 0.85, "L": 0.68, "H": 0.5}
+	}
+	pr, ok7 := cvssWeight(m["PR"], prWeights)
+
+	if !(ok1 && ok2 && ok3 && ok4 && ok5 && ok6 && ok7) {
+		return 0, false
+	}
+
+	iss := 1 - (1-c)*(1-i)*(1-a)
+
+	var impact float64
+	if scopeChanged {
+		impact = 7.52*(iss-0.029) - 3.25*math.Pow(iss-0.02, 15)
+	} else {
+		impact = 6.42 * iss
+	}
+
+	if impact <= 0 {
+		return 0, true
+	}
+
+	exploitability := 8.22 * av * ac * pr * ui
+
+	var score float64
+	if scopeChanged {
+		score = math.Min(1.08*(impact+exploitability), 10)
+	} else {
+		score = math.Min(impact+exploitability, 10)
+	}
+
+	return cvssRoundup(score), true
+}
+
+// cvssWeight looks up a metric value's weight, returning false for
+// unknown values (including the empty string when the metric is absent).
+func cvssWeight(value string, weights map[string]float64) (float64, bool) {
+	w, ok := weights[strings.ToUpper(value)]
+	return w, ok
+}
+
+// cvssRoundup implements the Roundup function from the CVSS v3.1
+// specification (Appendix A): round up to one decimal place, with integer
+// arithmetic to avoid floating-point artifacts (e.g. 4.02 → 4.1, 4.00 → 4.0).
+func cvssRoundup(x float64) float64 {
+	i := int(math.Round(x * 100_000))
+	if i%10_000 == 0 {
+		return float64(i) / 100_000
+	}
+	return (math.Floor(float64(i)/10_000) + 1) / 10
+}
+
+// severityFromScore maps a CVSS base score to the FIRST qualitative
+// severity rating scale.
+func severityFromScore(score float64) string {
+	switch {
+	case score >= 9.0:
+		return "critical"
+	case score >= 7.0:
+		return "high"
+	case score >= 4.0:
+		return "medium"
+	case score > 0:
+		return "low"
+	default:
+		return "none"
+	}
+}

--- a/internal/collectors/vuln_cvss.go
+++ b/internal/collectors/vuln_cvss.go
@@ -38,7 +38,7 @@ func cvssBaseScore(vector string) (float64, bool) {
 	}
 	pr, ok7 := cvssWeight(m["PR"], prWeights)
 
-	if !(ok1 && ok2 && ok3 && ok4 && ok5 && ok6 && ok7) {
+	if !ok1 || !ok2 || !ok3 || !ok4 || !ok5 || !ok6 || !ok7 {
 		return 0, false
 	}
 

--- a/internal/collectors/vuln_cvss_test.go
+++ b/internal/collectors/vuln_cvss_test.go
@@ -1,0 +1,82 @@
+// Copyright 2026 The Stringer Authors
+// SPDX-License-Identifier: MIT
+
+package collectors
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCVSSBaseScore(t *testing.T) {
+	tests := []struct {
+		name   string
+		vector string
+		want   float64
+		ok     bool
+	}{
+		// Canonical vectors with published base scores.
+		{"critical full compromise", "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", 9.8, true},
+		{"network DoS (image-size CVE-2025-71329 shape)", "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H", 7.5, true},
+		{"medium info leak", "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N", 5.3, true},
+		{"scope changed XSS shape", "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N", 6.1, true},
+		{"local low priv", "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N", 5.5, true},
+		{"zero impact", "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N", 0, true},
+		{"v3.0 vector uses same formula", "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H", 8.1, true},
+		{"empty", "", 0, false},
+		{"not a vector", "not-a-cvss-string", 0, false},
+		{"missing metrics", "CVSS:3.1/AV:N/AC:L", 0, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := cvssBaseScore(tt.vector)
+			assert.Equal(t, tt.ok, ok)
+			if tt.ok {
+				assert.InDelta(t, tt.want, got, 0.001)
+			}
+		})
+	}
+}
+
+// TestCVSSBaseScore_DoSDoesNotOutrankFullCompromise pins the ordering bug
+// from stringer-g9b: under the old CIA-flag heuristic, a DoS-only vector and
+// a full-compromise vector both mapped to "high". With real base scores the
+// full compromise is critical and sorts first.
+func TestCVSSBaseScore_DoSDoesNotOutrankFullCompromise(t *testing.T) {
+	dos, ok1 := cvssBaseScore("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H")
+	full, ok2 := cvssBaseScore("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H")
+	assert.True(t, ok1)
+	assert.True(t, ok2)
+	assert.Less(t, dos, full)
+	assert.Equal(t, "high", severityFromScore(dos))
+	assert.Equal(t, "critical", severityFromScore(full))
+}
+
+func TestSeverityFromScore(t *testing.T) {
+	tests := []struct {
+		score float64
+		want  string
+	}{
+		{10.0, "critical"},
+		{9.0, "critical"},
+		{8.9, "high"},
+		{7.0, "high"},
+		{6.9, "medium"},
+		{4.0, "medium"},
+		{3.9, "low"},
+		{0.1, "low"},
+		{0, "none"},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, severityFromScore(tt.score), "score %.1f", tt.score)
+	}
+}
+
+func TestCVSSRoundup(t *testing.T) {
+	// Examples from the CVSS v3.1 spec Appendix A.
+	assert.InDelta(t, 4.0, cvssRoundup(4.0), 0.0001)
+	assert.InDelta(t, 4.1, cvssRoundup(4.02), 0.0001)
+	assert.InDelta(t, 4.5, cvssRoundup(4.45), 0.0001)
+}

--- a/internal/collectors/vuln_npm.go
+++ b/internal/collectors/vuln_npm.go
@@ -27,8 +27,16 @@ func parseNpmDeps(data []byte) ([]PackageQuery, error) {
 	seen := make(map[string]bool)
 	var queries []PackageQuery
 
-	for _, deps := range []map[string]string{pkg.Dependencies, pkg.DevDependencies} {
-		for name, version := range deps {
+	// Dependencies first, devDependencies second: if a package somehow
+	// appears in both maps, the production entry wins (dev=false).
+	for _, group := range []struct {
+		deps map[string]string
+		dev  bool
+	}{
+		{pkg.Dependencies, false},
+		{pkg.DevDependencies, true},
+	} {
+		for name, version := range group.deps {
 			if seen[name] {
 				continue
 			}
@@ -43,6 +51,7 @@ func parseNpmDeps(data []byte) ([]PackageQuery, error) {
 				Ecosystem: "npm",
 				Name:      name,
 				Version:   v,
+				Dev:       group.dev,
 			})
 		}
 	}
@@ -70,7 +79,13 @@ func parseNpmLockDeps(data []byte) ([]PackageQuery, error) {
 		return nil, err
 	}
 
-	seen := make(map[string]bool)
+	// Dedup by name+version, not name alone: a lockfile routinely holds the
+	// same package at multiple versions (nested under different parents), and
+	// collapsing them once nondeterministically dropped a production-reachable
+	// vulnerable version while keeping the dev-only one (stringer-kgr).
+	// seen maps "name|version" → index into queries so a later production
+	// occurrence can clear the Dev flag on an entry first seen as dev-only.
+	seen := make(map[string]int)
 	var queries []PackageQuery
 
 	for path, entry := range lock.Packages {
@@ -95,15 +110,22 @@ func parseNpmLockDeps(data []byte) ([]PackageQuery, error) {
 			name = path[idx+len("node_modules/"):]
 		}
 
-		if seen[name] {
+		key := name + "|" + entry.Version
+		if i, ok := seen[key]; ok {
+			// Production reachability wins: dev-only holds only when every
+			// occurrence of this name+version is flagged dev.
+			if !entry.Dev {
+				queries[i].Dev = false
+			}
 			continue
 		}
-		seen[name] = true
+		seen[key] = len(queries)
 
 		queries = append(queries, PackageQuery{
 			Ecosystem: "npm",
 			Name:      name,
 			Version:   entry.Version,
+			Dev:       entry.Dev,
 		})
 	}
 

--- a/internal/collectors/vuln_npm_test.go
+++ b/internal/collectors/vuln_npm_test.go
@@ -309,9 +309,16 @@ func TestParseNpmLockDeps_NestedNodeModules(t *testing.T) {
 	}`)
 	queries, err := parseNpmLockDeps(data)
 	require.NoError(t, err)
-	// First occurrence wins — "debug" is deduped.
-	require.Len(t, queries, 1)
-	assert.Equal(t, "debug", queries[0].Name)
+	// Distinct versions of the same package are distinct queries: collapsing
+	// them once dropped a production-reachable vulnerable version (stringer-kgr).
+	require.Len(t, queries, 2)
+	versions := map[string]bool{}
+	for _, q := range queries {
+		assert.Equal(t, "debug", q.Name)
+		versions[q.Version] = true
+	}
+	assert.True(t, versions["4.3.4"])
+	assert.True(t, versions["2.6.9"])
 }
 
 func TestParseNpmLockDeps_SkipsRootEntry(t *testing.T) {
@@ -401,4 +408,62 @@ func TestExtractNpmVersion(t *testing.T) {
 			assert.Equal(t, tt.want, extractNpmVersion(tt.input))
 		})
 	}
+}
+
+// TestParseNpmLockDeps_DevFlag verifies the lockfile's dev flag survives
+// parsing instead of being discarded (stringer-bqg).
+func TestParseNpmLockDeps_DevFlag(t *testing.T) {
+	data := []byte(`{
+		"packages": {
+			"": {"version": "1.0.0"},
+			"node_modules/prod-pkg": {"version": "1.0.0"},
+			"node_modules/dev-pkg": {"version": "2.0.0", "dev": true}
+		}
+	}`)
+	queries, err := parseNpmLockDeps(data)
+	require.NoError(t, err)
+	require.Len(t, queries, 2)
+	byName := map[string]PackageQuery{}
+	for _, q := range queries {
+		byName[q.Name] = q
+	}
+	assert.False(t, byName["prod-pkg"].Dev)
+	assert.True(t, byName["dev-pkg"].Dev)
+}
+
+// TestParseNpmLockDeps_ProdWinsOverDev verifies that when the same
+// name+version appears both dev and production, production reachability wins.
+func TestParseNpmLockDeps_ProdWinsOverDev(t *testing.T) {
+	// Same package+version at two paths: dev at top level, production nested.
+	// Whichever map order surfaces first, the result must be Dev=false.
+	data := []byte(`{
+		"packages": {
+			"": {"version": "1.0.0"},
+			"node_modules/shared": {"version": "3.1.4", "dev": true},
+			"node_modules/app-lib/node_modules/shared": {"version": "3.1.4"}
+		}
+	}`)
+	queries, err := parseNpmLockDeps(data)
+	require.NoError(t, err)
+	require.Len(t, queries, 1)
+	assert.Equal(t, "shared", queries[0].Name)
+	assert.False(t, queries[0].Dev, "production occurrence must clear the dev flag")
+}
+
+// TestParseNpmDeps_DevFlag verifies devDependencies are marked dev in the
+// package.json fallback path.
+func TestParseNpmDeps_DevFlag(t *testing.T) {
+	data := []byte(`{
+		"dependencies": {"express": "^4.18.2"},
+		"devDependencies": {"vitest": "^1.2.0"}
+	}`)
+	queries, err := parseNpmDeps(data)
+	require.NoError(t, err)
+	require.Len(t, queries, 2)
+	byName := map[string]PackageQuery{}
+	for _, q := range queries {
+		byName[q.Name] = q
+	}
+	assert.False(t, byName["express"].Dev)
+	assert.True(t, byName["vitest"].Dev)
 }

--- a/internal/collectors/vuln_osv.go
+++ b/internal/collectors/vuln_osv.go
@@ -19,6 +19,7 @@ import (
 const (
 	osvDefaultBaseURL   = "https://api.osv.dev/v1"
 	osvBatchLimit       = 1000
+	osvMaxPages         = 5
 	osvMaxRetries       = 3
 	osvRetryBaseDelay   = 500 * time.Millisecond
 	osvMaxResponseBytes = 10 * 1024 * 1024 // 10 MiB
@@ -29,6 +30,7 @@ type PackageQuery struct {
 	Ecosystem string
 	Name      string
 	Version   string
+	Dev       bool // true when the dependency is development-only (not production-reachable)
 }
 
 // VulnDetail holds processed vulnerability information from OSV.dev.
@@ -41,11 +43,21 @@ type VulnDetail struct {
 	Version      string
 	FixedVersion string
 	Severity     string // CVSS v3 score string, or ""
+	Dev          bool   // true when the affected dependency is development-only
+}
+
+// OSVQueryResult holds vulnerability details plus coverage accounting so
+// callers can tell a clean scan from a partial one. A partial scan that
+// looks complete is worse than no scan, because it is trusted (stringer-kgr).
+type OSVQueryResult struct {
+	Details       []VulnDetail
+	FailedFetches int // vuln detail fetches that errored after retries
+	Truncated     int // queries whose paginated results were cut short
 }
 
 // osvClient abstracts OSV.dev API access for testability.
 type osvClient interface {
-	QueryBatch(ctx context.Context, queries []PackageQuery) ([]VulnDetail, error)
+	QueryBatch(ctx context.Context, queries []PackageQuery) (*OSVQueryResult, error)
 }
 
 // Compile-time check that realOSVClient implements osvClient.
@@ -67,9 +79,10 @@ func newOSVClient(timeout time.Duration) *realOSVClient {
 // QueryBatch queries OSV.dev for vulnerabilities affecting the given packages.
 // It splits large query sets into batches of osvBatchLimit, deduplicates vuln IDs,
 // fetches full details, and maps results back to the originating packages.
-func (c *realOSVClient) QueryBatch(ctx context.Context, queries []PackageQuery) ([]VulnDetail, error) {
+func (c *realOSVClient) QueryBatch(ctx context.Context, queries []PackageQuery) (*OSVQueryResult, error) {
+	out := &OSVQueryResult{}
 	if len(queries) == 0 {
-		return nil, nil
+		return out, nil
 	}
 
 	// Map query index → original PackageQuery for result mapping.
@@ -101,14 +114,48 @@ func (c *realOSVClient) QueryBatch(ctx context.Context, queries []PackageQuery) 
 		}
 
 		for i, r := range results {
+			if i >= len(batch) {
+				break
+			}
 			for _, v := range r.Vulns {
 				hits = append(hits, vulnHit{vulnID: v.ID, query: batch[i]})
+			}
+
+			// Follow pagination for heavily-affected packages. The batch
+			// endpoint returns a per-query next_page_token; ignoring it
+			// silently truncates results (stringer-kgr).
+			token := r.NextPageToken
+			for page := 0; token != "" && page < osvMaxPages; page++ {
+				pageResults, pageErr := c.postBatchQuery(ctx, []osvQueryItem{{
+					Package:   osvPackage{Name: batch[i].Name, Ecosystem: batch[i].Ecosystem},
+					Version:   batch[i].Version,
+					PageToken: token,
+				}})
+				if pageErr != nil {
+					slog.Warn("osv: pagination fetch failed, results truncated",
+						"package", batch[i].Name, "error", pageErr)
+					out.Truncated++
+					token = ""
+					break
+				}
+				token = ""
+				if len(pageResults) > 0 {
+					for _, v := range pageResults[0].Vulns {
+						hits = append(hits, vulnHit{vulnID: v.ID, query: batch[i]})
+					}
+					token = pageResults[0].NextPageToken
+				}
+			}
+			if token != "" {
+				slog.Warn("osv: pagination limit reached, results truncated",
+					"package", batch[i].Name, "pages", osvMaxPages)
+				out.Truncated++
 			}
 		}
 	}
 
 	if len(hits) == 0 {
-		return nil, nil
+		return out, nil
 	}
 
 	// Collect unique vuln IDs and fetch full details.
@@ -126,13 +173,16 @@ func (c *realOSVClient) QueryBatch(ctx context.Context, queries []PackageQuery) 
 		vuln, err := c.fetchVuln(ctx, id)
 		if err != nil {
 			slog.Warn("osv: failed to fetch vuln details, skipping", "id", id, "error", err)
+			out.FailedFetches++
 			continue
 		}
 		vulnCache[id] = vuln
 	}
 
-	// Build results mapping each (vuln, package) pair to a VulnDetail.
-	var details []VulnDetail
+	// Build results mapping each (vuln, package, version) triple to a
+	// VulnDetail. Version is part of the key because a lockfile can hold
+	// the same package at multiple versions (e.g. a nested dependency),
+	// and each installed instance is a distinct finding.
 	dedupKey := make(map[string]bool)
 	for _, h := range hits {
 		vuln := vulnCache[h.vulnID]
@@ -140,13 +190,13 @@ func (c *realOSVClient) QueryBatch(ctx context.Context, queries []PackageQuery) 
 			continue
 		}
 
-		key := h.vulnID + "|" + h.query.Ecosystem + "|" + h.query.Name
+		key := h.vulnID + "|" + h.query.Ecosystem + "|" + h.query.Name + "|" + h.query.Version
 		if dedupKey[key] {
 			continue
 		}
 		dedupKey[key] = true
 
-		details = append(details, VulnDetail{
+		out.Details = append(out.Details, VulnDetail{
 			ID:           vuln.ID,
 			Aliases:      vuln.Aliases,
 			Summary:      vuln.Summary,
@@ -155,10 +205,11 @@ func (c *realOSVClient) QueryBatch(ctx context.Context, queries []PackageQuery) 
 			Version:      h.query.Version,
 			FixedVersion: extractOSVFixVersion(vuln, h.query.Ecosystem, h.query.Name),
 			Severity:     extractOSVSeverity(vuln),
+			Dev:          h.query.Dev,
 		})
 	}
 
-	return details, nil
+	return out, nil
 }
 
 // postBatchQuery POSTs to /v1/querybatch and returns the results.
@@ -292,8 +343,9 @@ type osvBatchRequest struct {
 }
 
 type osvQueryItem struct {
-	Package osvPackage `json:"package"`
-	Version string     `json:"version"`
+	Package   osvPackage `json:"package"`
+	Version   string     `json:"version"`
+	PageToken string     `json:"page_token,omitempty"`
 }
 
 type osvPackage struct {
@@ -306,7 +358,8 @@ type osvBatchResponse struct {
 }
 
 type osvBatchResult struct {
-	Vulns []osvBatchVuln `json:"vulns"`
+	Vulns         []osvBatchVuln `json:"vulns"`
+	NextPageToken string         `json:"next_page_token"`
 }
 
 type osvBatchVuln struct {

--- a/internal/collectors/vuln_osv.go
+++ b/internal/collectors/vuln_osv.go
@@ -117,8 +117,9 @@ func (c *realOSVClient) QueryBatch(ctx context.Context, queries []PackageQuery) 
 			if i >= len(batch) {
 				break
 			}
+			q := batch[i]
 			for _, v := range r.Vulns {
-				hits = append(hits, vulnHit{vulnID: v.ID, query: batch[i]})
+				hits = append(hits, vulnHit{vulnID: v.ID, query: q})
 			}
 
 			// Follow pagination for heavily-affected packages. The batch
@@ -127,13 +128,13 @@ func (c *realOSVClient) QueryBatch(ctx context.Context, queries []PackageQuery) 
 			token := r.NextPageToken
 			for page := 0; token != "" && page < osvMaxPages; page++ {
 				pageResults, pageErr := c.postBatchQuery(ctx, []osvQueryItem{{
-					Package:   osvPackage{Name: batch[i].Name, Ecosystem: batch[i].Ecosystem},
-					Version:   batch[i].Version,
+					Package:   osvPackage{Name: q.Name, Ecosystem: q.Ecosystem},
+					Version:   q.Version,
 					PageToken: token,
 				}})
 				if pageErr != nil {
 					slog.Warn("osv: pagination fetch failed, results truncated",
-						"package", batch[i].Name, "error", pageErr)
+						"package", q.Name, "error", pageErr)
 					out.Truncated++
 					token = ""
 					break
@@ -141,14 +142,14 @@ func (c *realOSVClient) QueryBatch(ctx context.Context, queries []PackageQuery) 
 				token = ""
 				if len(pageResults) > 0 {
 					for _, v := range pageResults[0].Vulns {
-						hits = append(hits, vulnHit{vulnID: v.ID, query: batch[i]})
+						hits = append(hits, vulnHit{vulnID: v.ID, query: q})
 					}
 					token = pageResults[0].NextPageToken
 				}
 			}
 			if token != "" {
 				slog.Warn("osv: pagination limit reached, results truncated",
-					"package", batch[i].Name, "pages", osvMaxPages)
+					"package", q.Name, "pages", osvMaxPages)
 				out.Truncated++
 			}
 		}

--- a/internal/collectors/vuln_osv_test.go
+++ b/internal/collectors/vuln_osv_test.go
@@ -81,14 +81,14 @@ func TestOSVClient_QueryBatch_SingleVuln(t *testing.T) {
 	defer srv.Close()
 
 	client := newTestOSVClient(srv.URL)
-	results, err := client.QueryBatch(context.Background(), []PackageQuery{
+	res, err := client.QueryBatch(context.Background(), []PackageQuery{
 		{Ecosystem: "Maven", Name: "com.example:example-lib", Version: "1.5.0"},
 	})
 
 	require.NoError(t, err)
-	require.Len(t, results, 1)
+	require.Len(t, res.Details, 1)
 
-	d := results[0]
+	d := res.Details[0]
 	assert.Equal(t, "GHSA-1234-5678-abcd", d.ID)
 	assert.Equal(t, []string{"CVE-2024-12345"}, d.Aliases)
 	assert.Equal(t, "SQL injection in example-lib", d.Summary)
@@ -127,16 +127,16 @@ func TestOSVClient_QueryBatch_MultipleVulns(t *testing.T) {
 	defer srv.Close()
 
 	client := newTestOSVClient(srv.URL)
-	results, err := client.QueryBatch(context.Background(), []PackageQuery{
+	res, err := client.QueryBatch(context.Background(), []PackageQuery{
 		{Ecosystem: "Go", Name: "github.com/a/b", Version: "v1.0.0"},
 		{Ecosystem: "Go", Name: "github.com/c/d", Version: "v2.0.0"},
 	})
 
 	require.NoError(t, err)
-	require.Len(t, results, 3)
+	require.Len(t, res.Details, 3)
 
 	byID := make(map[string]VulnDetail)
-	for _, r := range results {
+	for _, r := range res.Details {
 		byID[r.ID] = r
 	}
 
@@ -159,24 +159,24 @@ func TestOSVClient_QueryBatch_NoVulns(t *testing.T) {
 	defer srv.Close()
 
 	client := newTestOSVClient(srv.URL)
-	results, err := client.QueryBatch(context.Background(), []PackageQuery{
+	res, err := client.QueryBatch(context.Background(), []PackageQuery{
 		{Ecosystem: "Go", Name: "github.com/safe/pkg", Version: "v1.0.0"},
 		{Ecosystem: "Go", Name: "github.com/also/safe", Version: "v2.0.0"},
 	})
 
 	require.NoError(t, err)
-	assert.Nil(t, results)
+	assert.Nil(t, res.Details)
 }
 
 func TestOSVClient_QueryBatch_EmptyInput(t *testing.T) {
 	client := newTestOSVClient("http://unused")
-	results, err := client.QueryBatch(context.Background(), nil)
+	res, err := client.QueryBatch(context.Background(), nil)
 	require.NoError(t, err)
-	assert.Nil(t, results)
+	assert.Nil(t, res.Details)
 
-	results, err = client.QueryBatch(context.Background(), []PackageQuery{})
+	res, err = client.QueryBatch(context.Background(), []PackageQuery{})
 	require.NoError(t, err)
-	assert.Nil(t, results)
+	assert.Nil(t, res.Details)
 }
 
 func TestOSVClient_QueryBatch_VulnFetchFailure(t *testing.T) {
@@ -197,14 +197,14 @@ func TestOSVClient_QueryBatch_VulnFetchFailure(t *testing.T) {
 	defer srv.Close()
 
 	client := newTestOSVClient(srv.URL)
-	results, err := client.QueryBatch(context.Background(), []PackageQuery{
+	res, err := client.QueryBatch(context.Background(), []PackageQuery{
 		{Ecosystem: "Go", Name: "pkg", Version: "v1.0.0"},
 	})
 
 	// Should succeed with partial results — MISSING-VULN skipped with warning.
 	require.NoError(t, err)
-	require.Len(t, results, 1)
-	assert.Equal(t, "PRESENT-VULN", results[0].ID)
+	require.Len(t, res.Details, 1)
+	assert.Equal(t, "PRESENT-VULN", res.Details[0].ID)
 }
 
 func TestOSVClient_QueryBatch_RetryOn5xx(t *testing.T) {
@@ -236,13 +236,13 @@ func TestOSVClient_QueryBatch_RetryOn5xx(t *testing.T) {
 	defer srv.Close()
 
 	client := newTestOSVClient(srv.URL)
-	results, err := client.QueryBatch(context.Background(), []PackageQuery{
+	res, err := client.QueryBatch(context.Background(), []PackageQuery{
 		{Ecosystem: "Go", Name: "pkg", Version: "v1.0.0"},
 	})
 
 	require.NoError(t, err)
-	require.Len(t, results, 1)
-	assert.Equal(t, "V1", results[0].ID)
+	require.Len(t, res.Details, 1)
+	assert.Equal(t, "V1", res.Details[0].ID)
 	assert.GreaterOrEqual(t, int(attempts.Load()), 2, "should have retried")
 }
 
@@ -306,17 +306,17 @@ func TestOSVClient_QueryBatch_DedupSameVulnAcrossPackages(t *testing.T) {
 	defer srv.Close()
 
 	client := newTestOSVClient(srv.URL)
-	results, err := client.QueryBatch(context.Background(), []PackageQuery{
+	res, err := client.QueryBatch(context.Background(), []PackageQuery{
 		{Ecosystem: "Go", Name: "pkg-a", Version: "v1.0.0"},
 		{Ecosystem: "Go", Name: "pkg-b", Version: "v2.0.0"},
 	})
 
 	require.NoError(t, err)
 	// Two results: one per package, even though it's the same vuln.
-	require.Len(t, results, 2)
+	require.Len(t, res.Details, 2)
 
 	byPkg := make(map[string]VulnDetail)
-	for _, r := range results {
+	for _, r := range res.Details {
 		byPkg[r.PackageName] = r
 	}
 	assert.Equal(t, "v1.1.0", byPkg["pkg-a"].FixedVersion)
@@ -343,13 +343,13 @@ func TestOSVClient_QueryBatch_NoFixVersion(t *testing.T) {
 	defer srv.Close()
 
 	client := newTestOSVClient(srv.URL)
-	results, err := client.QueryBatch(context.Background(), []PackageQuery{
+	res, err := client.QueryBatch(context.Background(), []PackageQuery{
 		{Ecosystem: "Go", Name: "pkg", Version: "v1.0.0"},
 	})
 
 	require.NoError(t, err)
-	require.Len(t, results, 1)
-	assert.Equal(t, "", results[0].FixedVersion)
+	require.Len(t, res.Details, 1)
+	assert.Equal(t, "", res.Details[0].FixedVersion)
 }
 
 func TestOSVClient_QueryBatch_NoSeverity(t *testing.T) {
@@ -369,13 +369,13 @@ func TestOSVClient_QueryBatch_NoSeverity(t *testing.T) {
 	defer srv.Close()
 
 	client := newTestOSVClient(srv.URL)
-	results, err := client.QueryBatch(context.Background(), []PackageQuery{
+	res, err := client.QueryBatch(context.Background(), []PackageQuery{
 		{Ecosystem: "Go", Name: "pkg", Version: "v1.0.0"},
 	})
 
 	require.NoError(t, err)
-	require.Len(t, results, 1)
-	assert.Equal(t, "", results[0].Severity)
+	require.Len(t, res.Details, 1)
+	assert.Equal(t, "", res.Details[0].Severity)
 }
 
 func TestOSVClient_QueryBatch_NonCVSS3Severity(t *testing.T) {
@@ -396,14 +396,14 @@ func TestOSVClient_QueryBatch_NonCVSS3Severity(t *testing.T) {
 	defer srv.Close()
 
 	client := newTestOSVClient(srv.URL)
-	results, err := client.QueryBatch(context.Background(), []PackageQuery{
+	res, err := client.QueryBatch(context.Background(), []PackageQuery{
 		{Ecosystem: "Go", Name: "pkg", Version: "v1.0.0"},
 	})
 
 	require.NoError(t, err)
-	require.Len(t, results, 1)
+	require.Len(t, res.Details, 1)
 	// Falls back to first severity entry.
-	assert.Equal(t, "AV:N/AC:L/Au:N/C:C/I:C/A:C", results[0].Severity)
+	assert.Equal(t, "AV:N/AC:L/Au:N/C:C/I:C/A:C", res.Details[0].Severity)
 }
 
 func TestExtractOSVFixVersion(t *testing.T) {
@@ -489,4 +489,118 @@ func TestNewOSVClient(t *testing.T) {
 	client := newOSVClient(10 * time.Second)
 	assert.Equal(t, osvDefaultBaseURL, client.baseURL)
 	assert.Equal(t, 10*time.Second, client.httpClient.Timeout)
+}
+
+// TestOSVClient_QueryBatch_Pagination verifies that per-query
+// next_page_token responses are followed rather than silently truncated
+// (stringer-kgr).
+func TestOSVClient_QueryBatch_Pagination(t *testing.T) {
+	vulns := map[string]*osvVulnerability{
+		"V-PAGE-1": {ID: "V-PAGE-1", Summary: "first page"},
+		"V-PAGE-2": {ID: "V-PAGE-2", Summary: "second page"},
+	}
+
+	var batchCalls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/querybatch" && r.Method == http.MethodPost:
+			batchCalls++
+			var req osvBatchRequest
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+			w.Header().Set("Content-Type", "application/json")
+			if len(req.Queries) > 0 && req.Queries[0].PageToken == "tok-1" {
+				// Second page: last vuln, no further token.
+				_ = json.NewEncoder(w).Encode(osvBatchResponse{Results: []osvBatchResult{
+					{Vulns: []osvBatchVuln{{ID: "V-PAGE-2"}}},
+				}})
+				return
+			}
+			// First page: one vuln plus a continuation token.
+			_ = json.NewEncoder(w).Encode(osvBatchResponse{Results: []osvBatchResult{
+				{Vulns: []osvBatchVuln{{ID: "V-PAGE-1"}}, NextPageToken: "tok-1"},
+			}})
+
+		case len(r.URL.Path) > 7 && r.URL.Path[:7] == "/vulns/":
+			id := r.URL.Path[7:]
+			vuln, ok := vulns[id]
+			require.True(t, ok, "unexpected vuln fetch %s", id)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(vuln)
+
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := newTestOSVClient(srv.URL)
+	res, err := client.QueryBatch(context.Background(), []PackageQuery{
+		{Ecosystem: "npm", Name: "busy-package", Version: "1.0.0"},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, batchCalls, "should have followed the page token")
+	require.Len(t, res.Details, 2)
+	ids := map[string]bool{}
+	for _, d := range res.Details {
+		ids[d.ID] = true
+	}
+	assert.True(t, ids["V-PAGE-1"])
+	assert.True(t, ids["V-PAGE-2"])
+	assert.Zero(t, res.Truncated)
+}
+
+// TestOSVClient_QueryBatch_FailedFetchCounted verifies that detail-fetch
+// failures are surfaced in the result instead of only a log line, so
+// callers can report a partial scan as partial (stringer-kgr).
+func TestOSVClient_QueryBatch_FailedFetchCounted(t *testing.T) {
+	batchResp := &osvBatchResponse{Results: []osvBatchResult{
+		{Vulns: []osvBatchVuln{{ID: "V-OK"}, {ID: "V-MISSING"}}},
+	}}
+	vulns := map[string]*osvVulnerability{
+		"V-OK": {ID: "V-OK", Summary: "fetchable"},
+	}
+
+	srv := newTestOSVServer(t, batchResp, vulns)
+	defer srv.Close()
+
+	client := newTestOSVClient(srv.URL)
+	res, err := client.QueryBatch(context.Background(), []PackageQuery{
+		{Ecosystem: "npm", Name: "pkg", Version: "1.0.0"},
+	})
+
+	require.NoError(t, err)
+	require.Len(t, res.Details, 1)
+	assert.Equal(t, "V-OK", res.Details[0].ID)
+	assert.Equal(t, 1, res.FailedFetches)
+}
+
+// TestOSVClient_QueryBatch_DistinctVersionsDistinctFindings verifies the
+// same package at two versions yields two findings for the same advisory.
+func TestOSVClient_QueryBatch_DistinctVersionsDistinctFindings(t *testing.T) {
+	batchResp := &osvBatchResponse{Results: []osvBatchResult{
+		{Vulns: []osvBatchVuln{{ID: "V-BOTH"}}},
+		{Vulns: []osvBatchVuln{{ID: "V-BOTH"}}},
+	}}
+	vulns := map[string]*osvVulnerability{
+		"V-BOTH": {ID: "V-BOTH", Summary: "affects both installed versions"},
+	}
+
+	srv := newTestOSVServer(t, batchResp, vulns)
+	defer srv.Close()
+
+	client := newTestOSVClient(srv.URL)
+	res, err := client.QueryBatch(context.Background(), []PackageQuery{
+		{Ecosystem: "npm", Name: "image-size", Version: "0.7.5"},
+		{Ecosystem: "npm", Name: "image-size", Version: "0.8.3", Dev: true},
+	})
+
+	require.NoError(t, err)
+	require.Len(t, res.Details, 2)
+	byVersion := map[string]VulnDetail{}
+	for _, d := range res.Details {
+		byVersion[d.Version] = d
+	}
+	assert.False(t, byVersion["0.7.5"].Dev)
+	assert.True(t, byVersion["0.8.3"].Dev)
 }

--- a/internal/collectors/vuln_test.go
+++ b/internal/collectors/vuln_test.go
@@ -5,9 +5,11 @@ package collectors
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -23,11 +25,11 @@ type mockOSVClient struct {
 	err     error
 }
 
-func (m *mockOSVClient) QueryBatch(_ context.Context, _ []PackageQuery) ([]VulnDetail, error) {
+func (m *mockOSVClient) QueryBatch(_ context.Context, _ []PackageQuery) (*OSVQueryResult, error) {
 	if m.err != nil {
 		return nil, m.err
 	}
-	return m.results, nil
+	return &OSVQueryResult{Details: m.results}, nil
 }
 
 // validGoMod returns a go.mod with require directives for testing.
@@ -112,7 +114,7 @@ func TestVulnCollector_NoFixAvailable(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, signals, 1)
 
-	assert.Equal(t, 0.80, signals[0].Confidence) // medium severity (C:L)
+	assert.InDelta(t, 0.65, signals[0].Confidence, 0.001) // medium severity (CVSS 5.3)
 	assert.Contains(t, signals[0].Description, "No fix available")
 }
 
@@ -269,7 +271,7 @@ func TestVulnCollector_Metrics(t *testing.T) {
 	assert.Equal(t, "github.com/x/y", metrics.Vulns[0].Module)
 	assert.Equal(t, "v1.0.0", metrics.Vulns[0].Version)
 	assert.Equal(t, "v1.1.0", metrics.Vulns[0].FixedVersion)
-	assert.Equal(t, "high", metrics.Vulns[0].Severity)
+	assert.Equal(t, "critical", metrics.Vulns[0].Severity)
 }
 
 func TestVulnCollector_ReadFileError(t *testing.T) {
@@ -324,22 +326,28 @@ func TestVulnCollector_SeverityBasedConfidence(t *testing.T) {
 		wantSev  string
 	}{
 		{
-			name:     "high severity → 0.95",
+			name:     "critical (9.8) → 0.95",
 			severity: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
 			wantConf: 0.95,
+			wantSev:  "critical",
+		},
+		{
+			name:     "high network DoS (7.5) → 0.85",
+			severity: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+			wantConf: 0.85,
 			wantSev:  "high",
 		},
 		{
-			name:     "medium severity → 0.80",
+			name:     "medium (5.3) → 0.65",
 			severity: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
-			wantConf: 0.80,
+			wantConf: 0.65,
 			wantSev:  "medium",
 		},
 		{
-			name:     "low severity → 0.60",
+			name:     "zero impact → none → 0.30",
 			severity: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N",
-			wantConf: 0.60,
-			wantSev:  "low",
+			wantConf: 0.30,
+			wantSev:  "none",
 		},
 		{
 			name:     "no severity data → 0.80 default",
@@ -402,9 +410,11 @@ func TestConfidenceForSeverity(t *testing.T) {
 		severity string
 		want     float64
 	}{
-		{"high", 0.95},
-		{"medium", 0.80},
-		{"low", 0.60},
+		{"critical", 0.95},
+		{"high", 0.85},
+		{"medium", 0.65},
+		{"low", 0.45},
+		{"none", 0.30},
 		{"", 0.80},
 		{"unknown", 0.80},
 	}
@@ -1370,4 +1380,66 @@ func TestVulnCollector_NpmParseError(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, signals, 1)
 	assert.Equal(t, "go.mod", signals[0].FilePath)
+}
+
+// TestVulnCollector_DevOnlyDiscount verifies dev-only advisories rank below
+// production advisories of equal severity, and that both say which they are
+// (stringer-bqg).
+func TestVulnCollector_DevOnlyDiscount(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "package.json"), []byte(`{
+		"dependencies": {"prod-pkg": "1.0.0"},
+		"devDependencies": {"dev-pkg": "2.0.0"}
+	}`), 0o600))
+
+	highSeverity := "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H" // 7.5 high
+	c := &VulnCollector{osv: &mockOSVClient{
+		results: []VulnDetail{
+			{
+				ID: "GHSA-prod", Summary: "prod vuln", Ecosystem: "npm",
+				PackageName: "prod-pkg", Version: "1.0.0", Severity: highSeverity,
+			},
+			{
+				ID: "GHSA-dev", Summary: "dev vuln", Ecosystem: "npm",
+				PackageName: "dev-pkg", Version: "2.0.0", Severity: highSeverity, Dev: true,
+			},
+		},
+	}}
+
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{})
+	require.NoError(t, err)
+	require.Len(t, signals, 2)
+
+	var prod, dev signal.RawSignal
+	for _, s := range signals {
+		if strings.Contains(s.Title, "prod-pkg") {
+			prod = s
+		} else {
+			dev = s
+		}
+	}
+
+	assert.Greater(t, prod.Confidence, dev.Confidence,
+		"a dev-only advisory must not outrank a production one of equal severity")
+	assert.Contains(t, prod.Description, "Reachability: production")
+	assert.Contains(t, dev.Description, "Reachability: dev-only")
+	assert.Contains(t, prod.Description, "Severity: high (CVSS 7.5)")
+	assert.Contains(t, dev.Tags, "dev-only")
+	assert.NotContains(t, prod.Tags, "dev-only")
+}
+
+// TestVulnCollector_UnavailableIsLoud verifies a total OSV failure is
+// recorded in metrics rather than looking like a clean scan (stringer-kgr).
+func TestVulnCollector_UnavailableIsLoud(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), validGoMod(), 0o600))
+
+	c := &VulnCollector{osv: &mockOSVClient{err: errors.New("network down")}}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{})
+	require.NoError(t, err)
+	assert.Nil(t, signals)
+
+	metrics := c.Metrics().(*VulnMetrics)
+	require.NotNil(t, metrics)
+	assert.True(t, metrics.Unavailable, "an unreachable OSV service must be visible in metrics")
 }


### PR DESCRIPTION
## Summary

Evaluation of stringer 1.8.6 against a real TypeScript/React repo (davetashner/sandtable) showed the vuln collector inverting triage: 4 of 5 filed advisories were dev-only (two at P1) while the one production-reachable advisory was missed entirely, and severity ordering contradicted CVSS. This PR fixes the three root causes and makes partial scans loud.

### Fixes

1. **Version-aware lockfile dedup** — `parseNpmLockDeps` deduped by name only; a lockfile with the same package at two versions (nested deps) queried one, picked by map iteration order. Now name+version, each installed instance a distinct finding. This is the bug that dropped production `image-size 0.7.5` on sandtable.
2. **Dev/prod reachability** — the lockfile's `dev` flag was parsed and discarded. It now flows `PackageQuery → VulnDetail → signal`: a `Reachability:` description line, a `dev-only` tag, and a −0.2 confidence discount so dev-only advisories never outrank production ones of equal severity. Production wins when the same name+version is reachable both ways.
3. **CVSS base-score severity** — severity was derived from CIA impact flags (any H → high), ignoring the score; a moderate advisory outranked a high one. New `vuln_cvss.go` computes the CVSS v3.x base score per the FIRST spec (verified against published scores); the flag heuristic remains as fallback.
4. **Loud partial coverage** — `querybatch` pagination (`next_page_token`) is now followed (max 5 pages/query); detail-fetch failures and truncations are counted in `OSVQueryResult`/`VulnMetrics`; total OSV outage logs at Warn and sets `VulnMetrics.Unavailable` instead of resembling a clean scan.

### Decision record

`docs/decisions/023-vuln-reachability-and-severity.md` — severity/confidence bands, dev discount design, dedup keys, partial-coverage contract.

### Tests

- CVSS base score against published vector scores (9.8/7.5/5.3/6.1/5.5/8.1, roundup edge cases)
- Ordering pin: DoS no longer ties full compromise; dev-only never outranks production at equal severity
- Lockfile dev-flag parsing, prod-wins-over-dev, distinct-versions-distinct-findings
- OSV pagination followed, failed fetches counted, unavailability recorded

Closes stringer-kgr
Closes stringer-bqg
Closes stringer-g9b

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VFi3bSiGFdcRCF3ajTamUA