### PR TITLE
fix(coupling): exempt aggregators from fan-out signals, add rich bodies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ stringer/
 │   │   ├── apidrift.go         # API drift: undocumented routes, unimplemented spec paths, stale versions
 │   │   ├── docstale.go         # Doc staleness: stale docs, co-change drift, broken links (URI-scheme targets and fenced code blocks are skipped)
 │   │   ├── duplication*.go     # Code duplication: exact clones (Type 1) and near-clones (Type 2) via FNV-64a sliding window; test-only clone groups down-weighted and tagged test-only
-│   │   ├── coupling*.go        # Coupling: circular dependencies (Tarjan's SCC) and high fan-out modules via import graph
+│   │   ├── coupling*.go        # Coupling: circular dependencies (Tarjan's SCC) and high fan-out modules via import graph; entry points/barrels auto-exempt, per-path exempt globs, default threshold 15 (DR-025)
 │   │   ├── complexity.go       # Complexity: AST-based for Go (cyclomatic/cognitive/nesting); other languages get indentation-derived nesting-weighted scoring with string/comment stripping and a 0.5× JSX logical-op discount (DR-024)
 │   │   ├── complexity_go.go    # Go AST analysis: cyclomatic, cognitive, nesting depth via go/parser
 │   │   ├── githygiene.go       # Git hygiene: large binaries, merge conflicts, committed secrets, mixed line endings — tracked files only (git ls-files), full-scan fallback outside a repo

