### PR TITLE
fix(collectors): eliminate three false-positive classes found on a TypeScript repo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,12 +48,12 @@ stringer/
 │   │   ├── vuln*.go            # Vuln scanner: 11 ecosystems via OSV.dev (+ PHP, Swift, Scala, Elixir parsers); CVSS v3 base-score severity, npm dev/prod reachability, paginated OSV queries with partial-coverage accounting (DR-023)
 │   │   ├── configdrift.go       # Config drift: env var drift, dead keys, inconsistent defaults
 │   │   ├── apidrift.go         # API drift: undocumented routes, unimplemented spec paths, stale versions
-│   │   ├── docstale.go         # Doc staleness: stale docs, co-change drift, broken links
-│   │   ├── duplication*.go     # Code duplication: exact clones (Type 1) and near-clones (Type 2) via FNV-64a sliding window
+│   │   ├── docstale.go         # Doc staleness: stale docs, co-change drift, broken links (URI-scheme targets and fenced code blocks are skipped)
+│   │   ├── duplication*.go     # Code duplication: exact clones (Type 1) and near-clones (Type 2) via FNV-64a sliding window; test-only clone groups down-weighted and tagged test-only
 │   │   ├── coupling*.go        # Coupling: circular dependencies (Tarjan's SCC) and high fan-out modules via import graph
 │   │   ├── complexity.go       # Complexity: AST-based for Go (cyclomatic/cognitive/nesting); other languages get indentation-derived nesting-weighted scoring with string/comment stripping and a 0.5× JSX logical-op discount (DR-024)
 │   │   ├── complexity_go.go    # Go AST analysis: cyclomatic, cognitive, nesting depth via go/parser
-│   │   ├── githygiene.go       # Git hygiene: large binaries, merge conflicts, committed secrets, mixed line endings
+│   │   ├── githygiene.go       # Git hygiene: large binaries, merge conflicts, committed secrets, mixed line endings — tracked files only (git ls-files), full-scan fallback outside a repo
 │   │   ├── secrets.go          # Secret detection: 24+ built-in patterns, custom patterns, allowlist, entropy detection
 │   │   └── duration.go         # Duration parsing helpers
 │   ├── analysis/           # LLM-powered analysis

--- a/internal/collectors/docstale.go
+++ b/internal/collectors/docstale.go
@@ -69,6 +69,16 @@ var docDirs = []string{"docs", "doc"}
 // mdLinkPattern matches markdown links: [text](target)
 var mdLinkPattern = regexp.MustCompile(`\[(?:[^\]]*)\]\(([^)]+)\)`)
 
