### PR TITLE
fix(vuln,complexity): version-qualified titles and recalibrated confidence bands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ stringer/
 │   │   ├── lotteryrisk*.go     # Lottery risk: core, ownership math, review analysis
 │   │   ├── github.go           # GitHub issues, PRs, and review comments
 │   │   ├── dephealth*.go       # Dependency health: 10 ecosystems (Go, npm, Cargo, Maven, NuGet, PyPI, Packagist, SwiftPM, sbt, Hex)
-│   │   ├── vuln*.go            # Vuln scanner: 11 ecosystems via OSV.dev (+ PHP, Swift, Scala, Elixir parsers); CVSS v3 base-score severity, npm dev/prod reachability, paginated OSV queries with partial-coverage accounting (DR-023)
+│   │   ├── vuln*.go            # Vuln scanner: 11 ecosystems via OSV.dev (+ PHP, Swift, Scala, Elixir parsers); CVSS v3 base-score severity, npm dev/prod reachability, paginated OSV queries with partial-coverage accounting, versioned signal titles (DR-023)
 │   │   ├── configdrift.go       # Config drift: env var drift, dead keys, inconsistent defaults
 │   │   ├── apidrift.go         # API drift: undocumented routes, unimplemented spec paths, stale versions
 │   │   ├── docstale.go         # Doc staleness: stale docs, co-change drift, broken links (URI-scheme targets and fenced code blocks are skipped)