--- a/cmd/stringer/collectors.go
+++ b/cmd/stringer/collectors.go
@@ -137,8 +137,9 @@ var collectorThresholds = map[string][]struct {
 		{"deadcode_max_files", "10000"},
 	},
 	"coupling": {
-		{"coupling_fan_out_threshold", "10"},
+		{"coupling_fan_out_threshold", "15"},
 		{"coupling_max_files", "10000"},
+		{"coupling_exempt_patterns", "[]"},
 	},
 	"docstale": {
 		{"doc_stale_days", "180"},

--- a/docs/decisions/025-coupling-aggregator-exemption.md
+++ b/docs/decisions/025-coupling-aggregator-exemption.md
@@ -1,0 +1,27 @@
+# 025: Aggregator Exemption for Fan-Out Coupling Signals
+
+**Status:** Accepted (pre-authorized in session, 2026-08-27)
+**Date:** 2026-08-27
+**Context:** stringer-3v0, stringer-h51 — of three high-coupling beads filed on davetashner/sandtable, two were false by construction: a component gallery whose purpose (enforced by a test) is importing every component, and the composition root of a single-page app. The third cleared the threshold at ten imports — unremarkable for a React card component.
+
+## Problem
+
+Fan-out is a real signal about modules in the *middle* of the import graph. A module whose role is aggregation — an entry point, a gallery, a barrel — has wide imports as its job, and an absolute threshold of 10 flags ordinary component-per-file code.
+
+## Options
+
+Considered per the bead, cheapest first; adopted a combination:
+
+1. **Per-path exemption config** — `coupling_exempt_patterns` glob list under the coupling collector, so a repo states "gallery and entry points are exempt" once. Adopted.
+2. **Automatic role recognition** — adopted two cheap, safe rules:
+   - *Entry points:* modules with in-degree 0 in the intra-project graph, counting only non-test importers (a test importing its subject does not make the subject mid-graph). Covers `main`, app roots, galleries, scripts.
+   - *Barrels:* modules whose basename is `index`, `mod`, or `__init__`.
+   Build-config entry detection (vite/webpack/package.json) was deferred: the in-degree rule already covers those files in practice.
+3. **Relative (repo-scaled) threshold** — deferred. The absolute default moved 10 → 15 instead; component-per-file ecosystems clear 10 trivially. Repo-relative ranking remains open if 15 proves wrong.
+4. **Rich bead body** — every fan-out signal now carries WHAT (count vs threshold), WHY, ACTION, a DISMISS naming the auto-exemptions and the config key, and CONTEXT. Circular-dependency signals already had descriptive bodies.
+
+## Consequences
+
+- Exempted modules are counted in `CouplingMetrics.ExemptedAggregators` so the report can show what was suppressed rather than silently dropping it.
+- A genuinely problematic god-module that nothing imports *yet* (dead aggregate) will not be flagged by fan-out; the deadcode collector is the right owner for that shape.
+- Threshold change 10 → 15 may suppress previously-reported signals; noted in the changelog.

--- a/internal/collectors/coupling.go
+++ b/internal/collectors/coupling.go
@@ -24,11 +24,12 @@ func init() {
 
 // CouplingMetrics holds structured metrics from the coupling scan.
 type CouplingMetrics struct {
-	FilesScanned       int
-	ModulesFound       int
-	CircularDeps       int
-	HighCouplingCount  int
-	SkippedCapExceeded bool
+	FilesScanned        int
+	ModulesFound        int
+	CircularDeps        int
+	HighCouplingCount   int
+	ExemptedAggregators int // entry points/barrels/exempt-glob modules not signaled
+	SkippedCapExceeded  bool
 }
 
 // CouplingCollector detects circular dependencies and high-coupling modules
@@ -203,6 +204,32 @@ func (c *CouplingCollector) Collect(ctx context.Context, repoPath string, opts s
 		return nil, err
 	}
 
+	// Fan-out matters when a module in the middle of the graph pulls in
+	// the world, not when a leaf entry does (stringer-3v0). Compute each
+	// module's in-degree, counting only non-test importers: a test
+	// importing its subject does not make the subject a mid-graph module.
+	inDegree := make(map[string]int)
+	for mod, deps := range graph {
+		if isTestModule(mod) {
+			continue
+		}
+		unique := make(map[string]bool)
+		for _, d := range deps {
+			unique[d] = true
+		}
+		for d := range unique {
+			inDegree[d]++
+		}
+	}
+
+	// Map modules back to a representative file path for glob matching.
+	moduleFile := make(map[string]string, len(files))
+	for _, f := range files {
+		if _, ok := moduleFile[f.module]; !ok {
+			moduleFile[f.module] = f.relPath
+		}
+	}
+
 	// Phase 5: Generate signals.
 	var signals []signal.RawSignal
 
@@ -221,21 +248,35 @@ func (c *CouplingCollector) Collect(ctx context.Context, repoPath string, opts s
 	}
 	sort.Strings(fanOutMods)
 
+	exempted := 0
 	for _, mod := range fanOutMods {
 		count := highFanOut[mod]
-		sig := buildFanOutSignal(mod, count, fanOutThreshold, opts.MinConfidence)
-		if sig != nil {
-			signals = append(signals, *sig)
+		switch {
+		case inDegree[mod] == 0:
+			// Entry points, galleries, scripts: nothing (outside tests)
+			// imports them, so wide imports are their job.
+			exempted++
+		case isBarrelModule(mod):
+			// index/barrel files exist to aggregate re-exports.
+			exempted++
+		case matchesAny(moduleFile[mod], opts.CouplingExemptPatterns):
+			exempted++
+		default:
+			sig := buildFanOutSignal(mod, count, fanOutThreshold, opts.MinConfidence)
+			if sig != nil {
+				signals = append(signals, *sig)
+			}
 		}
 	}
 
 	// Set metrics.
 	c.metrics = &CouplingMetrics{
-		FilesScanned:       fileCount,
-		ModulesFound:       len(moduleSet),
-		CircularDeps:       len(sccs),
-		HighCouplingCount:  len(highFanOut),
-		SkippedCapExceeded: capExceeded,
+		FilesScanned:        fileCount,
+		ModulesFound:        len(moduleSet),
+		CircularDeps:        len(sccs),
+		HighCouplingCount:   len(highFanOut) - exempted,
+		ExemptedAggregators: exempted,
+		SkippedCapExceeded:  capExceeded,
 	}
 
 	// Enrich timestamps from git log.
@@ -290,9 +331,12 @@ func buildFanOutSignal(module string, count, threshold int, minConfidence float6
 
 	title := fmt.Sprintf("High coupling: %s imports %d modules", module, count)
 	desc := fmt.Sprintf(
-		"Module %q has %d direct dependencies, which is above the threshold of %d. "+
-			"High fan-out increases the risk of cascading breakage when any dependency changes.",
-		module, count, threshold,
+		"WHAT: %q has %d direct in-project dependencies; the threshold is %d.\n"+
+			"WHY: a module in the middle of the graph with wide fan-out turns any dependency change into a potential cascade through it.\n"+
+			"ACTION: split the module along its clusters of imports, or push decisions down so callers depend on narrower seams.\n"+
+			"DISMISS: if this file's role is aggregation — an entry point, a gallery, a barrel — wide imports are its job; entry points (nothing imports them) and index barrels are auto-exempt, and you can exempt this path once via collectors.coupling.coupling_exempt_patterns in .stringer.yml.\n"+
+			"CONTEXT: threshold configurable via collectors.coupling.coupling_fan_out_threshold (default %d).",
+		module, count, threshold, defaultFanOutThreshold,
 	)
 
 	return &signal.RawSignal{
@@ -304,6 +348,21 @@ func buildFanOutSignal(module string, count, threshold int, minConfidence float6
 		Confidence:  conf,
 		Tags:        []string{"architecture", "coupling"},
 	}
+}
+
+// isTestModule reports whether a module name looks like a test module, so
+// test importers don't count toward a module's in-degree.
+func isTestModule(mod string) bool {
+	base := strings.ToLower(filepath.Base(mod))
+	return strings.Contains(base, ".test") || strings.Contains(base, ".spec") ||
+		strings.HasSuffix(base, "_test") || strings.HasPrefix(base, "test_")
+}
+
+// isBarrelModule reports whether a module is an index/barrel file whose
+// purpose is re-exporting.
+func isBarrelModule(mod string) bool {
+	base := strings.ToLower(filepath.Base(mod))
+	return base == "index" || base == "mod" || base == "__init__"
 }
 
 // cycleConfidence returns the confidence for a circular dependency signal.

--- a/internal/collectors/coupling_graph.go
+++ b/internal/collectors/coupling_graph.go
@@ -410,7 +410,11 @@ func tarjanSCC(ctx context.Context, graph importGraph) ([][]string, error) {
 
 // --- Fan-out analysis ---
 
-const defaultFanOutThreshold = 10
+// defaultFanOutThreshold is the fan-out count at which a module is flagged.
+// 15, not 10: in component-per-file ecosystems an ordinary React card with
+// hooks, types, styles and three children clears ten imports without being
+// coupled in any meaningful sense (stringer-3v0).
+const defaultFanOutThreshold = 15
 
 // fanOutModules returns modules whose direct import count meets or exceeds
 // the threshold, along with their counts.

--- a/internal/collectors/coupling_test.go
+++ b/internal/collectors/coupling_test.go
@@ -550,28 +550,33 @@ func TestCouplingCollect_HighCoupling(t *testing.T) {
 
 	writeCouplingTestFile(t, dir, "go.mod", "module "+modPath+"\n\ngo 1.21\n")
 
-	// Create 12 leaf packages.
-	for i := 0; i < 12; i++ {
+	// Create 16 leaf packages (default threshold is 15).
+	for i := 0; i < 16; i++ {
 		pkgName := string(rune('a' + i))
 		writeCouplingTestFile(t, dir, "pkg"+pkgName+"/"+pkgName+".go",
 			"package pkg"+pkgName+"\n\nfunc Do() {}\n")
 	}
 
-	// Create hub package that imports all 12.
+	// Create hub package that imports all 16.
 	var imports strings.Builder
 	imports.WriteString("package hub\n\nimport (\n")
-	for i := 0; i < 12; i++ {
+	for i := 0; i < 16; i++ {
 		pkgName := string(rune('a' + i))
 		imports.WriteString("\t\"" + modPath + "/pkg" + pkgName + "\"\n")
 	}
 	imports.WriteString(")\n\nfunc Hub() {\n")
-	for i := 0; i < 12; i++ {
+	for i := 0; i < 16; i++ {
 		pkgName := string(rune('a' + i))
 		imports.WriteString("\tpkg" + pkgName + ".Do()\n")
 	}
 	imports.WriteString("}\n")
 
 	writeCouplingTestFile(t, dir, "hub/hub.go", imports.String())
+
+	// A consumer imports hub, making hub a mid-graph module rather than an
+	// entry point (entry points are exempt from fan-out signals).
+	writeCouplingTestFile(t, dir, "consumer/consumer.go",
+		"package consumer\n\nimport \""+modPath+"/hub\"\n\nfunc Use() { hub.Hub() }\n")
 
 	c := &CouplingCollector{}
 	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{})
@@ -985,8 +990,11 @@ func Hub() { a.A(); b.B(); c.C(); d.D(); e.E() }
 		writeCouplingTestFile(t, dir, pkg+"/"+pkg+".go",
 			fmt.Sprintf("package %s\n\nfunc %s() {}\n", pkg, strings.ToUpper(pkg)))
 	}
+	// A consumer imports hub so hub is not an (exempt) entry point.
+	writeCouplingTestFile(t, dir, "consumer/consumer.go",
+		"package consumer\n\nimport \"example.com/test/hub\"\n\nfunc Use() { hub.Hub() }\n")
 
-	// With default threshold (10), 5 imports should NOT trigger.
+	// With default threshold (15), 5 imports should NOT trigger.
 	c1 := &CouplingCollector{}
 	sigs1, err := c1.Collect(context.Background(), dir, signal.CollectorOpts{})
 	require.NoError(t, err)
@@ -996,7 +1004,7 @@ func Hub() { a.A(); b.B(); c.C(); d.D(); e.E() }
 			fanOutCount1++
 		}
 	}
-	assert.Equal(t, 0, fanOutCount1, "should not trigger with default threshold 10")
+	assert.Equal(t, 0, fanOutCount1, "should not trigger with default threshold 15")
 
 	// With threshold 3, 5 imports SHOULD trigger.
 	c2 := &CouplingCollector{}
@@ -1041,5 +1049,133 @@ func TestFanOutModules_ContextCancellation(t *testing.T) {
 	_, err := fanOutModules(ctx, graph, 10)
 	if err == nil {
 		t.Error("expected error from cancelled context")
+	}
+}
+
+// TestCoupling_EntryPointExempt pins stringer-3v0: a module nothing imports
+// (an entry point, a gallery, a script) is exempt from fan-out signals —
+// wide imports are its job.
+func TestCoupling_EntryPointExempt(t *testing.T) {
+	dir := t.TempDir()
+	var b strings.Builder
+	b.WriteString("import { A } from './a'\n")
+	for i := 0; i < 20; i++ {
+		fmt.Fprintf(&b, "import { X%d } from './x%d'\n", i, i)
+	}
+	writeCouplingTestFile(t, dir, "src/gallery.ts", b.String())
+	for i := 0; i < 20; i++ {
+		writeCouplingTestFile(t, dir, fmt.Sprintf("src/x%d.ts", i), "export const X = 1\n")
+	}
+	writeCouplingTestFile(t, dir, "src/a.ts", "export const A = 1\n")
+
+	c := &CouplingCollector{}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{})
+	require.NoError(t, err)
+	for _, s := range signals {
+		assert.NotEqual(t, "high-coupling", s.Kind,
+			"entry point (in-degree 0) must be exempt, got signal %q", s.Title)
+	}
+	m := c.Metrics().(*CouplingMetrics)
+	assert.Equal(t, 1, m.ExemptedAggregators)
+}
+
+// TestCoupling_TestImporterDoesNotAnchor verifies that a module imported
+// ONLY by its test file still counts as an entry point: a test importing
+// its subject doesn't make the subject a mid-graph module.
+func TestCoupling_TestImporterDoesNotAnchor(t *testing.T) {
+	dir := t.TempDir()
+	var b strings.Builder
+	for i := 0; i < 20; i++ {
+		fmt.Fprintf(&b, "import { X%d } from './x%d'\n", i, i)
+	}
+	writeCouplingTestFile(t, dir, "src/gallery.ts", b.String())
+	writeCouplingTestFile(t, dir, "src/gallery.test.ts", "import { G } from './gallery'\n")
+	for i := 0; i < 20; i++ {
+		writeCouplingTestFile(t, dir, fmt.Sprintf("src/x%d.ts", i), "export const X = 1\n")
+	}
+
+	c := &CouplingCollector{}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{})
+	require.NoError(t, err)
+	for _, s := range signals {
+		assert.NotEqual(t, "high-coupling", s.Kind,
+			"module imported only by its test must stay exempt, got %q", s.Title)
+	}
+}
+
+// TestCoupling_MidGraphStillFlagged verifies a genuinely mid-graph module
+// with wide fan-out is still flagged, with the WHAT/WHY/ACTION/DISMISS body
+// (stringer-h51).
+func TestCoupling_MidGraphStillFlagged(t *testing.T) {
+	dir := t.TempDir()
+	var b strings.Builder
+	for i := 0; i < 20; i++ {
+		fmt.Fprintf(&b, "import { X%d } from './x%d'\n", i, i)
+	}
+	writeCouplingTestFile(t, dir, "src/middle.ts", b.String())
+	writeCouplingTestFile(t, dir, "src/app.ts", "import { M } from './middle'\n")
+	for i := 0; i < 20; i++ {
+		writeCouplingTestFile(t, dir, fmt.Sprintf("src/x%d.ts", i), "export const X = 1\n")
+	}
+
+	c := &CouplingCollector{}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{})
+	require.NoError(t, err)
+
+	var found *signal.RawSignal
+	for i := range signals {
+		if signals[i].Kind == "high-coupling" && strings.Contains(signals[i].Title, "middle") {
+			found = &signals[i]
+		}
+	}
+	require.NotNil(t, found, "mid-graph wide module must still be flagged")
+	assert.Contains(t, found.Description, "WHAT:")
+	assert.Contains(t, found.Description, "DISMISS:")
+	assert.Contains(t, found.Description, "coupling_exempt_patterns")
+}
+
+// TestCoupling_BarrelExempt verifies index/barrel files are exempt.
+func TestCoupling_BarrelExempt(t *testing.T) {
+	dir := t.TempDir()
+	var b strings.Builder
+	for i := 0; i < 20; i++ {
+		fmt.Fprintf(&b, "import { X%d } from './x%d'\n", i, i)
+	}
+	writeCouplingTestFile(t, dir, "src/index.ts", b.String())
+	writeCouplingTestFile(t, dir, "src/app.ts", "import { I } from './index'\n")
+	for i := 0; i < 20; i++ {
+		writeCouplingTestFile(t, dir, fmt.Sprintf("src/x%d.ts", i), "export const X = 1\n")
+	}
+
+	c := &CouplingCollector{}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{})
+	require.NoError(t, err)
+	for _, s := range signals {
+		assert.NotEqual(t, "high-coupling", s.Kind,
+			"barrel file must be exempt, got %q", s.Title)
+	}
+}
+
+// TestCoupling_ExemptPatterns verifies per-path glob exemption from config.
+func TestCoupling_ExemptPatterns(t *testing.T) {
+	dir := t.TempDir()
+	var b strings.Builder
+	for i := 0; i < 20; i++ {
+		fmt.Fprintf(&b, "import { X%d } from './x%d'\n", i, i)
+	}
+	writeCouplingTestFile(t, dir, "src/registry.ts", b.String())
+	writeCouplingTestFile(t, dir, "src/app.ts", "import { R } from './registry'\n")
+	for i := 0; i < 20; i++ {
+		writeCouplingTestFile(t, dir, fmt.Sprintf("src/x%d.ts", i), "export const X = 1\n")
+	}
+
+	c := &CouplingCollector{}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{
+		CouplingExemptPatterns: []string{"src/registry.ts"},
+	})
+	require.NoError(t, err)
+	for _, s := range signals {
+		assert.NotEqual(t, "high-coupling", s.Kind,
+			"exempt-glob module must not be flagged, got %q", s.Title)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -69,8 +69,9 @@ type CollectorConfig struct {
 	DeadcodeMaxFiles int `yaml:"deadcode_max_files,omitempty"`
 
 	// Coupling collector settings.
-	CouplingFanOutThreshold int `yaml:"coupling_fan_out_threshold,omitempty"`
-	CouplingMaxFiles        int `yaml:"coupling_max_files,omitempty"`
+	CouplingFanOutThreshold int      `yaml:"coupling_fan_out_threshold,omitempty"`
+	CouplingMaxFiles        int      `yaml:"coupling_max_files,omitempty"`
+	CouplingExemptPatterns  []string `yaml:"coupling_exempt_patterns,omitempty"`
 
 	// Doc staleness collector settings.
 	DocStaleDays       int `yaml:"doc_stale_days,omitempty"`

--- a/internal/config/merge.go
+++ b/internal/config/merge.go
@@ -101,6 +101,9 @@ func Merge(fileCfg *Config, cliCfg signal.ScanConfig) signal.ScanConfig {
 			if co.CouplingMaxFiles == 0 && fc.CouplingMaxFiles > 0 {
 				co.CouplingMaxFiles = fc.CouplingMaxFiles
 			}
+			if len(co.CouplingExemptPatterns) == 0 && len(fc.CouplingExemptPatterns) > 0 {
+				co.CouplingExemptPatterns = fc.CouplingExemptPatterns
+			}
 			if co.DocStaleDays == 0 && fc.DocStaleDays > 0 {
 				co.DocStaleDays = fc.DocStaleDays
 			}

--- a/internal/signal/signal.go
+++ b/internal/signal/signal.go
@@ -137,6 +137,10 @@ type CollectorOpts struct {
 	// 0 uses default (10000).
 	CouplingMaxFiles int
 
+	// CouplingExemptPatterns are path globs whose modules are exempt from
+	// high-coupling (fan-out) signals — entry points, galleries, barrels.
+	CouplingExemptPatterns []string
+
 	// DocStaleDays overrides the minimum age gap in days between source and doc
 	// last-commit to flag a stale-doc signal. 0 uses default (180).
 	DocStaleDays int


### PR DESCRIPTION
## Summary

Two of three high-coupling findings on davetashner/sandtable were false by construction (a test-enforced component gallery; a SPA composition root), and the third cleared the old threshold at 10 imports — ordinary for component-per-file code. Fan-out is a mid-graph signal; aggregators do aggregation for a living.

### Changes

- **Entry points auto-exempt** — in-degree 0 in the intra-project import graph, counting only non-test importers (a test importing its subject doesn't anchor it mid-graph)
- **Barrels auto-exempt** — `index` / `mod` / `__init__` basenames
- **`coupling_exempt_patterns`** — new per-path glob config so a repo exempts its registry/gallery once (stringer-3v0's cheapest-first ask)
- **Default threshold 10 → 15**
- **Rich bodies** (stringer-h51, coupling half) — WHAT/WHY/ACTION/DISMISS/CONTEXT, with DISMISS naming the auto-exemptions and the config key
- Exemptions counted in `CouplingMetrics.ExemptedAggregators`, not silently dropped

### Decision record

`docs/decisions/025-coupling-aggregator-exemption.md`

Together with #406 this completes stringer-h51 (complexity + coupling were the named offenders; vuln bodies were already the 'what good looks like' example).

Closes stringer-3v0
Closes stringer-h51

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VFi3bSiGFdcRCF3ajTamUA