+// uriSchemePattern matches a scheme-like prefix (person:, tel:, vscode:,
+// 1914:, …) — RFC 3986 schemes plus digit-led variants used as entity-ID
+// namespaces in content systems. A colon in the first path segment of a
+// markdown link target essentially never denotes a relative file, so such
+// targets are not checked against the working tree (stringer-rd7).
+var uriSchemePattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9+.-]*:`)
+
+// fencePattern matches a code-fence delimiter line (``` or ~~~).
+var fencePattern = regexp.MustCompile("^\\s*(```|~~~)")
+
 // Collect walks the repository looking for stale documentation, co-change
 // drift, and broken internal links.
 func (c *DocStaleCollector) Collect(ctx context.Context, repoPath string, opts signal.CollectorOpts) ([]signal.RawSignal, error) {
@@ -310,21 +320,28 @@ func findBrokenLinks(repoPath, relPath string) []brokenLink {
 
 	scanner := bufio.NewScanner(f)
 	lineNo := 0
+	inFence := false
 	for scanner.Scan() {
 		lineNo++
 		line := scanner.Text()
+
+		// Link-shaped text inside fenced code blocks is sample code, not a
+		// link (stringer-rd7).
+		if fencePattern.MatchString(line) {
+			inFence = !inFence
+			continue
+		}
+		if inFence {
+			continue
+		}
 
 		matches := mdLinkPattern.FindAllStringSubmatch(line, -1)
 		for _, m := range matches {
 			target := m[1]
 
-			// Skip external URLs.
-			if strings.HasPrefix(target, "http://") || strings.HasPrefix(target, "https://") {
-				continue
-			}
-
-			// Skip mailto links.
-			if strings.HasPrefix(target, "mailto:") {
+			// Skip any target with a URI scheme (http:, mailto:, but also
+			// person:, tel:, vscode:, …) — schemes are not paths.
+			if uriSchemePattern.MatchString(target) {
 				continue
 			}
 
@@ -338,6 +355,11 @@ func findBrokenLinks(repoPath, relPath string) []brokenLink {
 				continue
 			}
 
+			// Skip placeholder targets that are not plausible paths.
+			if isPlaceholderLinkTarget(target) {
+				continue
+			}
+
 			// Resolve relative to the markdown file's directory.
 			resolved := filepath.Join(docDir, target)
 			if _, statErr := FS.Stat(resolved); statErr != nil {
@@ -347,6 +369,19 @@ func findBrokenLinks(repoPath, relPath string) []brokenLink {
 	}
 
 	return broken
+}
+
+// isPlaceholderLinkTarget reports whether a link target is documentation
+// filler rather than a checkable path: ellipses, bracketed placeholders.
+func isPlaceholderLinkTarget(target string) bool {
+	t := strings.TrimSpace(target)
+	if t == "…" || t == "..." || t == ".." || t == "." {
+		return true
+	}
+	if strings.HasPrefix(t, "<") && strings.HasSuffix(t, ">") {
+		return true
+	}
+	return false
 }
 
 // detectDocCodeDrift analyzes commit history to find source dirs with many

--- a/internal/collectors/docstale_test.go
+++ b/internal/collectors/docstale_test.go
@@ -409,3 +409,30 @@ func TestDocStale_ConfigurableDriftMinCommits(t *testing.T) {
 	}
 	assert.Equal(t, 5, minCommits)
 }
+
+// TestFindBrokenLinks_SkipsURISchemesAndFences pins stringer-rd7: entity-ID
+// link targets (person:lanrezac-charles) and link-shaped text inside fenced
+// code blocks are not filesystem paths; all seven broken-link findings on a
+// real repo were these two shapes.
+func TestFindBrokenLinks_SkipsURISchemesAndFences(t *testing.T) {
+	dir := t.TempDir()
+	doc := `# Authoring
+
+A [person link](person:lanrezac-charles) and an [era link](1914:army-de-4).
+A [tel link](tel:+15551234) and a [vscode link](vscode://file/x).
+A [placeholder](…) and [another](<entity-id>).
+
+` + "```" + `markdown
+A [sample link in a fence](missing-from-fence.md)
+` + "```" + `
+
+A [genuinely broken link](does-not-exist.md) survives all filters.
+A [good link](real.md) is fine.
+`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "guide.md"), []byte(doc), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "real.md"), []byte("# real\n"), 0o600))
+
+	broken := findBrokenLinks(dir, "guide.md")
+	require.Len(t, broken, 1, "only the genuinely broken relative link should be reported, got %v", broken)
+	assert.Equal(t, "does-not-exist.md", broken[0].target)
+}

--- a/internal/collectors/duplication.go
+++ b/internal/collectors/duplication.go
@@ -219,7 +219,8 @@ func (c *DuplicationCollector) Collect(ctx context.Context, repoPath string, opt
 		dupLines += g.Lines * len(g.Locations)
 	}
 
-	// Sort signals by confidence descending.
+	// Sort signals by confidence descending. Test-only clone groups carry
+	// discounted confidence, so the cap below truncates boilerplate first.
 	sort.Slice(signals, func(i, j int) bool {
 		return signals[i].Confidence > signals[j].Confidence
 	})