--- a/docs/decisions/023-vuln-reachability-and-severity.md
+++ b/docs/decisions/023-vuln-reachability-and-severity.md
@@ -26,6 +26,10 @@ Additionally, partial OSV failures (unfetchable details, unpaginated `querybatch
 
 **Partial coverage:** `QueryBatch` now returns `OSVQueryResult{Details, FailedFetches, Truncated}`; `querybatch` pagination (`next_page_token`) is followed up to 5 pages per query; total failure sets `VulnMetrics.Unavailable` and logs at Warn. Scans stay non-fatal offline, but never silently.
 
+## Amendment (same day, from acceptance testing)
+
+Signal titles now include the package version (`image-size@0.7.5`): the pipeline deduplicates on Source+Kind+FilePath+Line+Title, so without the version a dev-only and a production instance of the same CVE collapsed into a single signal that carried the production confidence and the dev-only description. Titles are part of signal IDs; this changes IDs once.
+
 ## Consequences
 
 - npm gains full reachability awareness; other ecosystems with a dev distinction (Cargo `dev-dependencies`, Poetry/uv groups, Gemfile groups) parse as production until given the same treatment (follow-up bead).

--- a/docs/decisions/024-regex-complexity-nesting.md
+++ b/docs/decisions/024-regex-complexity-nesting.md
@@ -25,6 +25,10 @@ Non-Go languages get token counting where complexity is about structure:
 
 **Bead bodies:** every complexity signal now carries WHAT (the metrics), WHY, ACTION, DISMISS, and CONTEXT (threshold + config key), per stringer-h51. DISMISS is tailored: flat functions are told they are probably fine.
 
+## Amendment (same day, from acceptance testing)
+
+The DR-013 confidence bands (0.8 at score 15) were calibrated for raw branch counts; depth-weighted scores run roughly 2× higher, which pushed ordinary loop+guard+condition validators (nesting 3) to P1 — 16 P1 findings in one file on the eval repo. Bands recalibrated to the AST path's cognitive/30 shape: 0.8 at 30, 0.6 at 18, 0.4 at 6. After recalibration the eval repo's validator file retains two P1s (its two genuinely densest functions) and the top hotspot (TourProvider, 97.5) keeps its rank.
+
 ## Consequences
 
 - Scores drop for flat/JSX-heavy code and hold for nested code; signal titles change (nesting added), so signal IDs change and delta scans will report these as new once.

--- a/internal/collectors/complexity.go
+++ b/internal/collectors/complexity.go
@@ -791,23 +791,25 @@ func astComplexityDescription(fc FunctionComplexity) string {
 	return b.String()
 }
 
-// complexityConfidence maps a complexity score to a confidence value per DR-013:
-//   - score >= 15: 0.8
-//   - score 8–15: linear interpolation 0.6–0.8
-//   - score 6–8: linear interpolation 0.5–0.6
+// complexityConfidence maps a nesting-weighted score to confidence.
+// Recalibrated for DR-024's depth-weighted scoring, which roughly doubled
+// raw scores (a branch at depth d costs d): the DR-013 bands (0.8 at 15)
+// were tuned for raw branch counts and pushed ordinary loop+guard
+// validators to P1. New bands, mirroring the AST path's cognitive/30 shape:
+//   - score >= 30: 0.8 (P1 territory — genuinely tangled)
+//   - score 18–30: linear 0.6–0.8
+//   - score 6–18: linear 0.4–0.6
 //   - score < 6: not emitted (handled by caller)
 func complexityConfidence(score float64) float64 {
 	switch {
-	case score >= 15:
+	case score >= 30:
 		return 0.8
-	case score >= 8:
-		// Linear from 0.6 at 8 to 0.8 at 15.
-		return 0.6 + 0.2*(score-8)/(15-8)
+	case score >= 18:
+		return 0.6 + 0.2*(score-18)/(30-18)
 	case score >= 6:
-		// Linear from 0.5 at 6 to 0.6 at 8.
-		return 0.5 + 0.1*(score-6)/(8-6)
+		return 0.4 + 0.2*(score-6)/(18-6)
 	default:
-		return 0.5
+		return 0.4
 	}
 }
 

--- a/internal/collectors/complexity_test.go
+++ b/internal/collectors/complexity_test.go
@@ -400,11 +400,11 @@ func TestInferIndentUnit(t *testing.T) {
 func TestRegexComplexityConfidence_FlatCap(t *testing.T) {
 	// A high score with flat structure is capped at 0.55 (P3): flat guard
 	// lists are often the clearest way to write the code (stringer-t98).
-	assert.InDelta(t, 0.55, regexComplexityConfidence(20.0, 1), 0.001)
-	assert.InDelta(t, 0.55, regexComplexityConfidence(20.0, 2), 0.001)
-	assert.InDelta(t, 0.8, regexComplexityConfidence(20.0, 3), 0.001)
+	assert.InDelta(t, 0.55, regexComplexityConfidence(40.0, 1), 0.001)
+	assert.InDelta(t, 0.55, regexComplexityConfidence(40.0, 2), 0.001)
+	assert.InDelta(t, 0.8, regexComplexityConfidence(40.0, 3), 0.001)
 	// Below the cap, flat functions keep their score-based confidence.
-	assert.InDelta(t, 0.5, regexComplexityConfidence(6.0, 1), 0.001)
+	assert.InDelta(t, 0.4, regexComplexityConfidence(6.0, 1), 0.001)
 }
 
 func TestComplexityConfidence(t *testing.T) {
@@ -412,13 +412,13 @@ func TestComplexityConfidence(t *testing.T) {
 		score float64
 		want  float64
 	}{
-		{20.0, 0.8},
-		{15.0, 0.8},
-		{8.0, 0.6},
-		{11.5, 0.7},
-		{6.0, 0.5},
-		{7.0, 0.55},
-		{5.0, 0.5},
+		{45.0, 0.8},
+		{30.0, 0.8},
+		{24.0, 0.7},
+		{18.0, 0.6},
+		{12.0, 0.5},
+		{6.0, 0.4},
+		{5.0, 0.4},
 	}
 	for _, tt := range tests {
 		got := complexityConfidence(tt.score)

--- a/internal/collectors/vuln.go
+++ b/internal/collectors/vuln.go
@@ -218,7 +218,12 @@ func (c *VulnCollector) Collect(ctx context.Context, repoPath string, _ signal.C
 			titleID = r.ID
 		}
 
-		title := fmt.Sprintf("Vulnerable dependency: %s [%s]", r.PackageName, titleID)
+		// The version is part of the title: the pipeline deduplicates on
+		// Source+Kind+FilePath+Line+Title, and a lockfile can hold the same
+		// package at multiple versions — without the version, a dev-only
+		// and a production instance of the same CVE collapse into one
+		// signal with a misleading mix of both (stringer-kgr).
+		title := fmt.Sprintf("Vulnerable dependency: %s@%s [%s]", r.PackageName, r.Version, titleID)
 
 		var desc string
 		if r.FixedVersion != "" {

--- a/internal/collectors/vuln_test.go
+++ b/internal/collectors/vuln_test.go
@@ -1443,3 +1443,31 @@ func TestVulnCollector_UnavailableIsLoud(t *testing.T) {
 	require.NotNil(t, metrics)
 	assert.True(t, metrics.Unavailable, "an unreachable OSV service must be visible in metrics")
 }
+
+// TestVulnCollector_TitleIncludesVersion pins the version into the signal
+// title: the pipeline dedups on Source+Kind+FilePath+Line+Title, so without
+// the version a dev-only and a production instance of the same CVE collapse
+// into one signal carrying a misleading mix of both.
+func TestVulnCollector_TitleIncludesVersion(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "package.json"), []byte(`{
+		"dependencies": {"image-size": "0.7.5"}
+	}`), 0o600))
+
+	c := &VulnCollector{osv: &mockOSVClient{
+		results: []VulnDetail{
+			{ID: "GHSA-x", Summary: "prod copy", Ecosystem: "npm", PackageName: "image-size", Version: "0.7.5"},
+			{ID: "GHSA-x", Summary: "dev copy", Ecosystem: "npm", PackageName: "image-size", Version: "0.8.3", Dev: true},
+		},
+	}}
+
+	signals, err := c.Collect(context.Background(), dir, signal.CollectorOpts{})
+	require.NoError(t, err)
+	require.Len(t, signals, 2)
+	titles := map[string]bool{}
+	for _, s := range signals {
+		titles[s.Title] = true
+	}
+	assert.True(t, titles["Vulnerable dependency: image-size@0.7.5 [GHSA-x]"], "titles: %v", titles)
+	assert.True(t, titles["Vulnerable dependency: image-size@0.8.3 [GHSA-x]"])
+}


### PR DESCRIPTION
Acceptance-testing the merged v1.9.0 fixes against davetashner/sandtable surfaced two calibration defects; both fixed with regression tests and DR amendments.

### 1. Vuln titles lacked the version → pipeline dedup collapsed multi-version findings

`DeduplicateSignals` keys on Source+Kind+FilePath+Line+**Title**. `image-size` at 0.7.5 (production) and 0.8.3 (dev) share a CVE → identical titles → one signal survived, carrying the production confidence (P1) and the dev-only description. Titles are now `package@version [CVE]`. (DR-023 amendment; IDs change once.)

### 2. Complexity confidence bands were tuned for the old raw-branch scores

Depth-weighted scores run ~2× higher than raw branch counts, so the DR-013 bands (0.8 at 15) pushed loop+guard+condition validators (nesting 3) to P1 — 16 P1s in `validate.ts` alone. Recalibrated to the AST path's cognitive/30 shape: 0.8 at 30, 0.6 at 18, 0.4 at 6. Result on the eval repo: `validate.ts` keeps 2 P1s (its two densest functions); `TourProvider` (97.5, nesting 4) stays the top finding. (DR-024 amendment.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VFi3bSiGFdcRCF3ajTamUA