### PR TITLE
fix(complexity): nesting-aware scoring for regex-analyzed languages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ stringer/
 │   │   ├── docstale.go         # Doc staleness: stale docs, co-change drift, broken links
 │   │   ├── duplication*.go     # Code duplication: exact clones (Type 1) and near-clones (Type 2) via FNV-64a sliding window
 │   │   ├── coupling*.go        # Coupling: circular dependencies (Tarjan's SCC) and high fan-out modules via import graph
-│   │   ├── complexity.go       # Complexity: AST-based for Go (cyclomatic/cognitive/nesting), regex-based for other languages
+│   │   ├── complexity.go       # Complexity: AST-based for Go (cyclomatic/cognitive/nesting); other languages get indentation-derived nesting-weighted scoring with string/comment stripping and a 0.5× JSX logical-op discount (DR-024)
 │   │   ├── complexity_go.go    # Go AST analysis: cyclomatic, cognitive, nesting depth via go/parser
 │   │   ├── githygiene.go       # Git hygiene: large binaries, merge conflicts, committed secrets, mixed line endings
 │   │   ├── secrets.go          # Secret detection: 24+ built-in patterns, custom patterns, allowlist, entropy detection

--- a/docs/decisions/024-regex-complexity-nesting.md
+++ b/docs/decisions/024-regex-complexity-nesting.md
@@ -1,0 +1,32 @@
+# 024: Nesting-Weighted Complexity for Regex-Analyzed Languages
+
+**Status:** Accepted (pre-authorized in session, 2026-08-27)
+**Date:** 2026-08-27
+**Context:** stringer-t98, stringer-sby, stringer-h51 — evaluation of 43 complexity beads on davetashner/sandtable (TypeScript/React) found 25 (58%) pointing at one schema-validator file whose functions are flat lists of independent one-line guards. The old regex score (`lines/50 + branch count`) cannot distinguish twenty flat guards from four conditions nested four deep; Go's AST path already can.
+
+## Problem
+
+Non-Go languages get token counting where complexity is about structure:
+
+1. No nesting term — the score *is* the branch count.
+2. `&&`/`||` counted as branches everywhere, including JSX conditional rendering (`{cond && <X/>}`), React's declarative "show this when" idiom.
+3. Trailing comments and string literals counted — `doThing() // if this fails, retry` and `"retry if unclear"` each contribute a branch.
+4. The bead body was a bare `Location:` line — no metrics, no rationale, no dismiss criteria.
+
+## Options
+
+**Nesting source:** (a) tree-sitter/AST per language — correct but a large dependency and per-language work (remains the long-term fix, tracked separately); (b) indentation-derived depth. Chose **(b)** for now: depth = 1 + (indent − base)/unit, where unit is the smallest observed indent step (≥2 columns, fallback 4), capped at 10. Continuation-line indentation is kept out of the reported nesting by tracking max depth only on lines that carry control-flow keywords.
+
+**Weighting:** cognitive-complexity shape — a branch keyword at depth *d* costs *d* (flat guards cost 1 each, exactly the old behavior; nesting is superlinear in aggregate because deeper branches imply their enclosing branches). Logical operators cost a flat 1 — they are conditions, not structure — and 0.5 in `.jsx`/`.tsx` files, where distinguishing JSX expressions from logic without a parser is impractical; the discount is documented rather than hidden.
+
+**Flat-function confidence cap:** when max nesting ≤ 2, confidence is capped at 0.55 (P3). A validator or dispatch table written as a flat rule list is often the clearest form of that code; the cap keeps such findings visible without letting them claim P1/P2, and the bead body says explicitly that the finding is dismissible. On sandtable this demotes all 25 validator beads while `TourProvider` (genuinely tangled, produced a shipped bug) keeps its top rank.
+
+**Counting hygiene:** a line-local quote-state scan strips string contents and trailing `//`, `#` (Python/Ruby/Elixir), and `/* */` comments before matching. Rust exempts `'` (lifetimes would read as unterminated char literals).
+
+**Bead bodies:** every complexity signal now carries WHAT (the metrics), WHY, ACTION, DISMISS, and CONTEXT (threshold + config key), per stringer-h51. DISMISS is tailored: flat functions are told they are probably fine.
+
+## Consequences
+
+- Scores drop for flat/JSX-heavy code and hold for nested code; signal titles change (nesting added), so signal IDs change and delta scans will report these as new once.
+- Indentation-derived depth is a heuristic: unindented (minified) code reads as flat — acceptable, since minified files are mostly excluded as generated.
+- Tree-sitter adoption would collapse the two analysis tiers entirely; this record does not preclude it.