@@ -276,6 +277,19 @@ func cloneGroupToSignal(g cloneGroup) signal.RawSignal {
 
 	confidence := duplicationConfidence(g.Lines, len(g.Locations), g.NearClone)
 
+	// A clone group living entirely in test files is usually deliberate
+	// setup boilerplate; down-weight it and say so, so production clones
+	// win the signal cap (stringer-e0o). A clone spanning test AND
+	// production code keeps full confidence.
+	if testOnly := cloneGroupIsTestOnly(g); testOnly {
+		confidence -= 0.15
+		if confidence < 0.2 {
+			confidence = 0.2
+		}
+		tags = append(tags, "test-only")
+		fmt.Fprintf(&desc, "All %d locations are test files — repeated test setup is often deliberate; extract a helper only if it clarifies.\n", len(g.Locations))
+	}
+
 	return signal.RawSignal{
 		Source:      "duplication",
 		Kind:        kind,
@@ -286,6 +300,17 @@ func cloneGroupToSignal(g cloneGroup) signal.RawSignal {
 		Confidence:  confidence,
 		Tags:        tags,
 	}
+}
+
+// cloneGroupIsTestOnly reports whether every location in the group is a
+// test file.
+func cloneGroupIsTestOnly(g cloneGroup) bool {
+	for _, loc := range g.Locations {
+		if !isTestFile(loc.Path) {
+			return false
+		}
+	}
+	return len(g.Locations) > 0
 }
 
 // duplicationConfidence computes confidence per DR-017:

--- a/internal/collectors/duplication_test.go
+++ b/internal/collectors/duplication_test.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -986,5 +987,45 @@ func writeTestFile(t *testing.T, dir, relPath, content string) {
 	}
 	if err := os.WriteFile(fullPath, []byte(content), 0o600); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// TestDuplication_TestOnlyClonesDownWeighted pins stringer-e0o: a clone
+// group living entirely in test files is discounted and labeled so that
+// production clones win the signal cap.
+func TestDuplication_TestOnlyClonesDownWeighted(t *testing.T) {
+	testOnly := cloneGroup{
+		Lines:     7,
+		Locations: []cloneLocation{{Path: "src/a.test.ts", StartLine: 3}, {Path: "src/b.test.ts", StartLine: 9}},
+	}
+	production := cloneGroup{
+		Lines:     7,
+		Locations: []cloneLocation{{Path: "src/a.ts", StartLine: 3}, {Path: "src/b.ts", StartLine: 9}},
+	}
+	mixed := cloneGroup{
+		Lines:     7,
+		Locations: []cloneLocation{{Path: "src/a.test.ts", StartLine: 3}, {Path: "src/b.ts", StartLine: 9}},
+	}
+
+	sigTest := cloneGroupToSignal(testOnly)
+	sigProd := cloneGroupToSignal(production)
+	sigMixed := cloneGroupToSignal(mixed)
+
+	if sigTest.Confidence >= sigProd.Confidence {
+		t.Errorf("test-only boilerplate (%.2f) must rank below identical production clones (%.2f)",
+			sigTest.Confidence, sigProd.Confidence)
+	}
+	if math.Abs(sigProd.Confidence-sigMixed.Confidence) > 0.001 {
+		t.Errorf("a clone spanning test AND production must keep full confidence: prod %.2f, mixed %.2f",
+			sigProd.Confidence, sigMixed.Confidence)
+	}
+	if !slices.Contains(sigTest.Tags, "test-only") {
+		t.Errorf("test-only group must carry the test-only tag, got %v", sigTest.Tags)
+	}
+	if !strings.Contains(sigTest.Description, "test files") {
+		t.Errorf("test-only group description must say so, got %q", sigTest.Description)
+	}
+	if slices.Contains(sigProd.Tags, "test-only") {
+		t.Errorf("production group must not carry the test-only tag")
 	}
 }

--- a/internal/collectors/githygiene.go
+++ b/internal/collectors/githygiene.go
@@ -7,12 +7,14 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
 
 	"github.com/davetashner/stringer/internal/collector"
+	"github.com/davetashner/stringer/internal/gitcli"
 	"github.com/davetashner/stringer/internal/signal"
 )
 
@@ -84,6 +86,17 @@ func (c *GitHygieneCollector) Collect(ctx context.Context, repoPath string, opts
 	// Parse .gitattributes for LFS-tracked patterns.
 	lfsPatterns := parseLFSPatterns(repoPath)
 
+	// Git hygiene is about the repository, not the working directory:
+	// an untracked or gitignored file cannot be a committed binary or a
+	// committed secret. Restrict the scan to tracked files; when the path
+	// is not a git repo (or git is unavailable), fall back to scanning
+	// everything so the collector still works on bare exports (stringer-nw3).
+	tracked, trackedErr := gitcli.ListTrackedFiles(ctx, repoPath)
+	if trackedErr != nil {
+		slog.Debug("githygiene: not filtering to tracked files", "error", trackedErr)
+		tracked = nil
+	}
+
 	var signals []signal.RawSignal
 	metrics := &GitHygieneMetrics{}
 
@@ -117,6 +130,11 @@ func (c *GitHygieneCollector) Collect(ctx context.Context, repoPath string, opts
 		}
 
 		if len(opts.IncludePatterns) > 0 && !matchesAny(relPath, opts.IncludePatterns) {
+			return nil
+		}
+
+		// Skip files git does not track (see above).
+		if tracked != nil && !tracked[filepath.ToSlash(relPath)] {
 			return nil
 		}
 

--- a/internal/collectors/githygiene_test.go
+++ b/internal/collectors/githygiene_test.go
@@ -6,6 +6,7 @@ package collectors
 import (
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -318,4 +319,73 @@ func TestGitHygiene_ConfigurableLargeBinaryThreshold(t *testing.T) {
 	require.NoError(t, err)
 	largeBins2 := filterByKind(sigs2, "large-binary")
 	assert.NotEmpty(t, largeBins2, "500-byte binary should trigger 100-byte threshold")
+}
+
+// gitHygieneRunGit runs a git command in dir, failing the test on error.
+func gitHygieneRunGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+// TestGitHygiene_SkipsUntrackedAndIgnoredFiles pins stringer-nw3: a large
+// binary that git does not track — gitignored working files — is not a git
+// hygiene problem. On a real repo this produced 48 false P1 signals for
+// gitignored media assets.
+func TestGitHygiene_SkipsUntrackedAndIgnoredFiles(t *testing.T) {
+	dir := t.TempDir()
+	gitHygieneRunGit(t, dir, "init")
+
+	// Tracked large binary: must be flagged.
+	tracked := make([]byte, 1_100_000)
+	tracked[0] = 0x00 // NUL byte marks it binary
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "tracked.bin"), tracked, 0o600))
+
+	// Gitignored large binary: must NOT be flagged.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".gitignore"), []byte("ignored.bin\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "ignored.bin"), tracked, 0o600))
+
+	// Untracked large binary (not even ignored): must NOT be flagged.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "untracked.bin"), tracked, 0o600))
+
+	gitHygieneRunGit(t, dir, "add", "tracked.bin", ".gitignore")
+	gitHygieneRunGit(t, dir, "-c", "user.name=Test", "-c", "user.email=test@test.com",
+		"commit", "-m", "add tracked binary")
+
+	c := &GitHygieneCollector{}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{})
+	require.NoError(t, err)
+
+	var large []signal.RawSignal
+	for _, s := range signals {
+		if s.Kind == "large-binary" {
+			large = append(large, s)
+		}
+	}
+	require.Len(t, large, 1, "only the tracked binary is a git hygiene problem")
+	assert.Equal(t, "tracked.bin", large[0].FilePath)
+}
+
+// TestGitHygiene_NonRepoFallsBackToFullScan verifies the collector still
+// works on a bare directory export (no .git).
+func TestGitHygiene_NonRepoFallsBackToFullScan(t *testing.T) {
+	dir := t.TempDir()
+	data := make([]byte, 1_100_000)
+	data[0] = 0x00
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "big.bin"), data, 0o600))
+
+	c := &GitHygieneCollector{}
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{})
+	require.NoError(t, err)
+
+	found := false
+	for _, s := range signals {
+		if s.Kind == "large-binary" {
+			found = true
+		}
+	}
+	assert.True(t, found, "non-repo scan should still flag large binaries")
 }

