### PR TITLE
fix(scan): exclude embedded .claude/worktrees checkouts by default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ stringer/
 │   ├── collector/          # Collector registry and interface
 │   │   └── collector.go        # Register(), List(), Get(), Collector interface
 │   ├── collectors/         # Signal extraction modules (one file per collector)
-│   │   ├── todos.go            # TODO/FIXME/HACK/XXX/BUG/OPTIMIZE scanner
+│   │   ├── todos.go            # TODO/FIXME/HACK/XXX/BUG/OPTIMIZE scanner; owns defaultExcludePatterns (vendor, node_modules, .beads, .stringer, .claude/worktrees, …) shared by all collectors
 │   │   ├── gitlog.go           # Reverts, high-churn files, stale branches
 │   │   ├── patterns.go         # Large files, missing tests, low test coverage ratios (Go, JS/TS, Python, Ruby, Java, Kotlin, Rust, C#, PHP, Swift)
 │   │   ├── lotteryrisk*.go     # Lottery risk: core, ownership math, review analysis

--- a/internal/collectors/todos.go
+++ b/internal/collectors/todos.go
@@ -74,6 +74,7 @@ var defaultExcludePatterns = []string{
 	"eval/**",
 	".beads/**",
 	".stringer/**",
+	".claude/worktrees/**",
 }
 
 // defaultDemoPatterns are directory globs for demo/example/tutorial paths.

--- a/internal/collectors/todos_test.go
+++ b/internal/collectors/todos_test.go
@@ -1432,3 +1432,20 @@ func TestIsBinaryFile_MockOpenError(t *testing.T) {
 	// Should treat as binary (unreadable).
 	assert.True(t, isBinaryFile("/any/path"))
 }
+
+// TestDefaultExcludes_ClaudeWorktrees pins the exclusion of embedded
+// .claude/worktrees working copies: scanning a repo that carries agent
+// worktree checkouts produced 890 duplicate complexity signals from stale
+// copies of the same source tree.
+func TestDefaultExcludes_ClaudeWorktrees(t *testing.T) {
+	excludes := mergeExcludes(nil)
+	if !shouldExclude(".claude/worktrees/feat/thing/src/App.tsx", excludes) {
+		t.Error("files under .claude/worktrees must be excluded by default")
+	}
+	if !shouldExclude(".claude/worktrees", excludes) && !shouldExclude(".claude/worktrees/feat", excludes) {
+		t.Error("the .claude/worktrees directory itself should be prunable")
+	}
+	if shouldExclude(".claude/settings.json", excludes) {
+		t.Error(".claude config files other than worktrees must not be excluded")
+	}
+}


### PR DESCRIPTION
During acceptance testing of the v1.9.0 fixes against davetashner/sandtable, one scan ran while the repo's `.claude/worktrees/` still held checked-out agent worktree copies — and produced **890 duplicate complexity signals** (1653 total vs 428 without them), all pointing at stale copies of the same source files.

Worktree checkouts are working copies, not project source. Add `.claude/worktrees/**` to `defaultExcludePatterns`, alongside `vendor/**`, `node_modules/**`, `.beads/**`, `.stringer/**`. Other `.claude/` content (settings, commands, skills) remains scannable.

Test pins: worktree files excluded, `.claude/settings.json` not excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VFi3bSiGFdcRCF3ajTamUA