--- a/internal/collectors/complexity.go
+++ b/internal/collectors/complexity.go
@@ -36,11 +36,11 @@ type FunctionComplexity struct {
 	StartLine  int
 	EndLine    int
 	Lines      int
-	Branches   int
-	Score      float64 // lines/50 + branches (regex) or max(cyc/20, cog/30, nest/5) (AST)
+	Branches   int     // raw branch keywords + logical operators
+	Score      float64 // lines/50 + nesting-weighted branches (regex) or cognitive (AST)
 	Cyclomatic int     // AST-based cyclomatic complexity (0 if regex-analyzed)
 	Cognitive  int     // AST-based cognitive complexity (0 if regex-analyzed)
-	MaxNesting int     // AST-based max nesting depth (0 if regex-analyzed)
+	MaxNesting int     // max nesting depth: AST-derived (Go) or indentation-derived (regex)
 	ASTBased   bool    // true if analyzed via Go AST, false if regex-based
 }
 
@@ -311,7 +311,7 @@ func (c *ComplexityCollector) Collect(ctx context.Context, repoPath string, opts
 				FilePath:    fc.FilePath,
 				Line:        fc.StartLine,
 				Title:       fmt.Sprintf("%s: %s (cyclomatic: %d, cognitive: %d, nesting: %d)", titleKind, fc.FuncName, fc.Cyclomatic, fc.Cognitive, fc.MaxNesting),
-				Description: fmt.Sprintf("Lines %d-%d in %s", fc.StartLine, fc.EndLine, fc.FilePath),
+				Description: astComplexityDescription(fc),
 				Confidence:  conf,
 				Tags:        []string{"complexity", "go", "ast-analyzed"},
 			})
@@ -320,15 +320,16 @@ func (c *ComplexityCollector) Collect(ctx context.Context, repoPath string, opts
 			if fc.Score < minScore {
 				continue
 			}
-			conf := complexityConfidence(fc.Score)
+			conf := regexComplexityConfidence(fc.Score, fc.MaxNesting)
 			signals = append(signals, signal.RawSignal{
-				Source:     "complexity",
-				Kind:       "complex-function",
-				FilePath:   fc.FilePath,
-				Line:       fc.StartLine,
-				Title:      fmt.Sprintf("Complex function: %s (score %.1f, %d lines, %d branches)", fc.FuncName, fc.Score, fc.Lines, fc.Branches),
-				Confidence: conf,
-				Tags:       []string{"complexity", "refactor-candidate"},
+				Source:      "complexity",
+				Kind:        "complex-function",
+				FilePath:    fc.FilePath,
+				Line:        fc.StartLine,
+				Title:       fmt.Sprintf("Complex function: %s (score %.1f, %d lines, %d branches, nesting %d)", fc.FuncName, fc.Score, fc.Lines, fc.Branches, fc.MaxNesting),
+				Description: regexComplexityDescription(fc, minScore),
+				Confidence:  conf,
+				Tags:        []string{"complexity", "refactor-candidate"},
 			})
 		}
 	}