--- a/internal/gitcli/gitcli.go
+++ b/internal/gitcli/gitcli.go
@@ -67,6 +67,24 @@ func Exec(ctx context.Context, repoDir string, args ...string) (string, error) {
 	return string(out), nil
 }
 
+// ListTrackedFiles runs `git ls-files -z` in repoDir and returns the set of
+// tracked file paths (relative to repoDir, slash-separated as git emits
+// them). Returns an error when repoDir is not inside a git work tree or git
+// is unavailable.
+func ListTrackedFiles(ctx context.Context, repoDir string) (map[string]bool, error) {
+	out, err := Exec(ctx, repoDir, "ls-files", "-z")
+	if err != nil {
+		return nil, err
+	}
+	tracked := make(map[string]bool)
+	for _, f := range strings.Split(out, "\x00") {
+		if f != "" {
+			tracked[f] = true
+		}
+	}
+	return tracked, nil
+}
+
 // BlameSingleLine runs `git blame --porcelain -L <line>,<line> -- <relPath>`
 // and returns the attribution for that line.
 func BlameSingleLine(ctx context.Context, repoDir, relPath string, line int) (*BlameLine, error) {


### PR DESCRIPTION
## Summary

Running stringer 1.8.6 against davetashner/sandtable (TypeScript/React) surfaced three false-positive classes; each is fixed with a pinned regression test.

### githygiene: gitignored files flagged as committed (stringer-nw3)

48 false P1 'Large binary file' signals for `.wav`/`.png` files that are **gitignored** — absent from any clone. The collector walked the filesystem and never consulted git. Now restricted to tracked files via new `gitcli.ListTrackedFiles` (`git ls-files -z`), falling back to a full scan outside a git repo so bare exports still work.

### docstale: entity IDs and code fences as broken links (stringer-rd7)

All 7 broken-link findings were false: `[Lanrezac](person:lanrezac-charles)`-style entity IDs resolved as relative paths, plus link-shaped text inside ``` fences. Now skipped: colon-prefixed scheme-like targets (letters *and* digit-led namespaces like `1914:`), fenced code block contents, and placeholder targets (`…`, `<entity-id>`).

### duplication: test boilerplate crowds out production clones (stringer-e0o)

The 200-signal cap filled with 6-line test-setup clones ranked equal to production duplication. Test-only clone groups now get −0.15 confidence, a `test-only` tag, and an honest body note ('repeated test setup is often deliberate'); the confidence sort then truncates boilerplate first. Mixed test/production clones keep full confidence.

Closes stringer-nw3
Closes stringer-rd7
Closes stringer-e0o

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VFi3bSiGFdcRCF3ajTamUA