@@ -395,17 +396,22 @@ func extractFunctions(lines []string, relPath string, spec *langSpec, minLines i
 		}
 
 		if len(bodyLines) >= minLines {
-			branches := countBranches(bodyLines)
+			ext := filepath.Ext(relPath)
+			body := analyzeBody(bodyLines, ext)
 			nonBlank := countNonBlank(bodyLines)
-			score := float64(nonBlank)/50.0 + float64(branches)
+			// Lines contribute marginally; the score is dominated by
+			// nesting-weighted branch points so that a flat guard list
+			// scores far below equally-branchy nested code (stringer-t98).
+			score := float64(nonBlank)/50.0 + body.WeightedBranches
 
 			results = append(results, FunctionComplexity{
-				FilePath:  relPath,
-				FuncName:  funcName,
-				StartLine: startLine,
-				Lines:     nonBlank,
-				Branches:  branches,
-				Score:     score,
+				FilePath:   relPath,
+				FuncName:   funcName,
+				StartLine:  startLine,
+				Lines:      nonBlank,
+				Branches:   body.Branches,
+				Score:      score,
+				MaxNesting: body.MaxNesting,
 			})
 		}
 
@@ -566,22 +572,169 @@ func leadingSpaces(line string) int {
 	return count
 }
 
-// countBranches counts control flow keywords and logical operators in lines,
-// skipping comment-only lines.
-func countBranches(lines []string) int {
-	count := 0
+// bodyAnalysis holds the branch metrics for one function body.
+type bodyAnalysis struct {
+	Branches         int     // raw branch keywords + logical operators
+	WeightedBranches float64 // nesting-weighted branch cost (see analyzeBody)
+	MaxNesting       int     // indentation-derived max depth (1 = flat)
+}
+
+// jsxLogicalOpWeight discounts && and || in .jsx/.tsx files: `{cond && <X/>}`
+// is React's conditional-rendering idiom, not control flow a reader must
+// hold in their head (stringer-sby). Distinguishing JSX expressions from
+// real logic without a parser is impractical line-by-line, so logical
+// operators in these files count at half weight, documented in AGENTS.md.
+const jsxLogicalOpWeight = 0.5
+
+// maxIndentDepth caps indentation-derived nesting so continuation-line
+// indentation cannot run the depth to absurd values.
+const maxIndentDepth = 10
+
+// analyzeBody counts branch points in a function body, weighting each
+// control-flow keyword by the nesting depth of its line the way cognitive
+// complexity does: a branch at depth 1 costs 1, at depth d costs d. Depth
+// is derived from indentation (relative to the shallowest code line, in
+// units of the smallest observed indent step), which separates "twenty
+// flat guards" from "four conditions nested four deep" without a parser
+// (stringer-t98). String literals and comments are stripped before
+// matching so message text and trailing notes don't count as control flow
+// (stringer-sby). Logical operators count at depth-independent weight 1
+// (0.5 in .jsx/.tsx): they are conditions, not structure.
+func analyzeBody(lines []string, ext string) bodyAnalysis {
+	logicalWeight := 1.0
+	if ext == ".jsx" || ext == ".tsx" {
+		logicalWeight = jsxLogicalOpWeight
+	}
+
+	type codeLine struct {
+		clean  string
+		indent int
+	}
+	var code []codeLine
 	for _, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		if trimmed == "" {
+		if strings.TrimSpace(line) == "" {
 			continue
 		}
 		if commentLinePattern.MatchString(line) {
 			continue
 		}
-		count += len(branchPattern.FindAllString(line, -1))
-		count += len(logicalOpPattern.FindAllString(line, -1))
+		clean := stripStringsAndComments(line, ext)
+		if strings.TrimSpace(clean) == "" {
+			continue
+		}
+		code = append(code, codeLine{clean: clean, indent: leadingSpaces(line)})
 	}
-	return count
+	if len(code) == 0 {
+		return bodyAnalysis{MaxNesting: 1}
+	}
+
+	base := code[0].indent
+	indentSet := make(map[int]bool)
+	for _, cl := range code {
+		if cl.indent < base {
+			base = cl.indent
+		}
+		indentSet[cl.indent] = true
+	}
+	unit := inferIndentUnit(indentSet)
+
+	out := bodyAnalysis{MaxNesting: 1}
+	for _, cl := range code {
+		depth := 1 + (cl.indent-base)/unit
+		if depth > maxIndentDepth {
+			depth = maxIndentDepth
+		}
+
+		branches := len(branchPattern.FindAllString(cl.clean, -1))
+		logicals := len(logicalOpPattern.FindAllString(cl.clean, -1))
+
+		out.Branches += branches + logicals
+		out.WeightedBranches += float64(branches*depth) + float64(logicals)*logicalWeight
+
+		// Nesting is a structural property: track it on lines that carry
+		// control flow, so continuation-line indentation doesn't inflate it.
+		if branches > 0 && depth > out.MaxNesting {
+			out.MaxNesting = depth
+		}
+	}
+	return out
+}
+
+// inferIndentUnit returns the indentation step size for a body: the
+// smallest positive difference between observed indent levels, clamped to
+// at least 2 columns (1-column deltas are usually alignment, not nesting).
+// Falls back to 4 when the body has a single indent level.
+func inferIndentUnit(indents map[int]bool) int {
+	levels := make([]int, 0, len(indents))
+	for i := range indents {
+		levels = append(levels, i)
+	}
+	sort.Ints(levels)
+
+	unit := 0
+	for i := 1; i < len(levels); i++ {
+		d := levels[i] - levels[i-1]
+		if d >= 2 && (unit == 0 || d < unit) {
+			unit = d
+		}
+	}
+	if unit == 0 {
+		return 4
+	}
+	return unit
+}
+
+// stripStringsAndComments removes string-literal contents and trailing
+// comments from a line so tokens inside them ("retry if this fails",
+// `// if unset, defaults`) don't count as branches (stringer-sby). It is a
+// single-pass quote-state scan, deliberately line-local: multi-line
+// strings are already approximated by the surrounding heuristics.
+func stripStringsAndComments(line, ext string) string {
+	// Languages where # starts a comment.
+	hashComment := ext == ".py" || ext == ".rb" || ext == ".ex" || ext == ".exs"
+	// Rust lifetimes ('a) would read as an unterminated char literal and
+	// swallow the rest of the line, so ' is not a string quote there.
+	singleQuote := ext != ".rs"
+
+	var b strings.Builder
+	runes := []rune(line)
+	var quote rune
+	escaped := false
+
+	for i := 0; i < len(runes); i++ {
+		ch := runes[i]
+		if quote != 0 {
+			switch {
+			case escaped:
+				escaped = false
+			case ch == '\\':
+				escaped = true
+			case ch == quote:
+				quote = 0
+				b.WriteRune(ch)
+			}
+			continue
+		}
+		switch {
+		case ch == '"' || ch == '`' || (ch == '\'' && singleQuote):
+			quote = ch
+			b.WriteRune(ch)
+		case ch == '/' && i+1 < len(runes) && runes[i+1] == '/':
+			return b.String()
+		case ch == '/' && i+1 < len(runes) && runes[i+1] == '*':
+			rest := string(runes[i+2:])
+			end := strings.Index(rest, "*/")
+			if end < 0 {
+				return b.String()
+			}
+			i += 2 + end + 1
+		case ch == '#' && hashComment:
+			return b.String()
+		default:
+			b.WriteRune(ch)
+		}
+	}
+	return b.String()
 }
 
 // countNonBlank counts non-blank lines.
@@ -593,6 +746,49 @@ func countNonBlank(lines []string) int {
 		}
 	}
 	return count
+}
+
+// regexComplexityConfidence maps a regex-path score to confidence, then
+// caps mostly-flat functions at 0.55 (P3 after priority mapping): when
+// nesting is 1–2 the score is driven by branch count alone, and a flat
+// guard list — a validator, a dispatch table — is often the clearest way
+// to write that code (stringer-t98). The bead body says so explicitly.
+func regexComplexityConfidence(score float64, maxNesting int) float64 {
+	conf := complexityConfidence(score)
+	if maxNesting <= 2 && conf > 0.55 {
+		conf = 0.55
+	}
+	return conf
+}
+
+// regexComplexityDescription builds the WHAT/WHY/ACTION/DISMISS/CONTEXT body
+// for a regex-analyzed finding, so a generated bead carries its metrics,
+// its rationale, and an honest statement of when to close it (stringer-h51).
+func regexComplexityDescription(fc FunctionComplexity, minScore float64) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "WHAT: score %.1f = %d non-blank lines ÷ 50 + nesting-weighted branch points (%d raw branches/operators, max nesting depth %d).\n",
+		fc.Score, fc.Lines, fc.Branches, fc.MaxNesting)
+	b.WriteString("WHY: branches buried under nesting are where readers lose track of state; a flat list of guards reads cheaply even when long.\n")
+	if fc.MaxNesting <= 2 {
+		b.WriteString("ACTION: likely none — see DISMISS.\n")
+		b.WriteString("DISMISS: this function is mostly flat (nesting ≤ 2), so the score is driven by branch count alone; validators, dispatch tables, and config builders are often clearest as a flat rule list. Confidence has been capped accordingly — close as working-as-intended unless the branch logic genuinely interleaves.\n")
+	} else {
+		b.WriteString("ACTION: extract the most deeply nested blocks into named helpers, or invert conditions with early returns to flatten the structure.\n")
+		b.WriteString("DISMISS: if the nesting mirrors an inherent structure (a state machine, a recursive descent), a rewrite may not clarify — close with a comment saying so.\n")
+	}
+	fmt.Fprintf(&b, "CONTEXT: fires at score ≥ %.1f; tune via collectors.complexity.min_complexity_score. Non-Go languages are analyzed heuristically (indentation-derived nesting); Go gets AST-based cognitive complexity.", minScore)
+	return b.String()
+}
+
+// astComplexityDescription builds the body for a Go AST-analyzed finding.
+func astComplexityDescription(fc FunctionComplexity) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "WHAT: cyclomatic %d, cognitive %d, max nesting %d. Lines %d-%d in %s.\n",
+		fc.Cyclomatic, fc.Cognitive, fc.MaxNesting, fc.StartLine, fc.EndLine, fc.FilePath)
+	b.WriteString("WHY: cognitive complexity measures how much state a reader must hold; it grows superlinearly with nesting.\n")
+	b.WriteString("ACTION: extract the most deeply nested blocks into named functions; prefer early returns over else-chains.\n")
+	b.WriteString("DISMISS: table-driven or generated code with low nesting relative to cyclomatic count is often fine as-is — close with a comment saying so.")
+	return b.String()
 }
 
 // complexityConfidence maps a complexity score to a confidence value per DR-013:

--- a/internal/collectors/complexity_test.go
+++ b/internal/collectors/complexity_test.go
@@ -273,7 +273,7 @@ end`, "\n")
 	}
 }
 
-func TestCountBranches(t *testing.T) {
+func TestAnalyzeBody_CountsBranches(t *testing.T) {
 	lines := []string{
 		"	if x > 0 {",
 		"		// if this is a comment",
@@ -286,19 +286,125 @@ func TestCountBranches(t *testing.T) {
 		"		}",
 		"	}",
 	}
-	count := countBranches(lines)
-	// if + for + if + || + switch + case + case = 7
-	assert.Equal(t, 7, count)
+	body := analyzeBody(lines, ".ts")
+	// if + for + if + || + switch + case + case = 7 raw
+	assert.Equal(t, 7, body.Branches)
+	// Nested branches cost their depth: if@1 + for@2 + if@3 + switch@4 +
+	// case@4 + case@4 = 1+2+3+4+4+4 = 18, plus || at weight 1 = 19.
+	assert.InDelta(t, 19.0, body.WeightedBranches, 0.01)
+	assert.Equal(t, 4, body.MaxNesting)
 }
 
-func TestCountBranches_SkipsComments(t *testing.T) {
+func TestAnalyzeBody_SkipsComments(t *testing.T) {
 	lines := []string{
 		"// if this is commented",
 		"# elif this too",
 		"  if real_code:",
 	}
-	count := countBranches(lines)
-	assert.Equal(t, 1, count)
+	body := analyzeBody(lines, ".py")
+	assert.Equal(t, 1, body.Branches)
+}
+
+// TestAnalyzeBody_FlatVsNested is the eval fixture proposed in stringer-t98:
+// two bodies with identical branch counts, one flat and one nested four
+// deep. The nested one must score materially higher; before the nesting
+// term they tied.
+func TestAnalyzeBody_FlatVsNested(t *testing.T) {
+	flat := []string{
+		"  if a { doA() }",
+		"  if b { doB() }",
+		"  if c { doC() }",
+		"  if d { doD() }",
+	}
+	nested := []string{
+		"  if a {",
+		"    if b {",
+		"      if c {",
+		"        if d { doD() }",
+		"      }",
+		"    }",
+		"  }",
+	}
+	f := analyzeBody(flat, ".ts")
+	n := analyzeBody(nested, ".ts")
+	assert.Equal(t, f.Branches, n.Branches, "raw branch counts must match for the comparison to mean anything")
+	assert.Greater(t, n.WeightedBranches, f.WeightedBranches*1.5,
+		"nested-4-deep must score materially higher than a flat guard list")
+	assert.Equal(t, 1, f.MaxNesting)
+	assert.Equal(t, 4, n.MaxNesting)
+}
+
+// TestAnalyzeBody_JSXDiscount verifies && in .tsx counts at half weight:
+// conditional rendering is an idiom, not control flow (stringer-sby).
+func TestAnalyzeBody_JSXDiscount(t *testing.T) {
+	lines := []string{
+		"  return (",
+		"    <div>",
+		"      {showHeader && <Header/>}",
+		"      {showBody && <Body/>}",
+		"      {showFooter && <Footer/>}",
+		"    </div>",
+		"  )",
+	}
+	tsx := analyzeBody(lines, ".tsx")
+	ts := analyzeBody(lines, ".ts")
+	assert.Equal(t, 3, tsx.Branches)
+	assert.InDelta(t, 1.5, tsx.WeightedBranches, 0.01)
+	assert.InDelta(t, 3.0, ts.WeightedBranches, 0.01)
+}
+
+// TestAnalyzeBody_IgnoresStringsAndTrailingComments pins the two counting
+// bugs from stringer-sby: tokens inside string literals and trailing
+// comments counted as control flow.
+func TestAnalyzeBody_IgnoresStringsAndTrailingComments(t *testing.T) {
+	lines := []string{
+		`  log.error("retry if the switch fails, or when the case is unclear")`,
+		"  doThing() // if this fails, retry while the loop drains",
+		"  x := 1",
+	}
+	body := analyzeBody(lines, ".go")
+	assert.Equal(t, 0, body.Branches)
+}
+
+func TestStripStringsAndComments(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		ext  string
+		want string
+	}{
+		{"double-quoted string emptied", `x := "if for while"`, ".go", `x := ""`},
+		{"trailing // comment removed", "doThing() // if broken", ".ts", "doThing() "},
+		{"trailing # comment removed (python)", "do_thing()  # unless broken", ".py", "do_thing()  "},
+		{"# kept for non-hash languages", `tag := t # 1`, ".go", `tag := t # 1`},
+		{"inline block comment removed", "a /* if x */ b", ".go", "a  b"},
+		{"unterminated block comment truncates", "a /* if x", ".go", "a "},
+		{"escaped quote stays inside string", "s := \"say \\\"if\\\" twice\"; run()", ".go", `s := ""; run()`},
+		{"rust lifetime is not a string", "fn use_it(x: &'a str) { if y {} }", ".rs", "fn use_it(x: &'a str) { if y {} }"},
+		{"code after string survives", `if x == "case" && y {`, ".go", `if x == "" && y {`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, stripStringsAndComments(tt.line, tt.ext))
+		})
+	}
+}
+
+func TestInferIndentUnit(t *testing.T) {
+	assert.Equal(t, 2, inferIndentUnit(map[int]bool{2: true, 4: true, 6: true}))
+	assert.Equal(t, 4, inferIndentUnit(map[int]bool{4: true, 8: true}))
+	assert.Equal(t, 4, inferIndentUnit(map[int]bool{4: true}), "single level falls back to 4")
+	assert.Equal(t, 4, inferIndentUnit(map[int]bool{4: true, 5: true}), "1-column deltas are alignment, not nesting")
+}
+
+func TestRegexComplexityConfidence_FlatCap(t *testing.T) {
+	// A high score with flat structure is capped at 0.55 (P3): flat guard
+	// lists are often the clearest way to write the code (stringer-t98).
+	assert.InDelta(t, 0.55, regexComplexityConfidence(20.0, 1), 0.001)
+	assert.InDelta(t, 0.55, regexComplexityConfidence(20.0, 2), 0.001)
+	assert.InDelta(t, 0.8, regexComplexityConfidence(20.0, 3), 0.001)
+	// Below the cap, flat functions keep their score-based confidence.
+	assert.InDelta(t, 0.5, regexComplexityConfidence(6.0, 1), 0.001)
 }
 
 func TestComplexityConfidence(t *testing.T) {

--- a/internal/report/complexity.go
+++ b/internal/report/complexity.go
@@ -124,6 +124,7 @@ func (s *complexitySection) Render(w io.Writer) error {
 			Column{Header: "File"},
 			Column{Header: "Lines", Align: AlignRight},
 			Column{Header: "Branches", Align: AlignRight},
+			Column{Header: "Nesting", Align: AlignRight},
 			Column{Header: "Score", Align: AlignRight, Color: ColorComplexity},
 		)
 		for _, fc := range regexFuncs {
@@ -132,6 +133,7 @@ func (s *complexitySection) Render(w io.Writer) error {
 				fc.FilePath,
 				fmt.Sprintf("%d", fc.Lines),
 				fmt.Sprintf("%d", fc.Branches),
+				fmt.Sprintf("%d", fc.MaxNesting),
 				fmt.Sprintf("%.1f", fc.Score),
 			)
 		}


### PR DESCRIPTION
## Summary

On a real TypeScript/React repo, 25 of 43 complexity findings (58%) pointed at one schema-validator file whose functions are flat lists of independent one-line guards — by construction the clearest way to write them — because the regex path scores `lines/50 + raw branch count` with no nesting term, while JSX conditional rendering, trailing comments, and string-literal text all counted as control flow.

### Changes

1. **Nesting-weighted branches** (stringer-t98) — a branch keyword at indentation-derived depth *d* costs *d* (cognitive-complexity shape). Flat guards cost 1 each, exactly the old behavior; nested code now scores superlinearly higher. Depth unit is inferred per body, capped at 10, and tracked only on control-flow lines so continuation indentation doesn't inflate it.
2. **JSX discount** (stringer-sby) — `&&`/`||` count at 0.5 weight in `.jsx/.tsx`: `{cond && <X/>}` is a rendering idiom, not control flow. Logical ops elsewhere cost flat 1 (conditions, not structure).
3. **Counting hygiene** (stringer-sby) — string literals and trailing `//`, `#`, `/* */` comments stripped before matching via a quote-state scan (Rust exempts `'` for lifetimes).
4. **Flat-function cap** — nesting ≤ 2 caps confidence at 0.55 (P3): validators and dispatch tables stay visible but never claim P1/P2. On sandtable this demotes all 25 validator beads while `TourProvider` (genuinely tangled; produced a shipped bug) keeps top rank.
5. **Rich bead bodies** (stringer-h51, complexity half) — WHAT/WHY/ACTION/DISMISS/CONTEXT template for both regex and AST paths, with DISMISS tailored to flat functions. Titles and the report table gain the nesting metric.

### Eval fixture

`TestAnalyzeBody_FlatVsNested` pins the bead's proposed eval: identical branch counts, flat vs nested-4-deep — nested must score materially higher (before: they tied).

### Decision record

`docs/decisions/024-regex-complexity-nesting.md`

Note: titles change → signal IDs change, so the next delta scan reports these as new once. stringer-h51 stays open for the coupling half (next PR).

Closes stringer-t98
Closes stringer-sby

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VFi3bSiGFdcRCF3ajTamUA